### PR TITLE
Fix typos involving articles.

### DIFF
--- a/csug/debug.stex
+++ b/csug/debug.stex
@@ -559,7 +559,7 @@ The \scheme{debug} procedure may be used to inspect the condition.
 Whenever one of the built-in error-reporting mechanisms is used to
 raise an exception, the continuation at the point where the
 exception was raised can be inspected as well.
-More generally, \scheme{debug} allows the the continuation contained
+More generally, \scheme{debug} allows the continuation contained
 within any continuation condition created by
 \scheme{make-continuation-condition} to be inspected.
 

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -2231,7 +2231,7 @@ These are also typically registered using
 \scheme{Sforeign_symbol} or \scheme{Sregister_symbol}.
 
 \item The address of an entry, i.e., a function pointer, may be passed
-into Scheme and used as the the value of the entry expression in a
+into Scheme and used as the value of the entry expression in a
 foreign-procedure expression.  
 This allows foreign entry points to be used even when they are not
 registered by name.  

--- a/csug/io.stex
+++ b/csug/io.stex
@@ -3319,7 +3319,7 @@ This section describes operations on files, directories, and pathnames.
 
 \noindent
 When invoked without arguments, \scheme{current-directory} returns a string
-representing the the current working directory.
+representing the current working directory.
 Otherwise, the current working directory is changed to the directory
 specified by the argument, which must be a string representing a valid
 directory pathname.

--- a/csug/libraries.stex
+++ b/csug/libraries.stex
@@ -1013,9 +1013,9 @@ Section~\ref{SECTBUILTINLIBRARIES} above.
 %----------------------------------------------------------------------------
 \noskipentryheader
 \formdef{library-version}{\categoryprocedure}{(library-version \var{libref})}
-\returns the version of the the specified library
+\returns the version of the specified library
 \formdef{library-exports}{\categoryprocedure}{(library-exports \var{libref})}
-\returns a list of the exports of the the specified library
+\returns a list of the exports of the specified library
 \formdef{library-requirements}{\categoryprocedure}{(library-requirements \var{libref})}
 \returns a list of libraries required by the specified library
 \formdef{library-requirements}{\categoryprocedure}{(library-requirements \var{libref} \var{options})}

--- a/csug/objects.stex
+++ b/csug/objects.stex
@@ -336,7 +336,7 @@ First, a \scheme{#\} prefix followed by exactly three octal digits is read
 as a character whose numeric code is the octal value of the three digits,
 e.g., \scheme{#\044} is read as \scheme{#\$}.
 Second, it recognizes several nonstandard named characters:
-\scheme{#\rubout} (which is the the same as \scheme{#\delete}),
+\scheme{#\rubout} (which is the same as \scheme{#\delete}),
 \scheme{#\bel} (which is the same as \scheme{#\alarm}),
 \scheme{#\vt} (which is the same as \scheme{#\vtab}),
 \scheme{#\nel} (the Unicode NEL character), and
@@ -606,7 +606,7 @@ See also the description of fixnum-only vectors (fxvectors) below.
 
 Fixnum-only vectors, or ``fxvectors,'' are like vectors but contain
 only fixnums.
-Fxvectors are written with the \scheme{#vfx} prefix in place of the the
+Fxvectors are written with the \scheme{#vfx} prefix in place of the
 \scheme{#} prefix for vectors, e.g., \scheme{#vfx(1 2 3)} or
 \scheme{#10vfx(2)}.
 The fxvector syntax is disabled in an input stream after \scheme{#!r6rs}

--- a/csug/syntax.stex
+++ b/csug/syntax.stex
@@ -141,7 +141,7 @@ The definition of \scheme{xname} binds it to the value of
 This allows the procedure to be used as a first-class value.
 Because \scheme{xname} is introduced by the transformer, the binding for
 \scheme{xname} is not visible anywhere except where references to it
-are introduced by the the transformer for \var{name}.
+are introduced by the transformer for \var{name}.
 
 Within \var{lambda-expression}, wherever it appears, \var{name}
 is rebound to a transformer that expands all references into references

--- a/csug/system.stex
+++ b/csug/system.stex
@@ -2291,7 +2291,7 @@ If a \scheme{2} or \scheme{3} appears in the form or between the
 an application of the primitive as if it were compiled
 at the corresponding optimize level (see the \scheme{optimize-level}
 parameter).
-If no number appears in the form, an the application of the primitive is
+If no number appears in the form, the application of the primitive is
 treated as an optimize-level 3 application if the current optimize
 level is 3;
 otherwise, it is treated as an optimize-level 2 application.
@@ -3069,7 +3069,7 @@ The car of each pair is a background color and the cdr is a foreground
 (text) color.
 Each color must be a string, and each string should contain an HTML
 cascading style sheet (css) color specifier.
-The first pair is used for unprofiled code, and the the second is used
+The first pair is used for unprofiled code, and the second is used
 for unexecuted profiled code.
 The third is used for code that is executed least frequently, the fourth
 for code executed next-least frequently, and so on, with the last

--- a/csug/use.stex
+++ b/csug/use.stex
@@ -91,7 +91,7 @@ One thing you might soon notice is that the system automatically indents
 the second and subsequent lines of an expression.
 For example, let's say we want to define \scheme{fact}, a procedure that
 implements the factorial function.
-If we type \scheme{(define fact} followed by a the enter key, the cursor
+If we type \scheme{(define fact} followed by the enter key, the cursor
 should be sitting under the first \scheme{e} in \scheme{define}, so that
 if we then type \scheme{(lambda (x)}, we should see:
 
@@ -1753,7 +1753,7 @@ to be loaded before {\ChezScheme} begins interacting with the user.
 
 Most of the options are described elsewhere in this chapter, and a few
 are self-explanatory.
-The remainder pertain the the loading of boot files at system start-up
+The remainder pertain the loading of boot files at system start-up
 time and are described below.
 
 \index{boot files}%

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -728,7 +728,7 @@ since the compiler converts calls to \scheme{member} into calls to
 comparisons) when it can determine the more expensive test is not
 required.
 
-The \scheme{case} syntax exported by the the \scheme{(rnrs)} and
+The \scheme{case} syntax exported by the \scheme{(rnrs)} and
 \scheme{(rnrs base)} libraries still uses \scheme{memv} for
 compatibility with the R6RS standard.
 

--- a/s/enum.ss
+++ b/s/enum.ss
@@ -20,7 +20,7 @@
 ;;  up to linear in the universe
 ;;
 ;; This code is a good candidate for partial-static-structure optimization
-;;  Right now the the define-enumeration macro is doing optimizations
+;;  Right now the define-enumeration macro is doing optimizations
 ;;  that could be automatically performed by PSS if PSS worked on enums
 ;;
 ;; The R6RS standard is unclear whether the function returned by enum-set-indexer

--- a/s/expeditor.ss
+++ b/s/expeditor.ss
@@ -709,7 +709,7 @@
 
   (module (display-rest/goto)
     (define (display-rest-of-line ee entry row col clear?)
-     ; display as much of the the rest of row as will fit on the screen
+     ; display as much of the rest of row as will fit on the screen
       (let ([lns (entry-lns entry)] [bot-line (entry-bot-line entry)])
        ; n = number of lines to display beyond the first
         (let loop ([n (fx- (if (fx= row (pos-row bot-line))


### PR DESCRIPTION
This fixes a variety of duplicated articles (``the the``) and the like.