### PR TITLE
fixed incorrect handling of library-extension when searching wpo files

### DIFF
--- a/LOG
+++ b/LOG
@@ -59,3 +59,6 @@
   object to a time-utc object.
     stats.c,
     date.ms
+- fixed incorrect handling of library-extension when searching wpo files
+    compile.ss
+    7.ms

--- a/mats/7.ms
+++ b/mats/7.ms
@@ -1918,6 +1918,36 @@ evaluating module init
   (equal?
     (separate-eval '(load "testfile-wpo-ab7-all.so"))
     "invoking a\ninvoking c\ninvoking b\n#t\n#t\n#t\n")
+
+  (begin
+    (with-output-to-file "testfile-wpo-extlib.chezscheme.sls"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-wpo-extlib)
+             (export magic)
+             (import (rnrs))
+             (define magic 9))))
+      'replace)
+    (with-output-to-file "testfile-wpo-ext.ss"
+      (lambda ()
+        (pretty-print '(import (chezscheme) (testfile-wpo-extlib)))
+        (pretty-print '(pretty-print magic)))
+      'replace)
+    (separate-compile
+      '(lambda (x)
+         (parameterize ([compile-imported-libraries #t]
+                        [generate-wpo-files #t])
+           (compile-program x)))
+      'wpo-ext)
+    #t)
+
+  (equal?
+    (separate-compile
+      '(lambda (x)
+         (parameterize ([generate-wpo-files #t])
+           (compile-whole-program (format "~a.wpo" x) (format "~a-all.so" x))))
+      'wpo-ext)
+    "()\n")
 )
 
 (mat compile-whole-library

--- a/s/compile.ss
+++ b/s/compile.ss
@@ -792,7 +792,7 @@
         (define read-library
           (lambda (path libs-visible?)
             (cond
-              [(find-library who path "wpo" (map (lambda (ext) (cons (car ext) ".wpo")) (library-extensions))) =>
+              [(find-library who path "wpo" (map (lambda (ext) (cons (car ext) (string-append (path-root (cdr ext)) ".wpo"))) (library-extensions))) =>
                (lambda (fn)
                  (let-values ([(no-program node*) (process-ir*! (read-input-file who fn) fn #f libs-visible?)])
                    (values fn node*)))]


### PR DESCRIPTION
Example: cannot make use of ".chezscheme.wpo" file.
All the tests have been fully tested before and after the fix and properly revealed the bug.