### PR TITLE
Make hrefs to tspl4 absolute.

### DIFF
--- a/csug/Makefile
+++ b/csug/Makefile
@@ -116,7 +116,7 @@ tspl.aux: ${TSPL}/tspl.aux
 
 tspl.haux: ${TSPL}/tspl.haux
 	sed -e 's/(putprop (quote /(putprop (quote |TSPL|:/' ${TSPL}/tspl.haux | \
-         sed -e 's;url) ";url) "${TSPL}/;' > tspl.haux
+         sed -e 's;url) ";url) "http://scheme.com/${TSPL}/;' > tspl.haux
 
 tspl.rfm: ${TSPL}/tspl.rfm
 	sed -e 's/\\pageref{/\\pageref{TSPL:/' ${TSPL}/tspl.rfm > tspl.rfm
@@ -131,7 +131,7 @@ tspl.idx: ${TSPL}/tspl.idx
          sed -e 's/{\([ivx][ivx]*\)}$$/{t\1}/' > tspl.idx
 
 in.hidx: ${TSPL}/out.hidx
-	sed -e 's;"\(.*\)\.html#;"${TSPL}/\1.html#;' ${TSPL}/out.hidx | \
+	sed -e 's;"\(.*\)\.html#;"http://scheme.com/${TSPL}/\1.html#;' ${TSPL}/out.hidx | \
          sed -e 's/"")$$/"t")/' > in.hidx
 
 $(texsrc): tspl4-prep.stex priminfo.ss ../s/primdata.ss


### PR DESCRIPTION
Since anyone can now "make docs" for csug, all hrefs to tspl4 should be absolute. Right now all of the tspl4 links on, for example, http://gwatt.github.io/csug/csug_1.html and http://cdn.virgil.xyz/csug9/csug_1.html 404. (Those are the index pages, but the same is true of the tspl4 links in the content—e.g., the first link on http://gwatt.github.io/csug/io.html.)