### PR TITLE
Bash test(1) does not allow bare numbers with ==, so use -eq

### DIFF
--- a/makefiles/installsh
+++ b/makefiles/installsh
@@ -61,7 +61,7 @@ while ${TRUE} ; do
     for file in $files ; do
       destfile=$dest
       if [ -d $destfile ] ; then destfile=$destfile/`basename $file` ; fi
-      if [ $ifdiff == 1 ] && cmp -s $file $destfile || cp -f -p $file $destfile ; then
+      if [ $ifdiff -eq 1 ] && cmp -s $file $destfile || cp -f -p $file $destfile ; then
         if [ "$owner" != "" ] ; then chown $owner $destfile ; fi
         if [ "$group" != "" ] ; then chgrp $group $destfile ; fi
         if [ "$mode" != "" ] ; then chmod $mode $destfile ; fi


### PR DESCRIPTION
I wasn't able to get "make install" to work on my Ubuntu 15.10 system because of a minor error in the makefiles/installsh script.   Enclosed patch fixes the problem.