### PR TITLE
Allow CPPFLAGS, CFLAGS, and LDFLAGS to be passed through configure

### DIFF
--- a/configure
+++ b/configure
@@ -37,9 +37,9 @@ installman=""
 installschemename="scheme"
 installpetitename="petite"
 installscriptname="scheme-script"
-CPPFLAGS=""
-CFLAGS=""
-LDFLAGS=""
+: ${CPPFLAGS:=""}
+: ${CFLAGS:=""}
+: ${LDFLAGS:=""}
 
 case `uname` in
   Linux)


### PR DESCRIPTION
This changes the configure script from unconditionally assigning CPPFLAGS,
CFLAGS, and LDFLAGS to the empty string, to only assigning them to the empty
string if they are unset.

This allows one to set the flags before calling configure, rather than as parameters
explicitly passed to the configure script.