### PR TITLE
Ignore etags files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /i3le/
 /i3nt/
 /i3osx/
+/TAGS
 /ta6le/
 /ta6nt/
 /ta6osx/


### PR DESCRIPTION
This commit adds the TAGS file generated by etags to the list of files ignored
by git.