### PR TITLE
Expeditor unicode support

### DIFF
--- a/LOG
+++ b/LOG
@@ -256,3 +256,7 @@
 - fixed three instances of unchecked mallocs reported by laqrix in
   github issue #77.
     io.c, schlib.c, thread.c
+- add unicode support to the expression editor.  entry and display now work
+  except that combining characters are not treated correctly for
+  line-wrapping.  this addresses github issue #32 and part of issue #81.
+    c/expeditor.c, s/expeditor.ss


### PR DESCRIPTION
This works for Mac OS X.

On Linux, characters entered with Ctrl+Shift+U #### aren't decoded properly (it seems to zero one of the bytes?)  It might be a couple days before I can investigate, but I leave this here for review of the approach.

