### PR TITLE
fix expeditor.c for 32bit hosts

### DIFF
--- a/c/expeditor.c
+++ b/c/expeditor.c
@@ -1017,7 +1017,7 @@ static ptr s_ee_get_clipboard(void) {
 }
 #endif
 
-static void s_ee_write_char(wchar_t wch) {
+static void s_ee_write_char(INT wch) {
   locale_t old; char buf[MB_LEN_MAX]; size_t n;
 
   old = uselocale(term_locale);


### PR DESCRIPTION
A change in #83 broken build on 32bit glibc. The function `s_ee_write_char` has `s_ee_write_char(INT)` prototype.

Despite it fixes build on 32bit Linux, perhaps, the correct fix is doing opposite; define some type for character-in-expeditor and change `s_ee_write_char` prototype. (Sorry, but i'm too lazy to explore on this.)

cc @eraserhd 