### PR TITLE
case and exclusive-cond syntax-error calls

### DIFF
--- a/LOG
+++ b/LOG
@@ -296,3 +296,6 @@
   can be overridden, as we do in our own make files.
     cafe.ss,
     7.ms
+- fixed a bug in case and exclusive-cond syntax-error calls causing an
+  exception in syntax-error instead of the intended error message.
+    s/syntax.ss

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -7243,7 +7243,7 @@
             #;[(e0) (make-clause clause #'e0)]
             [(e0 => e1) (make-clause clause #'e1)]
             [(e0 e1 e2 ...) (make-clause clause #'e1)]
-            [_ (syntax-error "invalid exclusive-cond clause" clause)]))
+            [_ (syntax-error clause "invalid exclusive-cond clause")]))
         (define (sort-em clause*)
           (if sort?
               (sort (lambda (cl1 cl2) (> (clause-weight cl1) (clause-weight cl2)))
@@ -7530,7 +7530,7 @@
             (syntax-case clause ()
               [((k ...) e1 e2 ...) (make-clause #'(k ...) #'(e1 e2 ...))]
               [(k e1 e2 ...) (make-clause #'(k) #'(e1 e2 ...))]
-              [_ (syntax-error "invalid case clause" clause)])))
+              [_ (syntax-error clause "invalid case clause")])))
         (define emit
           (lambda (kcond clause*)
             #`(let ([t #,key-expr])


### PR DESCRIPTION
This commit fixes calls to syntax-error in case and exclusive-cond (s/syntax.ss) which had their arguments reversed causing exceptions like:
`Exception in syntax-error: #<syntax ((0))> is not a string`
Instead of:
`Exception: invalid case clause ((0))`
In cases such as:
`(case 0 ((0)))`
All tests pass on my machine, and there weren't any other obvious (ie static strings) cases of this.