### PR TITLE
remove a duplicate let-statement.

### DIFF
--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -214,12 +214,7 @@
                           (loop1 (env-next env))
                           (if (eq? (vector-ref old-rib i) id)
                               (vector-ref new-rib i)
-                              (let ([i (fx+ i 1)])
-                                (if (fx= i n)
-                                    (loop1 (env-next env))
-                                    (if (eq? (vector-ref old-rib i) id)
-                                        (vector-ref new-rib i)
-                                        (loop2 (fx+ i 1)))))))))))))))
+                              (loop2 (fx+ i 1))))))))))))
 
     (define cp0-make-temp ; returns an unassigned temporary
       (lambda (multiply-referenced?)


### PR DESCRIPTION
I found in the original `loop2` in `lookup`:

```
(let loop2 ([i 0])
  (if (fx= i n)
      (loop1 (env-next env))
      (if (eq? (vector-ref old-rib i) id)
          (vector-ref new-rib i)
          (let ([i (fx+ i 1)])
            (if (fx= i n)
                (loop1 (env-next env))
                (if (eq? (vector-ref old-rib i) id)
                    (vector-ref new-rib i)
                    (loop2 (fx+ i 1))))))))
```

the last let-statement (`(let ([i (fx+ i 1)]) ...)`) is the duplicate one of the `loop2` and can be replaced with just the recursive call of `loop2`. It seems like a manual loop unrolling, but according to the third guidance mentioned in the *CONTRIBUTING.md*,

> All other things equal, shorter code is preferable to longer code.

I decide to open this pull request.