### PR TITLE
Correcting language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.h linguist-language=C
+*.ms linguist-language=Scheme


### PR DESCRIPTION
Apparently Github detects .ms files as MAXscript, making the mats files look like they're not Scheme. It also thinks the .h files are C++ as opposed to C. This pull request simply adds a .gitattributes file to hint the correct languages to Github.