### PR TITLE
Fix profile counters for non-s-expression source

### DIFF
--- a/LOG
+++ b/LOG
@@ -322,3 +322,6 @@
     examples/csocket.c, examples/socket.ss
 - use high-precision clock time on Windows 8 and up
     c/stats.c
+- fixed profiling code that keyed profiling locations off of only the
+  bfp to instead key off of both the bfp and efp.
+    pdhtml.ss

--- a/s/pdhtml.ss
+++ b/s/pdhtml.ss
@@ -201,13 +201,17 @@
       (let ([fdatav (hashtable-values fdata-ht)])
         (vector-for-each
           (lambda (fdata)
-            (let ([entry* (sort (lambda (x y) (> (entrydata-bfp x) (entrydata-bfp y)))
+            (let ([entry* (sort (lambda (x y)
+                                  (or (> (entrydata-bfp x) (entrydata-bfp y))
+                                      (and (= (entrydata-bfp x) (entrydata-bfp y))
+                                           (> (entrydata-efp x) (entrydata-efp y)))))
                                 (filedata-entry* fdata))])
               #;(assert (not (null? entry*)))
               (let loop ([entry (car entry*)] [entry* (cdr entry*)] [new-entry* '()])
                 (if (null? entry*)
                     (filedata-entry*-set! fdata (cons entry new-entry*))
-                    (if (= (entrydata-bfp (car entry*)) (entrydata-bfp entry))
+                    (if (and (= (entrydata-bfp (car entry*)) (entrydata-bfp entry))
+                             (= (entrydata-efp (car entry*)) (entrydata-efp entry)))
                         (begin
                           (entrydata-count-set! entry
                             (+ (entrydata-count entry)


### PR DESCRIPTION
Check both the beginning file pointer (bfp) and end file pointer (efp)
of the source location associated with a profile counter when updating
its count.

Assuming that each expression has a unique bfp with respect to profiling
seems to give accurate execution counts for s-expression-based source
locations as in Scheme, but causes problems when targeting other kinds
of syntax. For instance, a C-style function call, referencing the called
function by name, such as "fn(arg)", can logically have profile counters
associated with 1) the function name reference ("fn") and 2) the entire
function call expression ("fn(arg)"), both of which begin at the same
source location. Only the bfp is checked when updating profile counters,
so the two source locations are conflated, and only one counter is
incremented, which gives inaccurate execution counts for both locations;
approximately twice as many for one, and zero for the other.