### PR TITLE
fix ee_read_char function to handle ^@ properly on linux

### DIFF
--- a/c/expeditor.c
+++ b/c/expeditor.c
@@ -675,11 +675,15 @@ static ptr s_ee_read_char(IBOOL blockp) {
 #endif /* PTHREADS */
 
     if (n == 1) {
-      old_locale = uselocale(term_locale);
-      sz = mbrtowc(&wch, buf, 1, &term_out_mbs);
-      uselocale(old_locale);
-      if (sz == 1) {
-        return Schar(wch);
+      if (buf[0] == '\0') {
+        return Schar('\0');
+      } else {
+        old_locale = uselocale(term_locale);
+        sz = mbrtowc(&wch, buf, 1, &term_out_mbs);
+        uselocale(old_locale);
+        if (sz == 1) {
+          return Schar(wch);
+        }
       }
     }
 


### PR DESCRIPTION
when ee_read_char read the ^@ or ^Space, the value in buf[0] is '\0'. Since this character also means the end of the string, it fails the mbrtowc function and raises an exception. 