### PR TITLE
Add cond-expand from SRFI-0.

### DIFF
--- a/LOG
+++ b/LOG
@@ -444,3 +444,6 @@
   $close-resurrected-mutexes&conditions, $keep-live primitive added
     externs.h, prim5.c, thread.c, 4.ms, thread.ms, release_notes.stex,
     7.ss, cpnanopass.ss, np-languages.ss, primdata.ss, prims.ss
+- added cond-expand from SRFI-0
+    pretty.ss, primdata.ss, syntax.ss,
+    8.ms, syntax.stex

--- a/csug/syntax.stex
+++ b/csug/syntax.stex
@@ -1448,6 +1448,23 @@ below.
   [else (safe-frob x)])
 \endschemedisplay
 
+\section{Feature-based conditional expansion\label{SECTSYNTAXCONDEXPAND}}
+
+Expansion-time feature detection can be done via \scheme{cond-expand},
+which is similar to \scheme{meta-cond} but is portable across a wide
+range of Scheme implementations.
+Chez Scheme defines a single feature: \scheme{chezscheme}
+
+\schemedisplay
+(cond-expand
+  [chezscheme (display "Chez Scheme")]
+  [chicken (display "Chicken Scheme")]
+  [guile (display "Guile Scheme")]
+  [else (display "Some other Scheme")])
+\endschemedisplay
+
+See also: \hyperlink{https://srfi.schemers.org/srfi-0/srfi-0.html}{SRFI-0}
+
 \section{Aliases\label{SECTSYNTAXALIAS}}
 
 %----------------------------------------------------------------------------

--- a/mats/8.ms
+++ b/mats/8.ms
@@ -6075,6 +6075,47 @@
       [else ""]))
 )
 
+(mat cond-expand
+  (error? (cond-expand))
+  (error? (cond-expand (faux 'unreachable)))
+  (eq?
+    (cond-expand
+      (chezscheme 'ok))
+    'ok)
+  (eq?
+    (cond-expand
+      (faux 'unreachable)
+      (chezscheme 'ok))
+    'ok)
+  (eq?
+    (cond-expand
+      (faux 'unreachable)
+      (else 'ok))
+    'ok)
+  (eq?
+    (cond-expand
+      ([or chezscheme faux] 'ok))
+    'ok)
+  (eq?
+    (cond-expand
+      ([and chezscheme faux] 'unreachable)
+      (else 'ok))
+    'ok)
+  (eq?
+    (cond-expand
+      ([not faux] 'ok))
+    'ok)
+  (eq?
+    (cond-expand
+      ([not chezscheme] 'unreachable)
+      (else 'ok))
+    'ok)
+  (eq?
+    (cond-expand
+      ([not (and chezscheme faux)] 'ok))
+    'ok)
+)
+
 (mat make-compile-time-value
   (error? ; incorrect number of arguments
     (let ()

--- a/s/pretty.ss
+++ b/s/pretty.ss
@@ -681,6 +681,7 @@
 (pretty-format 'case '(_ exp #f [bracket (fill 0 k ...) 0 e ...] ...))
 (pretty-format 'case-lambda '(_ #f [bracket (fill 0 x ...) 0 e ...] ...))
 (pretty-format 'cond '(_ #f (alt [bracket test '=> 0 exp] [bracket test 0 exp ...]) ...))
+(pretty-format 'cond-expand '(_ #f (alt [bracket test '=> 0 exp] [bracket test 0 exp ...]) ...))
 (pretty-format 'critical-section '(_ #f e ...))
 (pretty-format 'datum '(_ x))
 (pretty-format 'define '(_ (fill 0 x ...) #f e ...))

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1020,6 +1020,7 @@
   (alias [flags])
   (annotation-options [flags])
   (case [flags])
+  (cond-expand [flags])
   (constructor [flags])
   (critical-section [flags])
   (datum [flags])


### PR DESCRIPTION
Motivation: no cond-expand makes it pretty much impossible to port libraries to Chez Scheme.

I tried to follow the house style as much as possible, apologies if I got it wrong.  Thanks for Chez Scheme, it's amazing!

Closes out #91.