### PR TITLE
Move unused terminals in L4.5 to later languages.

### DIFF
--- a/s/np-languages.ss
+++ b/s/np-languages.ss
@@ -357,9 +357,7 @@
  ; introducing mvlet, and mvcall
   (define-language L4.5 (extends L4)
     (terminals
-      (+ (label (l))
-         (maybe-label (mdcl))
-         (immediate (imm))))
+      (+ (maybe-label (mdcl))))
     (entry CaseLambdaExpr)
     (Expr (e body)
       (- (call info e0 e1 ...))
@@ -370,6 +368,8 @@
  ; removes foreign, adds foreign-call, updates fcallable
   (define-language L4.75 (extends L4.5)
     (entry CaseLambdaExpr)
+    (terminals
+      (+ (label (l))))
     (Expr (e body)
       (- (foreign info e)
          (fcallable info e))
@@ -408,7 +408,8 @@
          (fixnum (interface)))
       (+ (var (x))
          (primitive (prim)) ; moved up one language to support closure instrumentation
-         (fixnum (interface offset))))
+         (fixnum (interface offset))
+         (immediate (imm))))
     (entry Program)
     (Program (prog)
       (+ (labels ([l* le*] ...) l)                     => (labels ([l* le*] ...) (l))))


### PR DESCRIPTION
L4.5 has several terminals that it does not use. Later languages,
however, do use them. So I moved the introduction site for those
terminals to the languages where they are first used.