### PR TITLE
support Windows build on Bash/WSL

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -167,15 +167,18 @@ The make file supports several targets:
 
 WINDOWS
 
-Building Chez Scheme under Windows with Cygwin follows the
-instructions above except that make install is not supported:
+Building Chez Scheme under Windows with Cygwin or Bash/WSL follows the
+instructions above, except that 'make install' is not supported, and
+the 'OS' environment variable must be set to 'Windows_NT' on Bash/WSL
+(to indicate a build for Windows, as opposed to a build for Linux on
+Windows):
 
-./configure
-make
+env OS=Windows_NT ./configure
+env OS=Windows_NT make
 
 Prerequisites:
 
-* Cygwin with bash, grep, make, sed, etc.
+* Cygwin or Bash/WSL with bash, grep, make, sed, etc.
 * Microsoft Visual Studio 2015
 * WiX Toolset (for making an install)
 

--- a/LOG
+++ b/LOG
@@ -450,3 +450,6 @@
   Also add a simplification for for-each with empty lists
   with optimization level 2.
     cp0.ss, 4.ms, primdata.ss
+- support Windows build on Bash/WSL
+    BUILDING, configure, workarea, c/vs.bat (new), mats/vs.bat (new),
+    c/Mf-*nt, mats/Mf-*, s/Mf-base

--- a/c/Mf-a6nt
+++ b/c/Mf-a6nt
@@ -25,27 +25,11 @@ mdclean=vs.bat make.bat scheme.res ../bin/$m/*.exp mtscheme.exe* mdscheme.exe*
 include Mf-base
 
 ${Scheme}: make.bat
-	./make.bat
+	cmd.exe /c make.bat
 	cp ../bin/$m/scheme.exe ../bin/$m/petite.exe
-
-vs.bat:
-	echo '@echo off' > $@
-	echo 'if "%VS140COMNTOOLS%" neq "" goto :VS' >> $@
-	echo 'echo Visual Studio 2015 must be installed.' >> $@
-	echo 'exit 1' >> $@
-	echo ':VS' >> $@
-	echo 'set INCLUDE=' >> $@
-	echo 'set LIB=' >> $@
-	echo 'set LIBPATH=' >> $@
-	echo 'set MACHINETYPE=amd64' >> $@
-	echo 'if exist "%VS140COMNTOOLS%..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" set MACHINETYPE=x86_amd64' >> $@
-	echo 'if exist "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat" set MACHINETYPE=amd64' >> $@
-	echo 'call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %MACHINETYPE%' >> $@
-	echo '%*' >> $@
-	chmod +x $@
 
 make.bat: vs.bat
 	echo '@echo off' > $@
 	echo 'set MAKEFLAGS=' >> $@
-	echo 'call vs.bat nmake /f Makefile.$m /nologo %*' >> $@
+	echo 'vs.bat x86_amd64 amd64 && nmake /f Makefile.$m /nologo %*' >> $@
 	chmod +x $@

--- a/c/Mf-i3nt
+++ b/c/Mf-i3nt
@@ -25,24 +25,11 @@ mdclean=vs.bat make.bat scheme.res ../bin/$m/*.exp mtscheme.exe* mdscheme.exe*
 include Mf-base
 
 ${Scheme}: make.bat
-	./make.bat
+	cmd.exe /c make.bat
 	cp ../bin/$m/scheme.exe ../bin/$m/petite.exe
-
-vs.bat:
-	echo '@echo off' > $@
-	echo 'if "%VS140COMNTOOLS%" neq "" goto :VS' >> $@
-	echo 'echo Visual Studio 2015 must be installed.' >> $@
-	echo 'exit 1' >> $@
-	echo ':VS' >> $@
-	echo 'set INCLUDE=' >> $@
-	echo 'set LIB=' >> $@
-	echo 'set LIBPATH=' >> $@
-	echo 'call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x86' >> $@
-	echo '%*' >> $@
-	chmod +x $@
 
 make.bat: vs.bat
 	echo '@echo off' > $@
 	echo 'set MAKEFLAGS=' >> $@
-	echo 'call vs.bat nmake /f Makefile.$m /nologo %*' >> $@
+	echo 'vs.bat x86 && nmake /f Makefile.$m /nologo %*' >> $@
 	chmod +x $@

--- a/c/Mf-ta6nt
+++ b/c/Mf-ta6nt
@@ -25,27 +25,11 @@ mdclean=vs.bat make.bat scheme.res ../bin/$m/*.exp mtscheme.exe* mdscheme.exe*
 include Mf-base
 
 ${Scheme}: make.bat
-	./make.bat
+	cmd.exe /c make.bat
 	cp ../bin/$m/scheme.exe ../bin/$m/petite.exe
-
-vs.bat:
-	echo '@echo off' > $@
-	echo 'if "%VS140COMNTOOLS%" neq "" goto :VS' >> $@
-	echo 'echo Visual Studio 2015 must be installed.' >> $@
-	echo 'exit 1' >> $@
-	echo ':VS' >> $@
-	echo 'set INCLUDE=' >> $@
-	echo 'set LIB=' >> $@
-	echo 'set LIBPATH=' >> $@
-	echo 'set MACHINETYPE=amd64' >> $@
-	echo 'if exist "%VS140COMNTOOLS%..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" set MACHINETYPE=x86_amd64' >> $@
-	echo 'if exist "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat" set MACHINETYPE=amd64' >> $@
-	echo 'call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %MACHINETYPE%' >> $@
-	echo '%*' >> $@
-	chmod +x $@
 
 make.bat: vs.bat
 	echo '@echo off' > $@
 	echo 'set MAKEFLAGS=' >> $@
-	echo 'call vs.bat nmake /f Makefile.$m /nologo %*' >> $@
+	echo 'vs.bat x86_amd64 amd64 && nmake /f Makefile.$m /nologo %*' >> $@
 	chmod +x $@

--- a/c/Mf-ti3nt
+++ b/c/Mf-ti3nt
@@ -25,24 +25,11 @@ mdclean=vs.bat make.bat scheme.res ../bin/$m/*.exp mtscheme.exe* mdscheme.exe*
 include Mf-base
 
 ${Scheme}: make.bat
-	./make.bat
+	cmd.exe /c make.bat
 	cp ../bin/$m/scheme.exe ../bin/$m/petite.exe
-
-vs.bat:
-	echo '@echo off' > $@
-	echo 'if "%VS140COMNTOOLS%" neq "" goto :VS' >> $@
-	echo 'echo Visual Studio 2015 must be installed.' >> $@
-	echo 'exit 1' >> $@
-	echo ':VS' >> $@
-	echo 'set INCLUDE=' >> $@
-	echo 'set LIB=' >> $@
-	echo 'set LIBPATH=' >> $@
-	echo 'call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x86' >> $@
-	echo '%*' >> $@
-	chmod +x $@
 
 make.bat: vs.bat
 	echo '@echo off' > $@
 	echo 'set MAKEFLAGS=' >> $@
-	echo 'call vs.bat nmake /f Makefile.$m /nologo %*' >> $@
+	echo 'vs.bat x86 && nmake /f Makefile.$m /nologo %*' >> $@
 	chmod +x $@

--- a/c/vs.bat
+++ b/c/vs.bat
@@ -1,0 +1,39 @@
+@echo off
+
+:: Set up Visual Studio command line environment variables given a
+:: sequence of machine types to try ("x86", "x86_amd64", and "amd64").
+
+:: Note: VS 11.0 (2012) and earlier won't work, because they
+:: don't support C99 mid-block declarations. Also, there's no
+:: such thing as VS 13.0.
+
+:: Clear environment variables that we might otherwise inherit
+set INCLUDE=
+set LIB=
+set LIBPATH=
+
+:: Find visual studio
+set VCDIR=%VS140COMNTOOLS%\..\..\vc
+if not exist "%VCDIR%\vcvarsall.bat" set VCDIR=%VS120COMNTOOLS%\..\..\vc
+
+:: Loop to find a requested machine type
+if exist "%VCDIR%\vcvarsall.bat" goto :VCDIR
+echo Could not find Visual Studio installed.
+exit 1
+
+:VCDIR
+
+set MACHINETYPE=%1
+if "%MACHINETYPE%" neq "" goto :MACHINE
+echo Could not find working machine type.
+exit 1
+
+:MACHINE
+if "%MACHINETYPE%" == "x86" goto :VS
+if exist "%VCDIR%\bin\%MACHINETYPE%\vcvars%MACHINETYPE%.bat" goto :VS
+shift
+goto :VCDIR
+
+:: Set environment variables
+:VS
+"%VCDIR%\vcvarsall.bat" %MACHINETYPE%

--- a/configure
+++ b/configure
@@ -41,7 +41,15 @@ installscriptname="scheme-script"
 : ${CFLAGS:=""}
 : ${LDFLAGS:=""}
 
-case `uname` in
+# On WSL, set OS to "Windows_NT" to create a Windows
+# build instead of a Linux (on Windows) build:
+if [ "$OS" = "Windows_NT" ] ; then
+    CONFIG_UNAME="CYGWIN_NT-"
+else
+    CONFIG_UNAME=`uname`
+fi
+
+case "${CONFIG_UNAME}" in
   Linux)
     if uname -a | egrep 'i386|i686|amd64|athlon|x86_64' > /dev/null 2>&1 ; then
       m32=i3le

--- a/mats/Mf-a6nt
+++ b/mats/Mf-a6nt
@@ -22,7 +22,7 @@ mdclean = cat_flush.exe cat_flush.obj foreign1.exp foreign1.lib foreign1.obj for
 include Mf-base
 
 foreign1.so: $(fsrc)
-	../c/vs.bat cl /DWIN32 /DX86_64 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv941.lib $(fsrc)
+	cmd.exe /c "vs.bat x86_amd64 amd64 && cl /DWIN32 /DX86_64 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv941.lib $(fsrc)"
 
 cat_flush: cat_flush.c
-	../c/vs.bat cl /DWIN32 /DX86_64 /MD /nologo $<
+	cmd.exe /c "vs.bat x86_amd64 amd64 && cl /DWIN32 /DX86_64 /MD /nologo $<"

--- a/mats/Mf-base
+++ b/mats/Mf-base
@@ -39,9 +39,17 @@ ifeq (${OS},Windows_NT)
 else
   dirsep = :
 endif
+
+# Explicit ".exe" needed for WSL
+ifeq ($(OS),Windows_NT)
+  ExeSuffix = .exe
+else
+  ExeSuffix =
+endif
+
 # Scheme is the scheme executable to test, and SCHEMEHEAPDIRS tells
 # it where to find its boot files
-Scheme = ../bin/$m/scheme
+Scheme = ../bin/$m/scheme${ExeSuffix}
 export SCHEMEHEAPDIRS=.${dirsep}../boot/%m
 
 # Include is the directory holding scheme.h.

--- a/mats/Mf-i3nt
+++ b/mats/Mf-i3nt
@@ -22,7 +22,7 @@ mdclean = cat_flush.exe cat_flush.obj foreign1.exp foreign1.lib foreign1.obj for
 include Mf-base
 
 foreign1.so: $(fsrc)
-	../c/vs.bat cl /DWIN32 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv941.lib $(fsrc)
+	cmd.exe /c "vs.bat x86 && cl /DWIN32 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv941.lib $(fsrc)"
 
 cat_flush: cat_flush.c
-	../c/vs.bat cl /DWIN32 /MD /nologo $<
+	cmd.exe /c "vs.bat x86 && cl /DWIN32 /MD /nologo $<"

--- a/mats/Mf-ta6nt
+++ b/mats/Mf-ta6nt
@@ -22,7 +22,7 @@ mdclean = cat_flush.exe cat_flush.obj foreign1.exp foreign1.lib foreign1.obj for
 include Mf-base
 
 foreign1.so: $(fsrc)
-	../c/vs.bat cl /DWIN32 /DX86_64 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv941.lib $(fsrc)
+	cmd.exe /c "vs.bat x86_amd64 amd64 && cl /DWIN32 /DX86_64 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv941.lib $(fsrc)"
 
 cat_flush: cat_flush.c
-	../c/vs.bat cl /DWIN32 /DX86_64 /MD /nologo $<
+	cmd.exe /c "vs.bat x86_amd64 amd64 && cl /DWIN32 /DX86_64 /MD /nologo $<"

--- a/mats/Mf-ti3nt
+++ b/mats/Mf-ti3nt
@@ -22,7 +22,7 @@ mdclean = cat_flush.exe cat_flush.obj foreign1.exp foreign1.lib foreign1.obj for
 include Mf-base
 
 foreign1.so: $(fsrc)
-	../c/vs.bat cl /DWIN32 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv941.lib $(fsrc)
+	cmd.exe /c "vs.bat x86 && cl /DWIN32 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv941.lib $(fsrc)"
 
 cat_flush: cat_flush.c
-	../c/vs.bat cl /DWIN32 /MD /nologo $<
+	cmd.exe /c "vs.bat x86 && cl /DWIN32 /MD /nologo $<"

--- a/mats/vs.bat
+++ b/mats/vs.bat
@@ -1,0 +1,3 @@
+:: Redirect to "..\c\vs.bat" without having to use
+:: backslashes in the makefile
+..\c\vs.bat %*

--- a/s/Mf-base
+++ b/s/Mf-base
@@ -67,10 +67,17 @@ gic = f
 # pps determines whether pass timings are printed
 pps = f
 
+# Explicit ".exe" needed for WSL
+ifeq ($(OS),Windows_NT)
+  ExeSuffix = .exe
+else
+  ExeSuffix =
+endif
+
 # The following control where files sit and typically don't need to be changed, except
 # that Scheme and SCHEMEHEAPDIRS are set by Mf-cross to point to the host Scheme
 # implementation
-Scheme = ../bin/$m/scheme
+Scheme = ../bin/$m/scheme${ExeSuffix}
 export SCHEMEHEAPDIRS=../boot/%m
 
 # Define the libdirs separator character
@@ -278,7 +285,7 @@ checkboot:
                  '(#%$$fasl-file-equal? "../boot/$m/sbb" "../boot/$m/petite.boot" #t)'\
                  '(#%$$fasl-file-equal? "../boot/$m/scb" "../boot/$m/scheme.boot" #t)'\
                  '(printf "bootfile comparison succeeded\n"))'\
-             | ../bin/$m/scheme -b ../boot/$m/sbb -q
+             | ../bin/$m/scheme${ExeSuffix} -b ../boot/$m/sbb -q
 
 xcheckboot: ${macroobj} ${patchfile}
 	@echo '(reset-handler abort)'\

--- a/workarea
+++ b/workarea
@@ -133,6 +133,12 @@ fi
 if [ ! -e $W/c/Mf-config ] ; then
   touch $W/c/Mf-config
 fi
+case $M in
+  *nt)
+    (cd $W/c; workln ../../c/vs.bat vs.bat)
+    ;;
+esac
+
 
 workdir $W/s
 (cd $W/s; workln ../../s/Mf-$M Mf-$M)
@@ -147,6 +153,11 @@ workdir $W/mats
 (cd $W/mats; forceworkln Mf-$M Makefile)
 (cd $W/mats; workln ../../mats/Mf-base Mf-base)
 (cd $W/mats; workln ../../mats/Mf-exobj Mf-exobj)
+case $M in
+  *nt)
+    (cd $W/mats; workln ../../mats/vs.bat vs.bat)
+    ;;
+esac
 
 for dir in `echo examples unicode` ; do
   workdir $W/$dir


### PR DESCRIPTION
The future of Unix tools on Windows is likely Bash on Ubuntu on Windows (a.k.a "Bash/WSL"), so this patch adapts the configure script and makefiles to support it – at least for the latest version, where Windows executables can be run from Bash/WSL.

Just running `configure` should create a Linux build in Bash/WSL, but this patch makes `configure` set up a Windows build when the `OS` environment variable is set to `Windows_NT`.

Visual Studio is found and set up essentially as before, but backslashes in makefiles are treated differently in Cygwin and Bash/WSL, so some parts are moved to ".bat" files. The makefiles now use "cmd.exe" to launch batch files or otherwise switch to Windows-command world. Finally, Bash/WSL needs "scheme.exe" instead of just "scheme" to run the built executable.