### PR TITLE
Fix fxbit-set? signature

### DIFF
--- a/LOG
+++ b/LOG
@@ -477,3 +477,5 @@
 - fix strip-fasl-file for immutable strings and vectors,
   fix an $oops call, and fix a vector-index increment in hashing
     strip.ss, 7.ss, newhash.ss, misc.ms
+- fix signature of fxbit-set?
+    primdata.ss

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -72,7 +72,7 @@
   (fxbit-count [sig [(fixnum) -> (fixnum)]] [flags arith-op cp02])
   (fxlength [sig [(fixnum) -> (fixnum)]] [flags arith-op cp02])
   (fxfirst-bit-set [sig [(fixnum) -> (fixnum)]] [flags arith-op cp02])
-  (fxbit-set? [sig [(fixnum sub-ufixnum) -> (fixnum)]] [flags pure cp02])
+  (fxbit-set? [sig [(fixnum sub-ufixnum) -> (boolean)]] [flags pure cp02])
   (fxcopy-bit [sig [(fixnum sub-ufixnum bit) -> (fixnum)]] [flags arith-op cp02])
   (fxbit-field [sig [(fixnum sub-ufixnum sub-ufixnum) -> (fixnum)]] [flags arith-op cp02 cp03])
   (fxcopy-bit-field [sig [(fixnum sub-ufixnum sub-ufixnum fixnum) -> (fixnum)]] [flags arith-op cp02])


### PR DESCRIPTION
The return value is marked as `fixnum`, but it should be `boolean`.

(I'm not sure if it is necesary to recalculate the bootfiles.)