### PR TITLE
Drop the arguments of void in cp0

### DIFF
--- a/LOG
+++ b/LOG
@@ -514,3 +514,6 @@
 - support Windows build on Bash/WSL
     BUILDING, configure, workarea, c/vs.bat (new), mats/vs.bat (new),
     c/Mf-*nt, mats/Mf-*, s/Mf-base
+- drop the arguments of void in cp0
+    cp0.ss
+    primdata.ss

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -1943,6 +1943,11 @@
                      (residualize-seq '() (list who e) ctxt)
                      true-rec)]))
 
+      (define-inline 3 (void)
+        [args
+         (residualize-seq '() args ctxt)
+         void-rec])
+
       (define-inline 2 (memq memv member assq assv assoc)
         [(x ls)
          (and (cp0-constant? null? (result-exp (value-visit-operand! ls)))

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1677,7 +1677,7 @@
   (virtual-register [sig [(sub-index) -> (ptr)]] [flags discard])
   (virtual-register-count [sig [() -> (length)]] [flags pure unrestricted true cp02])
   (visit [sig [(pathname) -> (void)]] [flags true])
-  (void [sig [() -> (void)]] [flags pure unrestricted mifoldable discard true])
+  (void [sig [() -> (void)]] [flags pure unrestricted mifoldable discard true cp03])
   (warning [sig [(who string sub-ptr ...) -> (ptr ...)]] [flags])
   (warningf [sig [(who string sub-ptr ...) -> (ptr ...)]] [flags])
   (weak-cons [sig [(ptr ptr) -> (ptr)]] [flags unrestricted alloc])


### PR DESCRIPTION
This reduces 

    (#3%void x (vector 1 2) (newline) y) ==> (begin (newline) (void))

This can be useful to mark `x` and `y` as unused and avoid allocating the `vector`.

I was not sure if it’s necessary to add tests, and in which file to put them.

I enabled it only for the optimization level `3` because otherwise it would reduce

    (#2%void (values 1 2)) ==> (void)

