### PR TITLE
Don't mark pariah as `simple?`

### DIFF
--- a/LOG
+++ b/LOG
@@ -529,3 +529,6 @@
     bytevector.ms, root-experr*
 - fixed typo in S_abnormal_exit
     schsig.c
+- don't remove the pariah form in the cp0 pass
+    cp0.ss,
+    misc.ms

--- a/mats/misc.ms
+++ b/mats/misc.ms
@@ -4865,6 +4865,17 @@
           (pariah 1)
           (* n (f (fx- n 1)))))
     3628800)
+  ; make sure that cp0 doesn't remove the pariah form
+  (not (equivalent-expansion?
+        (parameterize ([run-cp0 (lambda (cp0 x) (cp0 x))])
+          (expand/optimize
+            '(if (zero? (random 1000))
+               (pariah (display 0))
+               (display 1)))
+          (expand/optimize
+            '(if (zero? (random 1000))
+               (display 0)
+               (display 1))))))
 )
 
 (mat $read-time-stamp-counter

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -1055,7 +1055,7 @@
               [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type) (memoize (simple? e))]
               [(record-type ,rtd ,e) (memoize (simple? e))]
               [(record ,rtd ,rtd-expr ,e* ...) (memoize (and (simple? rtd-expr) (andmap simple? e*)))]
-              [(pariah) #t]
+              [(pariah) #f]
               [(profile ,src) #f]
               [(cte-optimization-loc ,box ,e) (memoize (simple? e))]
               [(moi) #t]


### PR DESCRIPTION
I'm not sure about this, and I'm not sure if this is the correct fix ...

If I run 

    (expand/optimize 
     '(if (zero? (random 37))
        (pariah (display "green"))
        (void)))

I get 

    (if (#2%zero? (#2%random 37))
        (#2%display "green")
        (#2%void))

but I expect something like

    (if (#2%zero? (#2%random 37))
        (begin
          (pariah (void))
          (#2%display "green"))
        (#2%void))

The problem is that `(pariah)` is marked as `simple?` and it's removed from the `begin` sequence.

This change breaks the reduction of

    (expand/optimize 
     '(if (zero? (random 37))
       (pariah (void))
       (void)))