### PR TITLE
add ordered guardians

### DIFF
--- a/LOG
+++ b/LOG
@@ -1042,3 +1042,7 @@
 - clarified required use of scheme-start to start an application
   packaged as a boot file and added a short "myecho" example.
     use.stex
+- add ordered guardians through a new optional argument to make-guardian
+    prims.ss, primdata.ss, cp0.ss, cpnanopass.ss,
+    cmacros.ss, mkheader.ss, gc.c, segment.c, types.h,
+    4.ms, smgmt.stex, release_notes.stex

--- a/c/segment.c
+++ b/c/segment.c
@@ -236,6 +236,9 @@ static void initialize_seginfo(seginfo *si, ISPC s, IGEN g) {
     /* fill sizeof(iptr) bytes at a time with 0xff */
     *dp = -1;
   }
+  si->has_triggers = 0;
+  si->trigger_ephemerons = 0;
+  si->trigger_guardians = 0;
 }
 
 iptr S_find_segments(s, g, n) ISPC s; IGEN g; iptr n; {

--- a/c/types.h
+++ b/c/types.h
@@ -118,7 +118,8 @@ typedef int IFASLCODE;      /* fasl type codes */
 typedef struct _seginfo {
   unsigned char space;                      /* space the segment is in */
   unsigned char generation;                 /* generation the segment is in */
-  unsigned char sorted;                     /* sorted indicator---possibly to be incorporated into space flags? */
+  unsigned char sorted : 1;                 /* sorted indicator---possibly to be incorporated into space flags? */
+  unsigned char has_triggers : 1;           /* set if trigger_ephemerons or trigger_guardians is set */
   octet min_dirty_byte;                     /* dirty byte for full segment, effectively min(dirty_bytes) */
   uptr number;                              /* the segment number */
   struct _chunkinfo *chunk;                 /* the chunk this segment belongs to */
@@ -126,6 +127,7 @@ typedef struct _seginfo {
   struct _seginfo **dirty_prev;             /* pointer to the next pointer on the previous seginfo in the DirtySegments list */
   struct _seginfo *dirty_next;              /* pointer to the next seginfo on the DirtySegments list */
   ptr trigger_ephemerons;                   /* ephemerons to re-check if object in segment is copied out */
+  ptr trigger_guardians;                    /* guardians to re-check if object in segment is copied out */
   octet dirty_bytes[cards_per_segment];     /* one dirty byte per card */
 } seginfo;
 

--- a/csug/smgmt.stex
+++ b/csug/smgmt.stex
@@ -551,7 +551,8 @@ reference, and that non-weak reference prevents the car field from becoming
 %----------------------------------------------------------------------------
 \entryheader
 \formdef{make-guardian}{\categoryprocedure}{(make-guardian)}
-\returns a new guardian
+\formdef{make-guardian}{\categoryprocedure}{(make-guardian \var{ordered?})}
+\returns a new guardian that is unordered unless \var{ordered?} is true
 \listlibraries
 \endentryheader
 
@@ -637,9 +638,25 @@ This feature circumvents the problems that might otherwise arise with
 shared or cyclic structure.
 A shared or cyclic structure consisting of inaccessible objects is
 preserved in its entirety, and each piece registered for preservation
-with any guardian is placed in the inaccessible set for that guardian.
+with any unordered guardian is placed in the inaccessible set for that guardian.
 The programmer then has complete control over the order in which pieces
 of the structure are processed.
+
+An ordered guardian, as created by providing a true value for
+\var{ordered?}, treats an object as inaccessible only when it is not
+accessible from any representative of an object that is in any
+usable guardian's inaccessible group and that is distinct from the
+object itself. Cycles among objects registered with ordered guardians
+can never become inaccessible unless the cycle is broken or some of
+the relevant guardians are dropped by the program, and each
+registered object's representative (if different from the object) can
+contribute to such cycles. If an object is registered to an ordered
+custodian with a representative that is different from the object but
+that references the object, then the object is in a cycle and will not
+become inaccessible unless the reference from the representative to
+the object is destroyed. Weak references do not count, so objects that
+form a cycle only when counting weak references may still become
+inaccessible.
 
 An object may be registered with a guardian more than once, in which
 case it will be retrievable more than once:
@@ -657,7 +674,12 @@ case it will be retrievable more than once:
 
 \noindent
 It may also be registered with more than one guardian, and guardians
-themselves can be registered with other guardians.
+themselves can be registered with other guardians. If an object
+is registered to both an unordered guardian and an ordered guardian
+and neither guardians is dropped, the object can become
+inaccessible for the ordered guardian only after it has been
+determined inaccessible for the unordered guardian and then
+retrieved and dropped again by the program.
 
 An object that has been registered with a guardian without a
 representative and placed in

--- a/mats/4.ms
+++ b/mats/4.ms
@@ -3367,10 +3367,29 @@
               (begin (x (cons 'a 'b)) (not (x)))
               (begin (collect) (equal? (x) '(a . b)))
               (not (x)))))
+   ;; same for ordered:
+   (with-interrupts-disabled
+      (let ([x (make-guardian #t)])
+         (and (not (x))
+              (begin (x (cons 'a 'b)) (not (x)))
+              (begin (collect) (equal? (x) '(a . b)))
+              (not (x)))))
    (with-interrupts-disabled
       (let ([x1 (make-guardian)])
          ; counting on a little compiler cleanliness here...
          (let ([x2 (make-guardian)])
+            (x1 x2)
+            (x2 x2))
+         (collect)
+         (let ([x2 (x1)])
+            (and (equal? (x2) x2)
+                 (not (x1))
+                 (not (x2))))))
+   ;; same for ordered:
+   (with-interrupts-disabled
+      (let ([x1 (make-guardian #t)])
+         ; counting on a little compiler cleanliness here...
+         (let ([x2 (make-guardian #t)])
             (x1 x2)
             (x2 x2))
          (collect)
@@ -3392,8 +3411,30 @@
                [(g) => (lambda (x) (f (- n 1)))]
                [else (collect) (f n)])))
          #t)))
+   ;; same for ordered:
+   (parameterize ([collect-trip-bytes (expt 2 24)])
+     (let ([k 1000000])
+       (let ([g (make-guardian #t)])
+         (let f ([n k])
+           (unless (= n 0)
+             (g (cons 3 4))
+             (let f () (cond [(g) => (lambda (x) (g x) (f))]))
+             (f (- n 1))))
+         (let f ([n k])
+           (unless (= n 0)
+             (cond
+               [(g) => (lambda (x) (f (- n 1)))]
+               [else (collect) (f n)])))
+         #t)))
    (with-interrupts-disabled
       (let ([x (make-guardian)])
+         (and (not (x))
+              (begin (x (cons 'a 'b) 'calvin) (not (x)))
+              (begin (collect) (equal? (x) 'calvin))
+              (not (x)))))
+   ;; same for ordered:
+   (with-interrupts-disabled
+      (let ([x (make-guardian #t)])
          (and (not (x))
               (begin (x (cons 'a 'b) 'calvin) (not (x)))
               (begin (collect) (equal? (x) 'calvin))
@@ -3404,8 +3445,22 @@
               (begin (x (cons 'a 'b) (cons 'calvin 'hobbes)) (not (x)))
               (begin (collect) (equal? (x) '(calvin . hobbes)))
               (not (x)))))
+   ;; same for ordered:
+   (with-interrupts-disabled
+      (let ([x (make-guardian #t)])
+         (and (not (x))
+              (begin (x (cons 'a 'b) (cons 'calvin 'hobbes)) (not (x)))
+              (begin (collect) (equal? (x) '(calvin . hobbes)))
+              (not (x)))))
    (with-interrupts-disabled
       (let ([x (make-guardian)])
+         (and (not (x))
+              (begin (x (cons 'a 'b) 17) (not (x)))
+              (begin (collect) (equal? (x) '17))
+              (not (x)))))
+   ;; same for ordered:
+   (with-interrupts-disabled
+      (let ([x (make-guardian #t)])
          (and (not (x))
               (begin (x (cons 'a 'b) 17) (not (x)))
               (begin (collect) (equal? (x) '17))
@@ -3421,9 +3476,29 @@
              (collect 0 0)
              (list ((g1)) p)))))
      '((c d) (b)))
+   ;; same for ordered:
+   (equal?
+     (with-interrupts-disabled
+       (let ([g1 (make-guardian #t)] [g2 (make-guardian #t)])
+         (let ([p (list 'a 'b)])
+           (g1 p g2)
+           (g2 (list 'c 'd))
+           (collect 0 0)
+           (let ([p (cdr p)])
+             (collect 0 0)
+             (list ((g1)) p)))))
+     '((c d) (b)))
 
    (eq? (with-interrupts-disabled
           (let* ([g (make-guardian)] [x (list 'a 'b)])
+            (g x)
+            (collect 0 0)
+            (#%$keep-live x)
+            (g)))
+        #f)
+   ;; same for ordered:
+   (eq? (with-interrupts-disabled
+          (let* ([g (make-guardian #t)] [x (list 'a 'b)])
             (g x)
             (collect 0 0)
             (#%$keep-live x)
@@ -3468,7 +3543,186 @@
        (error #f "no static-generation fraz in object-counts list"))
      (pretty-print (cons g x)) ; keep 'em live
      #t)
- )
+
+   (begin
+     (define (measure-guardian-chain-time n get-key ordered?)
+       ;; Create a chain of guardians `n` long and
+       ;; report how long a collection takes averaged
+       ;; over `iters` tries
+       (define iters 10)
+       (let loop ([g #f] [accum 0] [j iters])
+         (if (zero? j)
+             (if (zero? accum)
+                 g
+                 (/ accum iters))
+             (let ([g (let loop ([i n])
+                        (let ([g (make-guardian ordered?)])
+                          (if (zero? i)
+                              g
+                              (let ([next-g (loop (sub1 i))])
+                                (g (get-key next-g) next-g)
+                                g))))])
+               (let ([start (current-time)])
+                 (collect (collect-maximum-generation))
+                 (let ([delta (time-difference (current-time) start)])
+                   (loop g
+                         (+ accum
+                            (* (time-second delta) 1e9)
+                            (time-nanosecond delta))
+                         (sub1 j))))))))
+
+     ;; Make sure guardian chains imply GC times that
+     ;; look linear, as opposed to quadratic
+     (define (ok-relative-guardian-chain-time? get-key ordered?)
+       (let loop ([tries 3])
+         (or (< (/ (measure-guardian-chain-time 10000 get-key ordered?)
+                   (measure-guardian-chain-time 1000 get-key ordered?))
+                20)
+             (and (positive? tries)
+                  (loop (sub1 tries))))))
+
+     (and (ok-relative-guardian-chain-time? values #f)
+          (ok-relative-guardian-chain-time? values #t)
+          (let ([obj (gensym)])
+            (and
+             (ok-relative-guardian-chain-time? (lambda (x) obj) #f)
+             (ok-relative-guardian-chain-time? (lambda (x) obj) #t)))))
+
+   ;; Ordered finalization as different from unordred:
+   (with-interrupts-disabled
+    (let ([g1 (make-guardian #t)]
+          [g2 (make-guardian #t)]
+          [s (gensym)])
+      (g1 s)
+      (g2 (list s)) ; delays readying `s` in `g1`
+      (set! s #f)
+      (collect 0 0)
+      (and (list? (g2))
+           (not (g1))
+           (begin
+             (collect 0 0)
+             (and (symbol? (g1))
+                  (not (g2)))))))
+   ;; Unordered is different:
+   (with-interrupts-disabled
+    (let ([g1 (make-guardian #f)]
+          [g2 (make-guardian #f)]
+          [s (gensym)])
+      (g1 s)
+      (g2 (list s)) ; no delay
+      (set! s #f)
+      (collect 0 0)
+      (and (list? (g2))
+           (symbol? (g1))
+           (begin
+             (collect 0 0)
+             (and (not (g1))
+                  (not (g2)))))))
+
+   ;; cycle ok with unordered
+   (let ([g (make-guardian)])
+     (let ([s (gensym)])
+       (g s (list s)))
+     (collect)
+     (list? (g)))
+   ;; cycle not ok with ordered
+   (let ([g (make-guardian #t)])
+     (let ([s (gensym)])
+       (g s (list s)))
+     (collect)
+     (not (g)))
+   ;; self representative doesn't count as cycle
+   (let ([g (make-guardian #t)])
+     (let ([s (gensym)])
+       (g s  s))
+     (collect)
+     (symbol? (g)))
+   ;; try a longer cycle:
+   (let ([g (make-guardian #t)])
+     (let ([hd (cons 0 '())])
+       (set-cdr! hd
+                 (let loop ([i 100])
+                   (if (zero? i)
+                       hd
+                       (let ([p (cons i (loop (sub1 i)))])
+                         (g p)
+                         p)))))
+     (collect)
+     (not (g)))
+
+   ;; same object, ordered and unordered => ordered first
+   (with-interrupts-disabled
+    (let ([g1 (make-guardian)]
+          [g2 (make-guardian #t)])
+      (let ([s (gensym)])
+        (g1 s)
+        (g2 s))
+      (collect 0 0)
+      (collect 0 0)
+      (and (not (g2))
+           (symbol? (g1))
+           (not (g2))
+           (begin
+             (collect 0 0)
+             (and (symbol? (g2))
+                  (not (g1))
+                  (not (g2)))))))
+
+   ;; same object, both ordered => available from both
+   (with-interrupts-disabled
+    (let ([g1 (make-guardian #t)]
+          [g2 (make-guardian #t)])
+      (let ([s (gensym)])
+        (g1 s)
+        (g2 s))
+      (collect 0 0)
+      (and (symbol? (g2))
+           (symbol? (g1))
+           (not (g1))
+           (not (g2))
+           (begin
+             (collect 0 0)
+             (and (not (g1))
+                  (not (g2)))))))
+
+   ;; check ordered finalization on objects that immediately
+   ;; refer to themselves, which can create trouble for a naive
+   ;; approach to determining accessibility
+   (begin
+     (define (check-self-referencing p extract)
+       (with-interrupts-disabled
+        (let ([g (make-guardian #t)])
+          (g p)
+          (let ([wb (weak-cons p #f)])
+            (set! p #f)
+            (collect 0 0)
+            (let ([p (car wb)])
+              (and (not (g))
+                   (eq? p (extract p))))))))
+     (let ([p (cons #f #f)])
+       (set-car! p p)
+       (check-self-referencing p car)))
+   (let ([p (cons #f #f)])
+     (set-cdr! p p)
+     (check-self-referencing p cdr))
+   (let ([p (cons #f #f)])
+     (set-car! p p)
+     (set-cdr! p p)
+     (check-self-referencing p (lambda (p)
+                                 (and (eq? (car p) (cdr p))
+                                      (car p)))))
+   (let ([b (box #f)])
+     (set-box! b b)
+     (check-self-referencing b unbox))
+   (let ([f (letrec ([f (lambda () f)]) f)])
+     (check-self-referencing f (lambda (f) (f))))
+   (let ()
+     (define-record-type self (fields (mutable v)))
+     (let ([v (make-self #f)])
+       (self-v-set! v v)
+       (check-self-referencing v self-v)))
+  )
+
 
 (mat weak-cons
    (procedure? weak-cons)

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -58,6 +58,14 @@ Online versions of both books can be found at
 %-----------------------------------------------------------------------------
 \section{Functionality Changes}\label{section:functionality}
 
+\subsection{Ordered guardians (9.5.1)}
+
+The \scheme{make-guardian} function now accepts an optional argument to
+indicate whether the guardian is ordered or unordered. A guardian is
+unordered by default. An ordered guardian's objects are classified as
+inaccessible only when they are not reachable from the represetative
+of any inaccessible object in any other guardian.
+
 \subsection{Profile data retained for reclaimed code (9.5.1)}
 
 Profile data is now retained indefinitely even for code objects

--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -1441,7 +1441,9 @@
   ([ptr obj]
    [ptr rep]
    [ptr tconc]
-   [ptr next]))
+   [ptr next]
+   [ptr ordered?]  ; boolean to indicate finalization mode
+   [ptr pending])) ; for the GC's use
 
 ;;; forwarding addresses are recorded with a single forward-marker
 ;;; bit pattern (a special Scheme object) followed by the forwarding

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -5375,14 +5375,16 @@
           )
 
         (define-inline 3 $install-guardian
-          [(e-obj e-rep e-tconc)
-           (bind #f (e-obj e-rep e-tconc)
+          [(e-obj e-rep e-tconc ordered?)
+           (bind #f (e-obj e-rep e-tconc ordered?)
              (bind #t ([t (%constant-alloc typemod (constant size-guardian-entry))])
                (%seq
                  (set! ,(%mref ,t ,(constant guardian-entry-obj-disp)) ,e-obj)
                  (set! ,(%mref ,t ,(constant guardian-entry-rep-disp)) ,e-rep)
                  (set! ,(%mref ,t ,(constant guardian-entry-tconc-disp)) ,e-tconc)
                  (set! ,(%mref ,t ,(constant guardian-entry-next-disp)) ,(%tc-ref guardian-entries))
+                 (set! ,(%mref ,t ,(constant guardian-entry-ordered?-disp)) ,ordered?)
+                 (set! ,(%mref ,t ,(constant guardian-entry-pending-disp)) ,(%constant snil))
                  (set! ,(%tc-ref guardian-entries) ,t))))])
 
         (define-inline 2 virtual-register-count

--- a/s/mkheader.ss
+++ b/s/mkheader.ss
@@ -929,11 +929,15 @@
         (defref GUARDIANREP guardian-entry rep)
         (defref GUARDIANTCONC guardian-entry tconc)
         (defref GUARDIANNEXT guardian-entry next)
+        (defref GUARDIANORDERED guardian-entry ordered?)
+        (defref GUARDIANPENDING guardian-entry pending)
 
         (definit INITGUARDIANOBJ guardian-entry obj)
         (definit INITGUARDIANREP guardian-entry rep)
         (definit INITGUARDIANTCONC guardian-entry tconc)
         (definit INITGUARDIANNEXT guardian-entry next)
+        (definit INITGUARDIANORDERED guardian-entry ordered?)
+        (definit INITGUARDIANPENDING guardian-entry pending)
 
         (defref FORWARDMARKER forward marker)
         (defref FORWARDADDRESS forward address)

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1429,7 +1429,7 @@
   (make-engine [sig [(procedure) -> (engine)]] [flags pure alloc])
   (make-format-condition [sig [() -> (condition)]] [flags pure unrestricted mifoldable discard])
   (make-fxvector [sig [(length) (length fixnum) -> (fxvector)]] [flags alloc])
-  (make-guardian [sig [() -> (procedure)]] [flags alloc cp02])
+  (make-guardian [sig [() (ptr) -> (procedure)]] [flags alloc cp02])
   (make-hash-table [sig [() (ptr) -> (old-hash-table)]] [flags unrestricted alloc])
   (make-input-port [sig [(procedure string) -> (textual-input-port)]] [flags alloc])
   (make-input/output-port [sig [(procedure string string) -> (textual-input/output-port)]] [flags alloc])

--- a/s/prims.ss
+++ b/s/prims.ss
@@ -1408,11 +1408,13 @@
   (foreign-procedure "(cs)locked_objectp" (scheme-object) boolean))
 
 (define-who $install-guardian
-  (lambda (obj rep tconc)
+  (lambda (obj rep tconc ordered?)
     (unless (and (pair? tconc) (pair? (car tconc)) (pair? (cdr tconc))) ($oops who "~s is not a tconc" tconc))
-    (#3%$install-guardian obj rep tconc)))
+    (#3%$install-guardian obj rep tconc ordered?)))
 
-(define make-guardian (lambda () (#2%make-guardian)))
+(define make-guardian (case-lambda
+                       [() (#2%make-guardian)]
+                       [(ordered?) (#2%make-guardian ordered?)]))
 
 (define $address-in-heap?
   (foreign-procedure "(cs)s_addr_in_heap" (uptr) boolean))


### PR DESCRIPTION
Ordered finalization is intended to make certain finalization patterns more composable. A library might want to finalize internal parts of a data structure while allowing applications to finalize external pieces that refer to the internal parts. In that case, the goal is to finalize the internal pieces only after the application is definitely done with the external parts, including finalization on those external parts. Ordered finalization seems difficult to use correctly, but it looks like a good option for handling foreign resources.

This patch includes two changes to guardians: it uses the `seginfo` trigger mechanism to avoid quadratic-time handling of guardian chains (which are, granted, unlikely in practice), and it adds an optional `ordered?` argument to `make-guardian` to provide a form of ordered finalization. I initially planned to stage those changes as two commits, but various representation choices interact, so they're together here.

The implementation adds a field to a guardian entry, and so there's a second field to preserve double-word alignment – which I think is necessary to declare and initialize to work right with the GC, but correct me if that's not right. Since two words seem to be necessary for the one extra bit of information I need to distinguish ordered and unordered finalization, I used the second word to make the handling of triggers more convenient.

Another possible choice is to keep separate lists of ordered and unordered entries, but that seems much less convenient in the GC implementation. Also, the trigger lists in the `seginfo` record would have to be kept separate somehow, and triggers for "hold" versus "final" lists would have to be kept separate. I can think of ways to encode two extra bits of information in the current record, but the ways I see are too ugly unless this seems like a crucial issue.

The documentation update is minimal. It's unlikely to be a good specification of ordered finalization, and it certainly doesn't get across the pitfalls and intended use of ordered finalization.
