### PR TITLE
fix `(define-values () ....)` to expand to a definition

### DIFF
--- a/LOG
+++ b/LOG
@@ -541,3 +541,5 @@
     misc.ms
 - minor wordsmithing and fix for an overfull hbox
     objects.stex, system.stex
+- fix (define-values () ....) to expand to a definition
+    syntax.ss, 3.ms

--- a/mats/3.ms
+++ b/mats/3.ms
@@ -1087,6 +1087,16 @@
          (define-values (args . rot) (values #'(x ...) #'(x ...) 3))
          (list args rot))])
     '((a b c) ((a b c) 3)))
+  (equal?
+   (let ()
+     (define x 1)
+     (define-values ()
+       (begin
+         "don't interrupt definitions"
+         (values)))
+     (define y 2)
+     (list x y))
+   '(1 2))
 )
 
 (mat assimilation

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -7848,14 +7848,15 @@
     (syntax-case x ()
       [(_ () expr)
        (if (= (optimize-level) 3)
-           #'(begin expr (void))
-           #`(call-with-values
-               (lambda () expr)
-               (case-lambda
-                 [() (void)]
-                 [args #,($make-source-oops #'define-values
-                           "incorrect number of values from rhs"
-                           #'expr)])))]
+           #'(define unused (begin expr (void)))
+           #`(define unused
+               (call-with-values
+                 (lambda () expr)
+                 (case-lambda
+                   [() (void)]
+                   [args #,($make-source-oops #'define-values
+                             "incorrect number of values from rhs"
+                             #'expr)]))))]
       [(_ (x) expr)
        (identifier? #'x)
        (if (= (optimize-level) 3)


### PR DESCRIPTION
Expanding to a definition means that it doesn't interrupt a definition
sequence.