### PR TITLE
Add support for building with Visual Studio BuildTools

### DIFF
--- a/LOG
+++ b/LOG
@@ -566,3 +566,4 @@
     mats/Mf-a6nt, mats/Mf-ta6nt, mats/ftype.ms
 - added support for building Windows installs with Bash/WSL
     wininstall/Makefile, candle.bat, light.bat
+- added support for building with Visual Studio 2017's BuildTools in c/vs.bat

--- a/c/vs.bat
+++ b/c/vs.bat
@@ -15,6 +15,10 @@ if exist "%BATDIR%\vcvarsall.bat" goto found
 set BATDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
 if exist "%BATDIR%\vcvarsall.bat" goto found
 
+:: Visual Studio 2017 BuildTools
+set BATDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
 :: Visual Studio 2015
 set BATDIR=%VS140COMNTOOLS%..\..\VC
 if exist "%BATDIR%\vcvarsall.bat" goto found


### PR DESCRIPTION
I've been trying to build and run Chez in a container so support for Visual Studio BuildTools would be nice.

I have not yet successfully used VS's BuildTools to produce a build that passes all the mats and I'd be happy to sit on this PR until I can prove it all works.

Current mat summary: https://gist.github.com/kleinpa/84f535942dc370846774e38bbf17328a