### PR TITLE
small change in documentation, ouch to shout OUCH

### DIFF
--- a/csug/io.stex
+++ b/csug/io.stex
@@ -2729,7 +2729,7 @@ format string with the \scheme{~@(} and \scheme{~)} directives.
 
 \schemedisplay
 (format "~@(~r~)" 2599) ;=>  "Two thousand five hundred ninety-nine"
-(format "~@:(~a~)" "Ouch!") ;=>  "ouch!"
+(format "~@:(~a~)" "Ouch!") ;=>  "OUCH!"
 \endschemedisplay
 
 \noindent


### PR DESCRIPTION
The documentation currently shows

    (format "~@:(~a~)" "Ouch!")  =>  "ouch!"

Chez 9.4.1 instead outputs "OUCH!"

    Chez Scheme Version 9.4.1
    Copyright 1984-2017 Cisco Systems, Inc.
    
    > (format "~@:(~a~)" "Ouch!")
    "OUCH!"

Chez 8.4 also yields this same behavior. 