### PR TITLE
keeping procedure srclocs without other inspector info

### DIFF
--- a/LOG
+++ b/LOG
@@ -971,3 +971,7 @@
   bootstrap failures after small changes like the recent change to
   procedure names, so we don't have to rebuild the boot files as often.
     Mf-base
+- add generate-procedure-source-information
+    cmacros.ss, compile.ss, cpnanopass.ss, inspect.ss,
+    primdata.ss, prims.ss, misc.ms,
+    system.stex, release_notes.tex

--- a/csug/system.stex
+++ b/csug/system.stex
@@ -1108,6 +1108,7 @@ cp0-effort-limit
 cp0-score-limit
 cp0-outer-unroll-limit
 generate-inspector-information
+generate-procedure-source-information
 compile-profile
 generate-interrupt-trap
 enable-cross-library-optimization
@@ -2392,6 +2393,21 @@ For example, if:
 \noindent
 is included in a file, generation of inspector information will be
 disabled only for the remainder of that particular file.
+
+%----------------------------------------------------------------------------
+\entryheader\label{desc:generate-procedure-source-information}
+\formdef{generate-procedure-source-information}{\categorythreadparameter}{generate-procedure-source-information}
+\listlibraries
+\endentryheader
+
+\noindent
+When \scheme{generate-inspector-information} is set to \scheme{#f} and
+this parameter is set to \scheme{#t}, then a source location is preserved
+for a procedure, even though other inspector information is not preserved.
+Source information provides a small amount of debugging support at a
+much lower cost in memory and object-file size than full inspector information.
+If this parameter is changed during the compilation of a file, the
+original value will be restored.
 
 %----------------------------------------------------------------------------
 \entryheader

--- a/mats/misc.ms
+++ b/mats/misc.ms
@@ -2015,6 +2015,30 @@
   (eqv? (profile-clear) (void))
 )
 
+(mat generate-procedure-source-information
+  (begin
+    (define the-source
+      (let ([sfd (make-source-file-descriptor "the-source.ss" (open-bytevector-input-port '#vu8()))])
+        (make-source-object sfd 10 20)))
+    (define (make-proc full-inspect?)
+      (parameterize ([generate-inspector-information full-inspect?]
+                     [generate-procedure-source-information #t])
+        (let ([e '(lambda (x) x)])
+          (compile (make-annotation e the-source e)))))
+    (define proc-i (make-proc #t))
+    (define proc-n (make-proc #f))
+    (and (procedure? proc-i)
+         (procedure? proc-n)))
+  (equal? (((inspect/object proc-i) 'code) 'source-object)
+          the-source)
+  (equal? (((inspect/object proc-n) 'code) 'source-object)
+          the-source)
+  (equal? ((((inspect/object proc-i) 'code) 'source) 'value)
+          '(lambda (x) x))
+  (equal? (((inspect/object proc-n) 'code) 'source)
+          #f)
+)
+
 (mat strip-fasl-file
   (error?
     (fasl-strip-options ratfink profile-source))

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -58,6 +58,13 @@ Online versions of both books can be found at
 %-----------------------------------------------------------------------------
 \section{Functionality Changes}\label{section:functionality}
 
+\subsection{Procedure source location without inspector information (9.5.1)}
+
+When \scheme{generate-inspector-information} is set to \scheme{#f} and
+\scheme{generate-procedure-source-information} is set to \scheme{#t},
+source location information is preserved for a procedure, even though
+other inspector information is not preserved.
+
 \subsection{Foreign-procedure thread activation (9.5.1)}
 
 A new \scheme{__collect_safe} foreign-procedure convention, which can

--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -1362,6 +1362,7 @@
    [ptr meta-level]
    [ptr compile-profile]
    [ptr generate-inspector-information]
+   [ptr generate-procedure-source-information]
    [ptr generate-profile-forms]
    [ptr optimize-level]
    [ptr subset-mode]

--- a/s/compile.ss
+++ b/s/compile.ss
@@ -564,6 +564,7 @@
                    [cp0-score-limit (cp0-score-limit)]
                    [cp0-outer-unroll-limit (cp0-outer-unroll-limit)]
                    [generate-inspector-information (generate-inspector-information)]
+                   [generate-procedure-source-information (generate-procedure-source-information)]
                    [$compile-profile ($compile-profile)]
                    [generate-interrupt-trap (generate-interrupt-trap)]
                    [$optimize-closures ($optimize-closures)]

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -5334,6 +5334,7 @@
           (define-tc-parameter current-output-port current-output)
           (define-tc-parameter current-error-port current-error)
           (define-tc-parameter generate-inspector-information generate-inspector-information)
+          (define-tc-parameter generate-procedure-source-information generate-procedure-source-information)
           (define-tc-parameter generate-profile-forms generate-profile-forms)
           (define-tc-parameter $compile-profile compile-profile)
           (define-tc-parameter optimize-level optimize-level)
@@ -13913,6 +13914,11 @@
                                  (list->vector (ctci-rpi* ctci)))])
                         (vector-sort! (lambda (x y) (fx< (rp-info-offset x) (rp-info-offset y))) v)
                         v)))]
+                 [(and (generate-procedure-source-information)
+                       (info-lambda-src info)) =>
+                  (lambda (src)
+                    (include "types.ss")
+                    (make-code-info src #f #f #f #f))]
                  [else #f])
                (info-lambda-pinfo* info))
              (lambda (p) (c-trace (info-lambda-name info) code-size trace* p)))])

--- a/s/inspect.ss
+++ b/s/inspect.ss
@@ -2187,7 +2187,7 @@
               [len ($continuation-stack-length x)]
               [lpm ($continuation-return-livemask x)])
           (cond
-            [(and (code-info? info) (find-rpi offset (code-info-rpis info))) =>
+            [(and (code-info? info) (code-info-rpis info) (find-rpi offset (code-info-rpis info))) =>
              (lambda (rpi)
                (let ([cookie '(chocolate . chip)])
                  (let ([vals (make-vector len cookie)] [vars (make-vector len '())] [live (code-info-live info)])

--- a/s/patch.ss
+++ b/s/patch.ss
@@ -13,6 +13,11 @@
 ;;; See the License for the specific language governing permissions and
 ;;; limitations under the License.
 
+(define generate-procedure-source-information
+  (case-lambda
+   [() #f]
+   [(v) (void)]))
+
 (printf "loading ~s cross compiler~%" (constant machine-type-name))
 
 ; (current-expand (lambda args (apply sc-expand args)))

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -957,6 +957,7 @@
   (generate-inspector-information [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
   (generate-instruction-counts [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
   (generate-interrupt-trap [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
+  (generate-procedure-source-information [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
   (generate-profile-forms [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
   (generate-wpo-files [sig [() -> (boolean)] [(ptr) -> (void)]] [flags])
   (gensym-count [sig [() -> (uint)] [(uint) -> (void)]] [flags])

--- a/s/prims.ss
+++ b/s/prims.ss
@@ -1674,6 +1674,7 @@
                  [(x) (name (and x #t))]))
              (name init))])))
   (define-boolean-tc-parameter generate-inspector-information #t)
+  (define-boolean-tc-parameter generate-procedure-source-information #f)
   (define-boolean-tc-parameter generate-profile-forms #t)
   (define-boolean-tc-parameter $suppress-primitive-inlining #f)
 )


### PR DESCRIPTION
Procedure source locations are useful for error backtraces at a much lower cost (while losing some precision) compared to keeping full inspector information.

This patch adds `generate-procedure-source-information`, which defaults to #f and only applies when `generate-inspector-information` is #f. If `generate-procedure-source-information` is #t, then a source location is preserved with a code object even when  `generate-inspector-information` is #f.