### PR TITLE
Check that first argument of map in cp02 expansion

### DIFF
--- a/LOG
+++ b/LOG
@@ -766,4 +766,6 @@
 - Check that first argument of map is a procedure in cp02 expansion
   to raise the same error that the non expanded version
     cp0.ss
+- avoid building the result list in a map that is called for effect
+    cp0.ss
 

--- a/LOG
+++ b/LOG
@@ -763,4 +763,7 @@
   to use define-who instead of repeating 'substring-fill! in all the error
   messages.
     5_4.ss, 5_6.ss
+- Check that first argument of map is a procedure in cp02 expansion
+  to raise the same error that the non expanded version
+    cp0.ss
 

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -3588,6 +3588,9 @@
           (lambda (?p ?ls ?ls* lvl map? ctxt sc wd name moi)
             ; (map/for-each proc (list a11 a12 ... a1m) (list a21 a22 ... a2m) ... (list an1 an2 ... anm)) =>
             ;   (let ([p proc])
+            ;     (if (procedure? p)
+            ;         (void)
+            ;         ($oops 'map/for-each "~s is not a procedure" p))
             ;     (let ([t11 a11] ... [t1m a1m])
             ;       ...
             ;         (let ([tn1 an1] ... [tnm anm])
@@ -3605,22 +3608,32 @@
                                        e**)])
                          (residualize-seq (list* ?p ?ls ?ls*) '() ctxt)
                          (build-let (list p) (list (value-visit-operand! ?p))
-                           (let f ([t** temp**] [e** (reverse e**)] [ls* (cons ?ls ?ls*)])
-                             (if (null? t**)
-                                 (let ([results 
-                                        (let ([preinfo (app-preinfo ctxt)])
-                                          (let g ([t** temp**])
-                                            (if (null? (car t**))
-                                                '()
-                                                (cons `(call ,preinfo (ref #f ,p)
-                                                         ,(map (lambda (t*) (build-ref (car t*))) t**) ...)
-                                                  (g (map cdr t**))))))])
-                                   (if map?
-                                       (build-primcall lvl 'list results)
-                                       (make-seq* ctxt results)))
-                                 (non-result-exp (value-visit-operand! (car ls*))
-                                   (build-let (car t**) (car e**)
-                                     (f (cdr t**) (cdr e**) (cdr ls*)))))))))
+                           (let ([main
+                                  (let f ([t** temp**] [e** (reverse e**)] [ls* (cons ?ls ?ls*)])
+                                    (if (null? t**)
+                                        (let ([results 
+                                               (let ([preinfo (app-preinfo ctxt)])
+                                                 (let g ([t** temp**])
+                                                   (if (null? (car t**))
+                                                       '()
+                                                       (cons `(call ,preinfo (ref #f ,p)
+                                                                ,(map (lambda (t*) (build-ref (car t*))) t**) ...)
+                                                             (g (map cdr t**))))))])
+                                          (if map?
+                                              (build-primcall lvl 'list results)
+                                              (make-seq* ctxt results)))
+                                        (non-result-exp (value-visit-operand! (car ls*))
+                                          (build-let (car t**) (car e**)
+                                            (f (cdr t**) (cdr e**) (cdr ls*))))))]) 
+                             (if (fx= lvl 2)
+                               (make-seq ctxt
+                                 `(if ,(build-primcall 2 'procedure? (list `(ref #f ,p)))
+                                      ,void-rec
+                                      ,(build-primcall 3 '$oops (list `(quote ,(if map? 'map 'for-each))
+                                                                      `(quote  "~s is not a procedure")
+                                                                      `(ref #f ,p))))
+                                 main)
+                               main)))))
                   (nanopass-case (Lsrc Expr) (result-exp (value-visit-operand! (car ls*)))
                     [(quote ,d)
                      (and (list? d) (loop (cdr ls*) (cons (map (lambda (x) `(quote ,x)) d) e**) all-quoted?))]

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -3619,7 +3619,7 @@
                                                        (cons `(call ,preinfo (ref #f ,p)
                                                                 ,(map (lambda (t*) (build-ref (car t*))) t**) ...)
                                                              (g (map cdr t**))))))])
-                                          (if map?
+                                          (if (and map? (not (eq? ctxt 'effect)))
                                               (build-primcall lvl 'list results)
                                               (make-seq* ctxt results)))
                                         (non-result-exp (value-visit-operand! (car ls*))
@@ -3696,15 +3696,18 @@
                       (build-lambda (cons p ls*)
                         (let f ([n n] [ls* ls*] [ropnd* '()])
                           (if (fx= n 1)
-                              (build-primcall 3 'list
-                                (reverse
-                                  (cons
-                                    `(call ,(app-preinfo ctxt) (ref #f ,p)
-                                       ,(map (lambda (x)
-                                               (build-primcall 3 'car
-                                                 (list (build-ref x))))
-                                          ls*) ...)
-                                    ropnd*)))
+                              (let ([opnd*
+                                     (reverse
+                                       (cons
+                                         `(call ,(app-preinfo ctxt) (ref #f ,p)
+                                            ,(map (lambda (x)
+                                                    (build-primcall 3 'car
+                                                      (list (build-ref x))))
+                                               ls*) ...)
+                                         ropnd*))])
+                                (if (eq? ctxt 'effect)
+                                    (make-seq* ctxt opnd*)
+                                    (build-primcall 3 'list opnd*)))
                               (let ([tls* (map (lambda (x) (cp0-make-temp #t)) ls*)])
                                 (build-let tls*
                                   (map (lambda (x)


### PR DESCRIPTION
The first commit adds a checks that first argument of `map` is a procedure in cp02 expansion to raise the same error that the non expanded version

This fix an error in the tests in Windows of the mat "4.ms", [line 1082-1083](https://github.com/cisco/ChezScheme/blob/master/mats/4.ms#L1082-L1083) and [line 1713-L1714](https://github.com/cisco/ChezScheme/blob/master/mats/4.ms#L1713-L1714)

    (error? ; nonprocedure
      (map 3 '(a b c)))
    ;[...]
    (error?
      (for-each 3 '(a b c)))

The summary is something like

    -------- o=0 cp0=t --------
    [...]
    270c273
    < 4.mo:Expected error in mat map: "map: 3 is not a procedure".
    ---
    > 4.mo:Expected error in mat map: "attempt to apply non-procedure 3".
    340c343
    < 4.mo:Expected error in mat for-each: "for-each: 3 is not a procedure".
    ---
    > 4.mo:Expected error in mat for-each: "attempt to apply non-procedure 3".

I really don't understand why the test in Linux don't detect this. (Reading some error messages, I guess that it's a difference between scheme.boot and petite.boot, but I'm not sure if this even make sense. I'm very confused.)

----

The second commit is a small improvement. It avoids building the result list in a map that is called for effect.