### PR TITLE
foreign-procedure thread-activation control

### DIFF
--- a/LOG
+++ b/LOG
@@ -895,3 +895,9 @@
 - reworked the S_call_help/S_return CCHAIN handling to fix a bug in which
   the signal handler could trip over the NULL jumpbuf in a CCHAIN record.  
     schlib.c
+- add a __thread convention for foreign procedures and callables
+  to automate thread [de]activation
+    syntax.ss, ftype.ss, x86.ss, x86_64.ss, ppc32.ss,
+    cmacros.ss, base-lang.ss, np-languages.ss, cprep.ss
+    thread.c, prim.c, externs.h, foreign.stex, release_notes.stex,
+    mats/Mf-t*, foreign.ms, foreign4.c

--- a/LOG
+++ b/LOG
@@ -895,9 +895,10 @@
 - reworked the S_call_help/S_return CCHAIN handling to fix a bug in which
   the signal handler could trip over the NULL jumpbuf in a CCHAIN record.  
     schlib.c
-- add a __thread convention for foreign procedures and callables
+- add a __collect_safe convention for foreign procedures and callables
   to automate thread [de]activation
     syntax.ss, ftype.ss, x86.ss, x86_64.ss, ppc32.ss,
-    cmacros.ss, base-lang.ss, np-languages.ss, cprep.ss
+    cmacros.ss, base-lang.ss, np-languages.ss, cprep.ss, cpcommonize.ss,
+    cp0.ss, cpcheck.ss, cpvalid.ss, interpret.ss, cpletrec.ss,
     thread.c, prim.c, externs.h, foreign.stex, release_notes.stex,
     mats/Mf-t*, foreign.ms, foreign4.c

--- a/boot/a6le/equates.h
+++ b/boot/a6le/equates.h
@@ -87,8 +87,8 @@ typedef unsigned long U64;
 #define bytevector_length_factor 0x8
 #define bytevector_length_offset 0x3
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x8
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x9
@@ -681,6 +681,9 @@ typedef unsigned long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned long int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x80
@@ -695,28 +698,31 @@ typedef unsigned long U64;
 #define wchar_bits 0x20
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/a6nt/equates.h
+++ b/boot/a6nt/equates.h
@@ -87,8 +87,8 @@ typedef unsigned long long U64;
 #define bytevector_length_factor 0x8
 #define bytevector_length_offset 0x3
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x8
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x9
@@ -681,6 +681,9 @@ typedef unsigned long long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned long long int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x80
@@ -695,28 +698,31 @@ typedef unsigned long long U64;
 #define wchar_bits 0x10
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/a6osx/equates.h
+++ b/boot/a6osx/equates.h
@@ -87,8 +87,8 @@ typedef unsigned long U64;
 #define bytevector_length_factor 0x8
 #define bytevector_length_offset 0x3
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x8
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x9
@@ -681,6 +681,9 @@ typedef unsigned long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned long int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x80
@@ -695,28 +698,31 @@ typedef unsigned long U64;
 #define wchar_bits 0x20
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/i3le/equates.h
+++ b/boot/i3le/equates.h
@@ -88,8 +88,8 @@ typedef unsigned long long U64;
 #define bytevector_length_offset 0x3
 #define bytevector_pad_disp 0x5
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x4
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x8
@@ -679,6 +679,9 @@ typedef unsigned long long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x40
@@ -693,28 +696,31 @@ typedef unsigned long long U64;
 #define wchar_bits 0x20
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/i3nt/equates.h
+++ b/boot/i3nt/equates.h
@@ -88,8 +88,8 @@ typedef unsigned __int64 U64;
 #define bytevector_length_offset 0x3
 #define bytevector_pad_disp 0x5
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x4
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x8
@@ -680,6 +680,9 @@ typedef unsigned __int64 U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x40
@@ -694,28 +697,31 @@ typedef unsigned __int64 U64;
 #define wchar_bits 0x10
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/i3osx/equates.h
+++ b/boot/i3osx/equates.h
@@ -88,8 +88,8 @@ typedef unsigned long long U64;
 #define bytevector_length_offset 0x3
 #define bytevector_pad_disp 0x5
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x4
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x8
@@ -679,6 +679,9 @@ typedef unsigned long long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x40
@@ -693,28 +696,31 @@ typedef unsigned long long U64;
 #define wchar_bits 0x20
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/ta6le/equates.h
+++ b/boot/ta6le/equates.h
@@ -87,8 +87,8 @@ typedef unsigned long U64;
 #define bytevector_length_factor 0x8
 #define bytevector_length_offset 0x3
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x8
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x9
@@ -681,6 +681,9 @@ typedef unsigned long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned long int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x80
@@ -695,28 +698,31 @@ typedef unsigned long U64;
 #define wchar_bits 0x20
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/ta6nt/equates.h
+++ b/boot/ta6nt/equates.h
@@ -87,8 +87,8 @@ typedef unsigned long long U64;
 #define bytevector_length_factor 0x8
 #define bytevector_length_offset 0x3
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x8
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x9
@@ -681,6 +681,9 @@ typedef unsigned long long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned long long int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x80
@@ -695,28 +698,31 @@ typedef unsigned long long U64;
 #define wchar_bits 0x10
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/ta6osx/equates.h
+++ b/boot/ta6osx/equates.h
@@ -87,8 +87,8 @@ typedef unsigned long U64;
 #define bytevector_length_factor 0x8
 #define bytevector_length_offset 0x3
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x8
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x9
@@ -681,6 +681,9 @@ typedef unsigned long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned long int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x80
@@ -695,28 +698,31 @@ typedef unsigned long U64;
 #define wchar_bits 0x20
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/ti3le/equates.h
+++ b/boot/ti3le/equates.h
@@ -88,8 +88,8 @@ typedef unsigned long long U64;
 #define bytevector_length_offset 0x3
 #define bytevector_pad_disp 0x5
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x4
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x8
@@ -679,6 +679,9 @@ typedef unsigned long long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x40
@@ -693,28 +696,31 @@ typedef unsigned long long U64;
 #define wchar_bits 0x20
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/ti3nt/equates.h
+++ b/boot/ti3nt/equates.h
@@ -88,8 +88,8 @@ typedef unsigned __int64 U64;
 #define bytevector_length_offset 0x3
 #define bytevector_pad_disp 0x5
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x4
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x8
@@ -680,6 +680,9 @@ typedef unsigned __int64 U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x40
@@ -694,28 +697,31 @@ typedef unsigned __int64 U64;
 #define wchar_bits 0x10
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/boot/ti3osx/equates.h
+++ b/boot/ti3osx/equates.h
@@ -88,8 +88,8 @@ typedef unsigned long long U64;
 #define bytevector_length_offset 0x3
 #define bytevector_pad_disp 0x5
 #define bytevector_type_disp 0x1
-#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
-#define c_entry_vector_size 0x16
+#define c_entry_name_vector #(thread-context get-thread-context handle-apply-overflood handle-docall-error handle-overflow handle-overflood handle-nonprocedure-symbol thread-list split-and-resize raw-collect-cond raw-tc-mutex activate-thread deactivate-thread unactivate-thread handle-values-error handle-mvlet-error handle-arg-error foreign-entry install-library-entry get-more-room scan-remembered-set instantiate-code-object Sreturn Scall-one-result Scall-any-results)
+#define c_entry_vector_size 0x19
 #define cached_stack_link_disp 0x4
 #define cached_stack_size_disp 0x0
 #define card_offset_bits 0x8
@@ -679,6 +679,9 @@ typedef unsigned long long U64;
 #define typedef_u8 "unsigned char"
 #define typedef_uptr "unsigned int"
 #define typemod 0x8
+#define unactivate_mode_deactivate 0x1
+#define unactivate_mode_destroy 0x2
+#define unactivate_mode_noop 0x0
 #define unaligned_floats 1
 #define unaligned_integers 1
 #define underflow_limit 0x40
@@ -693,28 +696,31 @@ typedef unsigned long long U64;
 #define wchar_bits 0x20
 
 /* constants from declare-c-entries */
-#define CENTRY_Scall_any_results 21
-#define CENTRY_Scall_one_result 20
-#define CENTRY_Sreturn 19
-#define CENTRY_foreign_entry 14
-#define CENTRY_get_more_room 16
+#define CENTRY_Scall_any_results 24
+#define CENTRY_Scall_one_result 23
+#define CENTRY_Sreturn 22
+#define CENTRY_activate_thread 11
+#define CENTRY_deactivate_thread 12
+#define CENTRY_foreign_entry 17
+#define CENTRY_get_more_room 19
 #define CENTRY_get_thread_context 1
 #define CENTRY_handle_apply_overflood 2
-#define CENTRY_handle_arg_error 13
+#define CENTRY_handle_arg_error 16
 #define CENTRY_handle_docall_error 3
-#define CENTRY_handle_mvlet_error 12
+#define CENTRY_handle_mvlet_error 15
 #define CENTRY_handle_nonprocedure_symbol 6
 #define CENTRY_handle_overflood 5
 #define CENTRY_handle_overflow 4
-#define CENTRY_handle_values_error 11
-#define CENTRY_install_library_entry 15
-#define CENTRY_instantiate_code_object 18
+#define CENTRY_handle_values_error 14
+#define CENTRY_install_library_entry 18
+#define CENTRY_instantiate_code_object 21
 #define CENTRY_raw_collect_cond 9
 #define CENTRY_raw_tc_mutex 10
-#define CENTRY_scan_remembered_set 17
+#define CENTRY_scan_remembered_set 20
 #define CENTRY_split_and_resize 8
 #define CENTRY_thread_context 0
 #define CENTRY_thread_list 7
+#define CENTRY_unactivate_thread 13
 
 /* displacements for records */
 #define eq_hashtable_rtd_disp 1

--- a/c/externs.h
+++ b/c/externs.h
@@ -216,6 +216,8 @@ extern void S_mutex_release PROTO((scheme_mutex_t *m));
 extern s_thread_cond_t *S_make_condition PROTO((void));
 extern void S_condition_free PROTO((s_thread_cond_t *c));
 extern IBOOL S_condition_wait PROTO((s_thread_cond_t *c, scheme_mutex_t *m, ptr t));
+extern INT S_activate_thread PROTO((void));
+extern void S_unactivate_thread PROTO((int mode));
 #endif
 
 /* scheme.c */

--- a/c/prim.c
+++ b/c/prim.c
@@ -124,6 +124,9 @@ static void create_c_entry_vector() {
 #ifdef PTHREADS
     install_c_entry(CENTRY_raw_collect_cond, (ptr)&S_collect_cond);
     install_c_entry(CENTRY_raw_tc_mutex, (ptr)&S_tc_mutex);
+    install_c_entry(CENTRY_activate_thread, proc2ptr(S_activate_thread));
+    install_c_entry(CENTRY_deactivate_thread, proc2ptr(Sdeactivate_thread));
+    install_c_entry(CENTRY_unactivate_thread, proc2ptr(S_unactivate_thread));
 #endif /* PTHREADS */
     install_c_entry(CENTRY_handle_values_error, proc2ptr(S_handle_values_error));
     install_c_entry(CENTRY_handle_mvlet_error, proc2ptr(S_handle_mvlet_error));
@@ -139,7 +142,10 @@ static void create_c_entry_vector() {
 
     for (i = 0; i < c_entry_vector_size; i++) {
 #ifndef PTHREADS
-      if (i == CENTRY_raw_collect_cond || i == CENTRY_raw_tc_mutex) continue;
+      if (i == CENTRY_raw_collect_cond || i == CENTRY_raw_tc_mutex
+          || i == CENTRY_activate_thread || i == CENTRY_deactivate_thread
+          || i == CENTRY_unactivate_thread)
+        continue;
 #endif /* NOT PTHREADS */
       if (Svector_ref(S_G.c_entry_vector, i) == Sfalse) {
         fprintf(stderr, "c_entry_vector entry %d is uninitialized\n", i);

--- a/c/thread.c
+++ b/c/thread.c
@@ -143,6 +143,33 @@ IBOOL Sactivate_thread() { /* create or reactivate current thread */
   }
 }
 
+int S_activate_thread() { /* Like Sactivate_thread(), but returns a mode to revert the effect */
+  ptr tc = get_thread_context();
+
+  if (tc == (ptr)0) {
+    Sactivate_thread();
+    return unactivate_mode_destroy;
+  } else if (!ACTIVE(tc)) {
+    reactivate_thread(tc);
+    return unactivate_mode_deactivate;
+  } else
+    return unactivate_mode_noop;
+}
+
+void S_unactivate_thread(int mode) { /* Reverts a previous S_activate_thread() effect */
+  switch (mode) {
+  case unactivate_mode_deactivate:
+    Sdeactivate_thread();
+    break;
+  case unactivate_mode_destroy:
+    Sdestroy_thread();
+    break;
+  case unactivate_mode_noop:
+  default:
+    break;
+  }
+}
+
 void Sdeactivate_thread() { /* deactivate current thread */
   ptr tc = get_thread_context();
   if (tc != (ptr)0) deactivate_thread(tc)

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -192,8 +192,7 @@ Scheme-callable wrappers for foreign procedures can also be created via
 
 %----------------------------------------------------------------------------
 \entryheader
-\formdef{foreign-procedure}{\categorysyntax}{(foreign-procedure \var{entry-exp} (\var{param-type} \dots) \var{res-type})}
-\formdef{foreign-procedure}{\categorysyntax}{(foreign-procedure \var{conv} \var{entry-exp} (\var{param-type} \dots) \var{res-type})}
+\formdef{foreign-procedure}{\categorysyntax}{(foreign-procedure \var{conv} \dots \var{entry-exp} (\var{param-type} \dots) \var{res-type})}
 \returns a procedure
 \listlibraries
 \endentryheader
@@ -213,13 +212,14 @@ by the \var{res-type}.
 Multiple procedures may be created for the same \index{foreign entry}foreign entry.
 
 \label{page:conv-description}%
-If \var{conv} is present, it specifies the calling convention to be used.
-The default is \scheme{#f}, which specifies the default calling convention
-on the target machine.
-Three other conventions are currently supported, all only under
-Windows: \scheme{__stdcall}, \scheme{__cdecl}, and \scheme{__com}.
+Each \var{conv} adjusts specifies the calling convention to be used.
+A \scheme{#f} is allowed as \var{conv} to inicated the default calling convention
+on the target machine (so the \scheme{#f} has no effect).
+Three other conventions are currently supported under
+Windows: \scheme{__stdcall}, \scheme{__cdecl}, and \scheme{__com} (32-bit only).
 Since \scheme{__cdecl} is the default, specifying \scheme{__cdecl} is
 equivalent to specifying \scheme{#f} or no convention.
+Finally, \var{conv} can be \scheme{__thread} to control thread deactivation.
 
 Use \scheme{__stdcall} to access most Windows API procedures.
 Use \scheme{__cdecl} for Windows API varargs procedures,
@@ -249,6 +249,31 @@ creates an interface to a COM method at offset 12 in the vtable
 encapsulated within the COM instance passed as the first argument,
 with the second argument being a double float and the return
 value being an integer.
+
+Use \scheme{__thread} to make the current thread deactivated (see
+\scheme{fork-thread}) while a foreign procedure is called. The
+thread is activated again when the foreign procedure returns. Deactivation
+of the thread allows garbage collection to proceed in other threads,
+so do not pass collectable memory to the foreign procedure, or use
+\scheme{lock-object} to lock the memory in place; see also
+\scheme{Sdeactivate_thread}. The \scheme{__thread}
+declaration has no effect on a non-threaded version of the system.
+
+For example, calling the C \scheme{sleep} function with the default
+convention will block other Scheme threads from performing a garbage
+collection, but adding the \scheme{__thread} declaration avoids that
+problem:
+
+\schemedisplay
+(define c-sleep (foreign-procedure __thread "sleep" (unsigned) unsigned))
+(c-sleep 10) \var{; sleeps for 10 seconds without blocking other threads}
+\endschemedisplay
+
+\noindent
+If a foreign procedure that is called with \scheme{__thread} can
+invoke callables, then each callable should also be declared with
+\scheme{__thread} so that the callable reactivates the thread.
+
 
 Complete type checking and conversion is performed on the parameters.
 The types
@@ -976,8 +1001,7 @@ function ftype (Section~\ref{SECTFOREIGNDATA}).
 
 %----------------------------------------------------------------------------
 \entryheader
-\formdef{foreign-callable}{\categorysyntax}{(foreign-callable \var{proc-exp} (\var{param-type} \dots) \var{res-type})}
-\formdef{foreign-procedure}{\categorysyntax}{(foreign-callable \var{conv} \var{proc-exp} (\var{param-type} \dots) \var{res-type})}
+\formdef{foreign-callable}{\categorysyntax}{(foreign-callable \var{conv} \dots \var{proc-exp} (\var{param-type} \dots) \var{res-type})}
 \returns a code object
 \listlibraries
 \endentryheader
@@ -1002,9 +1026,16 @@ since the parameter
 values are provided by the foreign code and must be assumed to be
 correct.
 
-If \var{conv} is present, it specifies the calling convention to be used.
+Each \var{conv} adjusts the calling convention to be used.
 \scheme{foreign-callable} supports the same conventions as
 \scheme{foreign-procedure} with the exception of \scheme{__com}.
+The \scheme{__thread} convention for a callable activates a
+calling thread if the thread is not already activated, and
+the thread's activation state is reverted when the callable
+returns. If a calling thread is not currently registered with
+the Scheme system, then reverting the thread's activation state implies
+destroying the thread's registration (see \scheme{Sdestroy_thread}).
+
 
 The value produced by \scheme{foreign-callable} is a Scheme code object,
 which contains some header information as well as code that performs
@@ -1067,8 +1098,8 @@ void cb_init(void) {
        callbacks[i] = (CB)0;
 }
 
-void register_callback(char c, int cb) {
-    callbacks[c] = (CB)cb;
+void register_callback(char c, CB cb) {
+    callbacks[c] = cb;
 }
 
 void event_loop(void) {
@@ -1090,9 +1121,9 @@ Interfaces to these functions may be defined in Scheme as follows.
 (define cb-init
   (foreign-procedure "cb_init" () void))
 (define register-callback
-  (foreign-procedure "register_callback" (char int) void))
+  (foreign-procedure "register_callback" (char void*) void))
 (define event-loop
-  (foreign-procedure "event_loop" () void))
+  (foreign-procedure __thread "event_loop" () void))
 \endschemedisplay
 
 \noindent
@@ -1101,7 +1132,7 @@ A callback for selected characters can then be defined.
 \schemedisplay
 (define callback
   (lambda (p)
-    (let ([code (foreign-callable p (char) void)])
+    (let ([code (foreign-callable __thread p (char) void)])
       (lock-object code)
       (foreign-callable-entry-point code))))
 (define ouch
@@ -1135,7 +1166,10 @@ Ouch! Hit by 'e'
 \endschemedisplay
 
 \noindent
-A more well-behaved version of this example would save each code object
+The \scheme{__thread} declarations in this example ensure that
+other threads can continue working while \scheme{event-loop}
+blocks waiting for input.
+A more well-behaved version of the example would save each code object
 returned by \scheme{foreign-callable} and unlock it when it is no longer
 registered as a callback.
 
@@ -1440,8 +1474,7 @@ An \var{ftype} must take one of the following forms:
 (array \var{length} \var{ftype})
 (* \var{ftype})
 (bits (\var{field-name} \var{signedness} \var{bits}) \dots)
-(function (\var{ftype} \dots) \var{ftype})
-(function \var{conv} (\var{ftype} \dots) \var{ftype})
+(function \var{conv} \dots (\var{ftype} \dots) \var{ftype})
 (packed \var{ftype})
 (unpacked \var{ftype})
 (endian \var{endianness} \var{ftype})
@@ -3431,15 +3464,17 @@ in the active state and need not be activated.
 Any thread that has been deactivated, and any
 thread created by some mechanism other than \scheme{fork-thread} must,
 however, be activated before before it can access Scheme data or execute
-Scheme code.
-\scheme{Sactivate_thread} is used for this purpose.
+Scheme code. A foreign callable that is declared with \scheme{__thread}
+can activate a calling thread.
+Otherwise, \scheme{Sactivate_thread} must be used to activate a thread.
 It returns 1 the first time the thread is activated and 0 on each
-subsequent call.
+subsequent call until the activation is destroyed with \scheme{Sdestroy_thread}.
 
 Since active threads operating in C code prevent the storage management
 system from garbage collecting,
-a thread should be deactivated via \scheme{Sdeactivate_thread} whenever
-it may spend a significant amount of time in C code.
+a thread should be deactivated via \scheme{Sdeactivate_thread} or
+through a \scheme{foreign-procedure} \scheme{__thread} declaration whenever
+the thread may spend a significant amount of time in C code.
 This is especially important whenever the thread calls a C library
 function, like \scheme{read}, that may block indefinitely.
 Once deactivated, the thread must not touch any Scheme data or

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -213,13 +213,14 @@ Multiple procedures may be created for the same \index{foreign entry}foreign ent
 
 \label{page:conv-description}%
 Each \var{conv} adjusts specifies the calling convention to be used.
-A \scheme{#f} is allowed as \var{conv} to inicated the default calling convention
+A \scheme{#f} is allowed as \var{conv} to indicate the default calling convention
 on the target machine (so the \scheme{#f} has no effect).
 Three other conventions are currently supported under
 Windows: \scheme{__stdcall}, \scheme{__cdecl}, and \scheme{__com} (32-bit only).
 Since \scheme{__cdecl} is the default, specifying \scheme{__cdecl} is
 equivalent to specifying \scheme{#f} or no convention.
-Finally, \var{conv} can be \scheme{__thread} to control thread deactivation.
+Finally, \var{conv} can be \scheme{__collect_safe} to indicate that garbage
+collection is allowed concurrent to a call of the foreign procedure.
 
 Use \scheme{__stdcall} to access most Windows API procedures.
 Use \scheme{__cdecl} for Windows API varargs procedures,
@@ -250,29 +251,31 @@ encapsulated within the COM instance passed as the first argument,
 with the second argument being a double float and the return
 value being an integer.
 
-Use \scheme{__thread} to make the current thread deactivated (see
-\scheme{fork-thread}) while a foreign procedure is called. The
-thread is activated again when the foreign procedure returns. Deactivation
-of the thread allows garbage collection to proceed in other threads,
-so do not pass collectable memory to the foreign procedure, or use
-\scheme{lock-object} to lock the memory in place; see also
-\scheme{Sdeactivate_thread}. The \scheme{__thread}
-declaration has no effect on a non-threaded version of the system.
+Use \scheme{__collect_safe} to declare that garbage collection is
+allowed concurrent to the foreign procedure. The
+\scheme{__collect_safe} declaration allows concurrent collection by
+deactivating the current thread (see \scheme{fork-thread}) when the
+foreign procedure is called, and the thread is activated again when
+the foreign procedure returns. Refrain from passing collectable memory to a
+\scheme{__collect_safe} foreign procedure, or use \scheme{lock-object}
+to lock the memory in place; see also \scheme{Sdeactivate_thread}. The
+\scheme{__collect_safe} declaration has no effect on a non-threaded
+version of the system.
 
 For example, calling the C \scheme{sleep} function with the default
 convention will block other Scheme threads from performing a garbage
-collection, but adding the \scheme{__thread} declaration avoids that
+collection, but adding the \scheme{__collect_safe} declaration avoids that
 problem:
 
 \schemedisplay
-(define c-sleep (foreign-procedure __thread "sleep" (unsigned) unsigned))
+(define c-sleep (foreign-procedure __collect_safe "sleep" (unsigned) unsigned))
 (c-sleep 10) \var{; sleeps for 10 seconds without blocking other threads}
 \endschemedisplay
 
 \noindent
-If a foreign procedure that is called with \scheme{__thread} can
+If a foreign procedure that is called with \scheme{__collect_safe} can
 invoke callables, then each callable should also be declared with
-\scheme{__thread} so that the callable reactivates the thread.
+\scheme{__collect_safe} so that the callable reactivates the thread.
 
 
 Complete type checking and conversion is performed on the parameters.
@@ -291,13 +294,17 @@ and
 \index{\scheme{utf-32be}}\scheme{utf-32be},
 must be used with caution, however, since they allow allocated
 Scheme objects to be used in places the Scheme memory management system
-cannot control.  
-No problems will arise as long as such objects are not
+cannot control. No problems will arise as long as such objects are not
 retained in
 foreign variables or data structures while Scheme code is running,
 since garbage collection can occur only while Scheme code is running.
-All other parameter types are converted to equivalent foreign
-representations and consequently can be retained indefinitely in
+The types \scheme{string}, \scheme{wstring}, and \scheme{utf-8} through \scheme{utf-32be}
+are disallowed as argument types for a \scheme{__collect_safe} foreign procedure, since the object
+passed to the foreign procedure is not accessible for locking
+before concurrent garbage collection is enabled.
+Parameter types other than \scheme{scheme-object} through \scheme{utf-32be}
+are converted to equivalent foreign
+representations and consequently they can be retained indefinitely in
 foreign variables and data structures.
 Following are the valid parameter types:
 
@@ -534,8 +541,9 @@ with an added null byte, and the address of the first byte of the
 bytevector is passed to C.
 The bytevector should not be retained in foreign variables or data
 structures, since the memory management system may relocate or discard
-them between foreign procedure calls, and use their storage for some
-other purpose.
+them between foreign procedure calls and use their storage for some
+other purpose. The \scheme{utf-8} argument type is not allowed for a
+\scheme{__collect_safe} foreign procedure.
 
 \foreigntype{\scheme{utf-16le}}
 \index{\scheme{utf-16le}}Arguments of this type are treated like arguments
@@ -1029,7 +1037,7 @@ correct.
 Each \var{conv} adjusts the calling convention to be used.
 \scheme{foreign-callable} supports the same conventions as
 \scheme{foreign-procedure} with the exception of \scheme{__com}.
-The \scheme{__thread} convention for a callable activates a
+The \scheme{__collect_safe} convention for a callable activates a
 calling thread if the thread is not already activated, and
 the thread's activation state is reverted when the callable
 returns. If a calling thread is not currently registered with
@@ -1123,7 +1131,7 @@ Interfaces to these functions may be defined in Scheme as follows.
 (define register-callback
   (foreign-procedure "register_callback" (char void*) void))
 (define event-loop
-  (foreign-procedure __thread "event_loop" () void))
+  (foreign-procedure __collect_safe "event_loop" () void))
 \endschemedisplay
 
 \noindent
@@ -1132,7 +1140,7 @@ A callback for selected characters can then be defined.
 \schemedisplay
 (define callback
   (lambda (p)
-    (let ([code (foreign-callable __thread p (char) void)])
+    (let ([code (foreign-callable __collect_safe p (char) void)])
       (lock-object code)
       (foreign-callable-entry-point code))))
 (define ouch
@@ -1166,7 +1174,7 @@ Ouch! Hit by 'e'
 \endschemedisplay
 
 \noindent
-The \scheme{__thread} declarations in this example ensure that
+The \scheme{__collect_safe} declarations in this example ensure that
 other threads can continue working while \scheme{event-loop}
 blocks waiting for input.
 A more well-behaved version of the example would save each code object
@@ -3464,7 +3472,7 @@ in the active state and need not be activated.
 Any thread that has been deactivated, and any
 thread created by some mechanism other than \scheme{fork-thread} must,
 however, be activated before before it can access Scheme data or execute
-Scheme code. A foreign callable that is declared with \scheme{__thread}
+Scheme code. A foreign callable that is declared with \scheme{__collect_safe}
 can activate a calling thread.
 Otherwise, \scheme{Sactivate_thread} must be used to activate a thread.
 It returns 1 the first time the thread is activated and 0 on each
@@ -3473,7 +3481,7 @@ subsequent call until the activation is destroyed with \scheme{Sdestroy_thread}.
 Since active threads operating in C code prevent the storage management
 system from garbage collecting,
 a thread should be deactivated via \scheme{Sdeactivate_thread} or
-through a \scheme{foreign-procedure} \scheme{__thread} declaration whenever
+through a \scheme{foreign-procedure} \scheme{__collect_safe} declaration whenever
 the thread may spend a significant amount of time in C code.
 This is especially important whenever the thread calls a C library
 function, like \scheme{read}, that may block indefinitely.

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -256,7 +256,9 @@ allowed concurrent to the foreign procedure. The
 \scheme{__collect_safe} declaration allows concurrent collection by
 deactivating the current thread (see \scheme{fork-thread}) when the
 foreign procedure is called, and the thread is activated again when
-the foreign procedure returns. Refrain from passing collectable memory to a
+the foreign procedure returns. The \scheme{__collect_safe} declaration
+is useful, for example, when calling a blocking I/O call to allow
+other Scheme threads to run normally. Refrain from passing collectable memory to a
 \scheme{__collect_safe} foreign procedure, or use \scheme{lock-object}
 to lock the memory in place; see also \scheme{Sdeactivate_thread}. The
 \scheme{__collect_safe} declaration has no effect on a non-threaded
@@ -278,7 +280,8 @@ invoke callables, then each callable should also be declared with
 \scheme{__collect_safe} so that the callable reactivates the thread.
 
 
-Complete type checking and conversion is performed on the parameters.
+Complete type checking and conversion is performed on the parameters
+to a foreign procedure.
 The types
 \index{\scheme{scheme-object}}\scheme{scheme-object},
 \index{\scheme{string}}\scheme{string},
@@ -295,17 +298,28 @@ and
 must be used with caution, however, since they allow allocated
 Scheme objects to be used in places the Scheme memory management system
 cannot control. No problems will arise as long as such objects are not
-retained in
-foreign variables or data structures while Scheme code is running,
-since garbage collection can occur only while Scheme code is running.
-The types \scheme{string}, \scheme{wstring}, and \scheme{utf-8} through \scheme{utf-32be}
-are disallowed as argument types for a \scheme{__collect_safe} foreign procedure, since the object
-passed to the foreign procedure is not accessible for locking
-before concurrent garbage collection is enabled.
-Parameter types other than \scheme{scheme-object} through \scheme{utf-32be}
-are converted to equivalent foreign
+retained in foreign variables or data structures while Scheme code is running,
+and as long as they are not passed as arguments to a \scheme{__collect_safe} procedure,
+since garbage collection can occur only while Scheme code is running
+or when concurrent garbage collection is enabled.
+Other parameter types are converted to equivalent foreign
 representations and consequently they can be retained indefinitely in
 foreign variables and data structures.
+
+For argument types \scheme{string}, \scheme{wstring},
+\index{\scheme{utf-8}}\scheme{utf-8},
+\index{\scheme{utf-16le}}\scheme{utf-16le},
+\index{\scheme{utf-16be}}\scheme{utf-16be},
+\index{\scheme{utf-32le}}\scheme{utf-32le}, and
+\index{\scheme{utf-32be}}\scheme{utf-32be}, an argument is converted
+to a fresh object that is passed to the foreign procedure. Since the
+fresh object is not accessible for locking before the call, it can
+never be treated correctly for a \scheme{__collect_safe} foreign
+procedure, so those types are disallowed as argument types for
+a \scheme{__collect_safe} foreign procedure. For analogous reasons,
+those types are disallowed as the result of a \scheme{__collect_safe}
+foreign callable.
+
 Following are the valid parameter types:
 
 \foreigntype{\scheme{integer-8}}

--- a/mats/Mf-ta6fb
+++ b/mats/Mf-ta6fb
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	cc -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ta6le
+++ b/mats/Mf-ta6le
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -m64 -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	cc -m64 -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ta6nb
+++ b/mats/Mf-ta6nb
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	cc -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ta6ob
+++ b/mats/Mf-ta6ob
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	cc -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ta6osx
+++ b/mats/Mf-ta6osx
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -m64 -dynamiclib -undefined dynamic_lookup -I${Include} -o foreign1.so ${fsrc}
+	cc -m64 -pthread -dynamiclib -undefined dynamic_lookup -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ta6s2
+++ b/mats/Mf-ta6s2
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	gcc -m64 -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	gcc -m64 -D_REENTRANT -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	gcc -o cat_flush cat_flush.c

--- a/mats/Mf-ti3fb
+++ b/mats/Mf-ti3fb
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	cc -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ti3le
+++ b/mats/Mf-ti3le
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -m32 -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	cc -m32 -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ti3nb
+++ b/mats/Mf-ti3nb
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	cc -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ti3ob
+++ b/mats/Mf-ti3ob
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	cc -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ti3osx
+++ b/mats/Mf-ti3osx
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -m32 -dynamiclib -undefined dynamic_lookup -I${Include} -o foreign1.so ${fsrc}
+	cc -m32 -pthread -dynamiclib -undefined dynamic_lookup -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/Mf-ti3s2
+++ b/mats/Mf-ti3s2
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	gcc -m32 -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	gcc -m32 -D_REENTRANT -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	gcc -o cat_flush cat_flush.c

--- a/mats/Mf-tppc32le
+++ b/mats/Mf-tppc32le
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	cc -m32 -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	cc -m32 -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	cc -o cat_flush cat_flush.c

--- a/mats/foreign.ms
+++ b/mats/foreign.ms
@@ -2932,14 +2932,14 @@
   (error? (foreign-procedure __collect_safe "unknown" (utf-32be) void))
   (error? (foreign-procedure __collect_safe "unknown" (utf-32le) void))
   (error? (foreign-procedure __collect_safe "unknown" (string) void))
-  ;; (error? (foreign-procedure __collect_safe "unknown" (wstring) void)) <- error message varies by platform
+  (error? (foreign-procedure __collect_safe "unknown" (wstring) void))
   (error? (foreign-callable __collect_safe (lambda () #f) () utf-8))
   (error? (foreign-callable __collect_safe (lambda () #f) () utf-16le))
   (error? (foreign-callable __collect_safe (lambda () #f) () utf-16be))
   (error? (foreign-callable __collect_safe (lambda () #f) () utf-32le))
   (error? (foreign-callable __collect_safe (lambda () #f) () utf-32be))
   (error? (foreign-callable __collect_safe (lambda () #f) () string))
-  ;; (error? (foreign-callable __collect_safe (lambda () #f) () wstring)) <- error message varies by platform
+  (error? (foreign-callable __collect_safe (lambda () #f) () wstring))
   (begin
     (define-ftype thread-callback-T (function __collect_safe (double) double))
     (define (call-with-thread-callback cb-proc proc)

--- a/mats/foreign.ms
+++ b/mats/foreign.ms
@@ -2792,7 +2792,7 @@
       (syntax-rules ()
         [(_ arg ...)
          (and (check* () arg ...)
-              (check* (__thread) arg ...))]))
+              (check* (__collect_safe) arg ...))]))
     (define-syntax check-n
       (syntax-rules ()
         [(_ [ni ti vi] ...)
@@ -2925,9 +2925,23 @@
   (check-union [x double 68.0] [y int 0])
   )
 
-(mat thread
+(mat collect-safe
+  (error? (foreign-procedure __collect_safe "unknown" (utf-8) void))
+  (error? (foreign-procedure __collect_safe "unknown" (utf-16be) void))
+  (error? (foreign-procedure __collect_safe "unknown" (utf-16le) void))
+  (error? (foreign-procedure __collect_safe "unknown" (utf-32be) void))
+  (error? (foreign-procedure __collect_safe "unknown" (utf-32le) void))
+  (error? (foreign-procedure __collect_safe "unknown" (string) void))
+  ;; (error? (foreign-procedure __collect_safe "unknown" (wstring) void)) <- error message varies by platform
+  (error? (foreign-callable __collect_safe (lambda () #f) () utf-8))
+  (error? (foreign-callable __collect_safe (lambda () #f) () utf-16le))
+  (error? (foreign-callable __collect_safe (lambda () #f) () utf-16be))
+  (error? (foreign-callable __collect_safe (lambda () #f) () utf-32le))
+  (error? (foreign-callable __collect_safe (lambda () #f) () utf-32be))
+  (error? (foreign-callable __collect_safe (lambda () #f) () string))
+  ;; (error? (foreign-callable __collect_safe (lambda () #f) () wstring)) <- error message varies by platform
   (begin
-    (define-ftype thread-callback-T (function __thread (double) double))
+    (define-ftype thread-callback-T (function __collect_safe (double) double))
     (define (call-with-thread-callback cb-proc proc)
       (let ([callback (make-ftype-pointer thread-callback-T cb-proc)])
         (let ([r (proc callback)])
@@ -2966,12 +2980,12 @@
                (lambda (callback) (call callback arg n-times #t #t)))))
           call-in-unknown-thread-1))
     (define call-in-unknown-thread-4
-      ;; In an truly unknown thread, but also using `__thread` to
+      ;; In an truly unknown thread, but also using `__collect_safe` to
       ;; deactivate the current thread instead of using `Sdeactivate_thread`
       ;; within the foreign function:
       (if (and (threaded?)
                (foreign-entry? "call_in_unknown_thread"))
-          (let ([call (foreign-procedure __thread "call_in_unknown_thread"
+          (let ([call (foreign-procedure __collect_safe "call_in_unknown_thread"
                                          ((* thread-callback-T) double int boolean boolean)
                                          double)])
             (lambda (proc arg n-times)
@@ -2999,7 +3013,7 @@
              n
              1))
           10.5)
-  ;; Try to crash a `__thread` foreign-procedure call by moving the
+  ;; Try to crash a `__collect_safe` foreign-procedure call by moving the
   ;; return address out from under the foreign procedure. This attempt
   ;; should fail, because deactivating a thread first locks the
   ;; current code object.
@@ -3014,7 +3028,7 @@
         (fork-thread (lambda ()
                        (let loop ([i 10])
                          (unless (zero? i)
-                           (let ([spin (eval '(foreign-procedure __thread "spin_a_while" (int unsigned unsigned) unsigned))])
+                           (let ([spin (eval '(foreign-procedure __collect_safe "spin_a_while" (int unsigned unsigned) unsigned))])
                              (spin 1000000 0 1))
                            (loop (sub1 i))))
                        (mutex-acquire m)
@@ -3035,20 +3049,20 @@
 
 (machine-case
   [(i3nt ti3nt)
-   (mat i3nt-stdcall-thread
+   (mat i3nt-stdcall-collect-safe
      (equal?
        (let ()
-         (define sum (foreign-procedure __thread __stdcall "_sum_stdcall@8" (int int) int))
+         (define sum (foreign-procedure __collect_safe __stdcall "_sum_stdcall@8" (int int) int))
 	 (sum 3 7))
         10)
      (equal?
       (let ()
         (define Sinvoke2
-          (foreign-procedure __thread "Sinvoke2_stdcall"
+          (foreign-procedure __collect_safe "Sinvoke2_stdcall"
             (scheme-object scheme-object iptr)
             scheme-object))
         (define Fcons
-          (foreign-callable __thread __stdcall
+          (foreign-callable __collect_safe __stdcall
             (lambda (x y) (cons x y))
             (scheme-object iptr)
             scheme-object))
@@ -3058,6 +3072,6 @@
      (eqv?
        (let ()
          (define com-instance ((foreign-procedure "get_com_instance" () iptr)))
-         ((foreign-procedure __thread __com 0 (iptr int) int) com-instance 3)
-         ((foreign-procedure __thread __com 4 (iptr int) int) com-instance 17))
+         ((foreign-procedure __collect_safe __com 0 (iptr int) int) com-instance 3)
+         ((foreign-procedure __collect_safe __com 4 (iptr int) int) com-instance 17))
        37))])

--- a/mats/foreign.ms
+++ b/mats/foreign.ms
@@ -2682,49 +2682,49 @@
     (define-ftype i64 integer-64)
     (define-syntax check*
       (syntax-rules ()
-        [(_ T s [vi ...] [T-ref ...] [T-set! ...])
+        [(_ (conv ...) T s [vi ...] [T-ref ...] [T-set! ...])
          (let ()
-           (define-ftype callback (function ((& T)) double))
-           (define-ftype callback-two (function ((& T) (& T)) double))
-           (define-ftype pre-int-callback (function (int (& T)) double))
-           (define-ftype pre-double-callback (function (double (& T)) double))
-           (define-ftype callback-r (function () (& T)))
-           (define get (foreign-procedure (format "f4_get~a" s)
+           (define-ftype callback (function conv ... ((& T)) double))
+           (define-ftype callback-two (function conv ... ((& T) (& T)) double))
+           (define-ftype pre-int-callback (function conv ... (int (& T)) double))
+           (define-ftype pre-double-callback (function conv ... (double (& T)) double))
+           (define-ftype callback-r (function conv ... () (& T)))
+           (define get (foreign-procedure conv ... (format "f4_get~a" s)
                                           () (& T)))
-           (define sum (foreign-procedure (format "f4_sum~a" s)
+           (define sum (foreign-procedure conv ... (format "f4_sum~a" s)
                                           ((& T)) double))
-           (define sum_two (foreign-procedure (format "f4_sum_two~a" s)
+           (define sum_two (foreign-procedure conv ... (format "f4_sum_two~a" s)
                                               ((& T) (& T)) double))
-           (define sum_pre_int (foreign-procedure (format "f4_sum_pre_int~a" s)
+           (define sum_pre_int (foreign-procedure conv ... (format "f4_sum_pre_int~a" s)
                                                   (int (& T)) double))
-           (define sum_pre_int_int (foreign-procedure (format "f4_sum_pre_int_int~a" s)
+           (define sum_pre_int_int (foreign-procedure conv ... (format "f4_sum_pre_int_int~a" s)
                                                       (int int (& T)) double))
-           (define sum_pre_int_int_int_int (foreign-procedure (format "f4_sum_pre_int_int_int_int~a" s)
+           (define sum_pre_int_int_int_int (foreign-procedure conv ... (format "f4_sum_pre_int_int_int_int~a" s)
                                                               (int int int int (& T)) double))
-           (define sum_pre_int_int_int_int_int_int (foreign-procedure (format "f4_sum_pre_int_int_int_int_int_int~a" s)
+           (define sum_pre_int_int_int_int_int_int (foreign-procedure conv ... (format "f4_sum_pre_int_int_int_int_int_int~a" s)
                                                                       (int int int int int int (& T)) double))
-           (define sum_post_int (foreign-procedure (format "f4_sum~a_post_int" s)
+           (define sum_post_int (foreign-procedure conv ... (format "f4_sum~a_post_int" s)
                                                    ((& T) int) double))
-           (define sum_pre_double (foreign-procedure (format "f4_sum_pre_double~a" s)
+           (define sum_pre_double (foreign-procedure conv ... (format "f4_sum_pre_double~a" s)
                                                      (double (& T)) double))
-           (define sum_pre_double_double (foreign-procedure (format "f4_sum_pre_double_double~a" s)
+           (define sum_pre_double_double (foreign-procedure conv ... (format "f4_sum_pre_double_double~a" s)
                                                             (double double (& T)) double))
-           (define sum_pre_double_double_double_double (foreign-procedure (format "f4_sum_pre_double_double_double_double~a" s)
+           (define sum_pre_double_double_double_double (foreign-procedure conv ... (format "f4_sum_pre_double_double_double_double~a" s)
                                                                           (double double double double (& T)) double))
            (define sum_pre_double_double_double_double_double_double_double_double
-             (foreign-procedure (format "f4_sum_pre_double_double_double_double_double_double_double_double~a" s)
+             (foreign-procedure conv ... (format "f4_sum_pre_double_double_double_double_double_double_double_double~a" s)
                                 (double double double double double double double double (& T)) double))
-           (define sum_post_double (foreign-procedure (format "f4_sum~a_post_double" s)
+           (define sum_post_double (foreign-procedure conv ... (format "f4_sum~a_post_double" s)
                                                       ((& T) double) double))
-           (define cb_send (foreign-procedure (format "f4_cb_send~a" s)
+           (define cb_send (foreign-procedure conv ... (format "f4_cb_send~a" s)
                                               ((* callback)) double))
-           (define cb_send_two (foreign-procedure (format "f4_cb_send_two~a" s)
+           (define cb_send_two (foreign-procedure conv ... (format "f4_cb_send_two~a" s)
                                                   ((* callback-two)) double))
-           (define cb_send_pre_int (foreign-procedure (format "f4_cb_send_pre_int~a" s)
+           (define cb_send_pre_int (foreign-procedure conv ... (format "f4_cb_send_pre_int~a" s)
                                                       ((* pre-int-callback)) double))
-           (define cb_send_pre_double (foreign-procedure (format "f4_cb_send_pre_double~a" s)
+           (define cb_send_pre_double (foreign-procedure conv ... (format "f4_cb_send_pre_double~a" s)
                                                          ((* pre-double-callback)) double))
-           (define sum_cb (foreign-procedure (format "f4_sum_cb~a" s)
+           (define sum_cb (foreign-procedure conv ... (format "f4_sum_cb~a" s)
                                              ((* callback-r)) double))
            (define-syntax with-callback
              (syntax-rules ()
@@ -2788,6 +2788,11 @@
                        (begin
                          (free_at_boundary (ftype-pointer-address a))
                          #t)))))]))
+    (define-syntax check*t
+      (syntax-rules ()
+        [(_ arg ...)
+         (and (check* () arg ...)
+              (check* (__thread) arg ...))]))
     (define-syntax check-n
       (syntax-rules ()
         [(_ [ni ti vi] ...)
@@ -2800,17 +2805,17 @@
                                [(null? l) '()]
                                [else (cons (format "_~a" (car l))
                                            (loop (cdr l)))]))))
-           (check* T s
-                   [vi ...]
-                   [(lambda (a) (ftype-ref T (ni) a)) ...]
-                   [(lambda (a) (ftype-set! T (ni) a vi)) ...]))]))
+           (check*t T s
+                    [vi ...]
+                    [(lambda (a) (ftype-ref T (ni) a)) ...]
+                    [(lambda (a) (ftype-set! T (ni) a vi)) ...]))]))
     (define-syntax check
       (syntax-rules ()
         [(_ t1 v1)
-         (check* t1 (format "_~a" 't1)
-                 [v1]
-                 [(lambda (a) (ftype-ref t1 () a))]
-                 [(lambda (a) (ftype-set! t1 () a v1))])]))
+         (check*t t1 (format "_~a" 't1)
+                  [v1]
+                  [(lambda (a) (ftype-ref t1 () a))]
+                  [(lambda (a) (ftype-set! t1 () a v1))])]))
     (define-syntax check-union
       (syntax-rules ()
         [(_ [n0 t0 v0] [ni ti vi] ...)
@@ -2823,10 +2828,10 @@
                                [(null? l) '()]
                                [else (cons (format "_~a" (car l))
                                            (loop (cdr l)))]))))
-           (check* T s
-                   [v0]
-                   [(lambda (a) (ftype-ref T (n0) a))]
-                   [(lambda (a) (ftype-set! T (n0) a v0))]))]))
+           (check*t T s
+                    [v0]
+                    [(lambda (a) (ftype-ref T (n0) a))]
+                    [(lambda (a) (ftype-set! T (n0) a v0))]))]))
     (define-syntax check-1
       (syntax-rules ()
         [(_ t1 v1)
@@ -2917,4 +2922,142 @@
   (check-union [x int 48] [y int 0])
   (check-union [x i64 43] [y int 0])
   (check-union [x float 58.0] [y int 0])
-  (check-union [x double 68.0] [y int 0]))
+  (check-union [x double 68.0] [y int 0])
+  )
+
+(mat thread
+  (begin
+    (define-ftype thread-callback-T (function __thread (double) double))
+    (define (call-with-thread-callback cb-proc proc)
+      (let ([callback (make-ftype-pointer thread-callback-T cb-proc)])
+        (let ([r (proc callback)])
+          (unlock-object
+           (foreign-callable-code-object
+            (ftype-pointer-address callback)))
+          r)))
+    (define (call-in-unknown-thread-1 proc arg n-times)
+      ;; Baseline implementation that uses the current thread
+      (let loop ([i 0] [arg arg])
+        (cond
+         [(= i n-times) arg]
+         [else (loop (fx+ i 1) (proc arg))])))
+    (define call-in-unknown-thread-2
+      ;; Call in the current thread, but through the foreign procedure
+      (if (and (threaded?)
+               (foreign-entry? "call_in_unknown_thread"))
+          (let ([call (foreign-procedure "call_in_unknown_thread"
+                                         ((* thread-callback-T) double int boolean boolean)
+                                         double)])
+            (lambda (proc arg n-times)
+              (call-with-thread-callback
+               proc
+               (lambda (callback) (call callback arg n-times #f #t)))))
+          call-in-unknown-thread-1))
+    (define call-in-unknown-thread-3
+      ;; Call in a truly unknown thread:
+      (if (and (threaded?)
+               (foreign-entry? "call_in_unknown_thread"))
+          (let ([call (foreign-procedure "call_in_unknown_thread"
+                                         ((* thread-callback-T) double int boolean boolean)
+                                         double)])
+            (lambda (proc arg n-times)
+              (call-with-thread-callback
+               proc
+               (lambda (callback) (call callback arg n-times #t #t)))))
+          call-in-unknown-thread-1))
+    (define call-in-unknown-thread-4
+      ;; In an truly unknown thread, but also using `__thread` to
+      ;; deactivate the current thread instead of using `Sdeactivate_thread`
+      ;; within the foreign function:
+      (if (and (threaded?)
+               (foreign-entry? "call_in_unknown_thread"))
+          (let ([call (foreign-procedure __thread "call_in_unknown_thread"
+                                         ((* thread-callback-T) double int boolean boolean)
+                                         double)])
+            (lambda (proc arg n-times)
+              (call-with-thread-callback
+               proc
+               (lambda (callback) (call callback arg n-times #t #f)))))
+          call-in-unknown-thread-1))
+    #t)
+  ;; These tests will pass only if `collect` can run, where `collect`
+  ;; can run only if a single thread is active
+  (equal? (call-in-unknown-thread-1 (lambda (n) (collect 0) (+ n 1.0)) 3.5 1)
+          4.5)
+  (equal? (call-in-unknown-thread-2 (lambda (n) (collect 0) (+ n 1.0)) 3.5 2)
+          5.5)
+  (equal? (call-in-unknown-thread-3 (lambda (n) (collect 0) (+ n 1.0)) 3.5 3)
+          6.5)
+  (equal? (call-in-unknown-thread-4 (lambda (n) (collect 0) (+ n 1.0)) 3.5 4)
+          7.5)
+  (equal? (let loop ([n 10.0])
+            (call-in-unknown-thread-4
+             (lambda (n)
+               (cond
+                [(zero? n) (collect) 0.5]
+                [else (+ 1.0 (loop (- n 1.0)))]))
+             n
+             1))
+          10.5)
+  ;; Try to crash a `__thread` foreign-procedure call by moving the
+  ;; return address out from under the foreign procedure. This attempt
+  ;; should fail, because deactivating a thread first locks the
+  ;; current code object.
+  (or (not (threaded?))
+      (let ([m (make-mutex)]
+            [done? #f]
+            [ok? #t])
+        (define object->addr
+          (foreign-procedure "(cs)fxmul"
+                             (scheme-object uptr)
+                             uptr))
+        (fork-thread (lambda ()
+                       (let loop ([i 10])
+                         (unless (zero? i)
+                           (let ([spin (eval '(foreign-procedure __thread "spin_a_while" (int unsigned unsigned) unsigned))])
+                             (spin 1000000 0 1))
+                           (loop (sub1 i))))
+                       (mutex-acquire m)
+                       (set! done? #t)
+                       (mutex-release m)))
+        (let loop ()
+          (mutex-acquire m)
+          (let ([done? done?])
+            (mutex-release m)
+            (unless done?
+              (let loop ([i 10])
+                (unless (zero? i)
+                  (eval '(foreign-procedure "spin_a_while" () void))
+                  (loop (sub1 i))))
+              (loop))))
+        ok?))
+)
+
+(machine-case
+  [(i3nt ti3nt)
+   (mat i3nt-stdcall-thread
+     (equal?
+       (let ()
+         (define sum (foreign-procedure __thread __stdcall "_sum_stdcall@8" (int int) int))
+	 (sum 3 7))
+        10)
+     (equal?
+      (let ()
+        (define Sinvoke2
+          (foreign-procedure __thread "Sinvoke2_stdcall"
+            (scheme-object scheme-object iptr)
+            scheme-object))
+        (define Fcons
+          (foreign-callable __thread __stdcall
+            (lambda (x y) (cons x y))
+            (scheme-object iptr)
+            scheme-object))
+        (Sinvoke2 Fcons 41 51))
+      '(41 . 51)))
+    (mat i3nt-com-thread
+     (eqv?
+       (let ()
+         (define com-instance ((foreign-procedure "get_com_instance" () iptr)))
+         ((foreign-procedure __thread __com 0 (iptr int) int) com-instance 3)
+         ((foreign-procedure __thread __com 4 (iptr int) int) com-instance 17))
+       37))])

--- a/mats/foreign3.c
+++ b/mats/foreign3.c
@@ -178,6 +178,10 @@ EXPORT char Srvtest_char(ptr code, ptr x1) {
 }
 
 #ifdef WIN32
+EXPORT int __stdcall sum_stdcall(int a, int b) {
+    return a + b;
+}
+
 EXPORT ptr Sinvoke2_stdcall(ptr code, ptr x1, iptr x2) {
     return (*((ptr (__stdcall *) PROTO((ptr, iptr)))Sforeign_callable_entry_point(code)))(x1, x2);
 }

--- a/mats/root-experr-compile-0-f-f-f
+++ b/mats/root-experr-compile-0-f-f-f
@@ -9484,6 +9484,18 @@ foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name 
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-8 argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-16be argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-16le argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-32be argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-32le argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-8 argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-8 result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-16le result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-16be result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-32le result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-32be result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-8 result not allowed with __collect_safe callable".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".

--- a/mats/root-experr-compile-0-f-f-f
+++ b/mats/root-experr-compile-0-f-f-f
@@ -9484,18 +9484,20 @@ foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name 
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-8 argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-16be argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-16le argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-32be argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-32le argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-8 argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-8 result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-16le result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-16be result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-32le result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-32be result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-8 result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".

--- a/mats/root-experr-compile-2-f-f-f
+++ b/mats/root-experr-compile-2-f-f-f
@@ -9484,6 +9484,18 @@ foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name 
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-8 argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-16be argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-16le argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-32be argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-32le argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-8 argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-8 result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-16le result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-16be result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-32le result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-32be result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-8 result not allowed with __collect_safe callable".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".

--- a/mats/root-experr-compile-2-f-f-f
+++ b/mats/root-experr-compile-2-f-f-f
@@ -9484,18 +9484,20 @@ foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name 
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-8 argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-16be argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-16le argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-32be argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-32le argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-procedure: utf-8 argument not allowed with __collect_safe procedure".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-8 result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-16le result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-16be result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-32le result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-32be result not allowed with __collect_safe callable".
-foreign.mo:Expected error in mat collect-safe: "foreign-callable: utf-8 result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-procedure: string argument not allowed with __collect_safe procedure".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
+foreign.mo:Expected error in mat collect-safe: "foreign-callable: string result not allowed with __collect_safe callable".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".
 ftype.mo:Expected error in mat ftype: "unexpected function ftype outside pointer field (function #f (int) int)".

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -60,14 +60,14 @@ Online versions of both books can be found at
 
 \subsection{Foreign-procedure thread activation (9.5.1)}
 
-A new \scheme{__thread} foreign-procedure convention, which can be
-combined with other conventions, causes a foreign-procedure call
-to deactive the current thread during the call. Similarly, the
-\scheme{__thread} convention modifier for callables causes the
-current thread to be activated on entry to the callable, and the
-activation state is reverted on exit from the callable; this
-activation makes callables work from threads that are otherwise
-unknown to the Scheme system.
+A new \scheme{__collect_safe} foreign-procedure convention, which can
+be combined with other conventions, causes a foreign-procedure call to
+deactive the current thread during the call so that other threads can
+perform a garbage collection. Similarly, the \scheme{__collect_safe}
+convention modifier for callables causes the current thread to be
+activated on entry to the callable, and the activation state is
+reverted on exit from the callable; this activation makes callables
+work from threads that are otherwise unknown to the Scheme system.
 
 \subsection{Foreign-procedure struct arguments and results (9.5.1)}
 

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -58,6 +58,17 @@ Online versions of both books can be found at
 %-----------------------------------------------------------------------------
 \section{Functionality Changes}\label{section:functionality}
 
+\subsection{Foreign-procedure thread activation (9.5.1)}
+
+A new \scheme{__thread} foreign-procedure convention, which can be
+combined with other conventions, causes a foreign-procedure call
+to deactive the current thread during the call. Similarly, the
+\scheme{__thread} convention modifier for callables causes the
+current thread to be activated on entry to the callable, and the
+activation state is reverted on exit from the callable; this
+activation makes callables work from threads that are otherwise
+unknown to the Scheme system.
+
 \subsection{Foreign-procedure struct arguments and results (9.5.1)}
 
 A new \scheme{(& \var{ftype})} form allows a struct or union to be

--- a/s/base-lang.ss
+++ b/s/base-lang.ss
@@ -155,7 +155,7 @@
 
   (define convention?
     (lambda (x)
-      (or (eq? x #f) (symbol? x))))
+      (and (list? x) (andmap symbol? x))))
 
   (define-record-type preinfo
     (nongenerative #{preinfo e23pkvo5btgapnzomqgegm-2})

--- a/s/base-lang.ss
+++ b/s/base-lang.ss
@@ -155,7 +155,7 @@
 
   (define convention?
     (lambda (x)
-      (and (list? x) (andmap symbol? x))))
+      (symbol? x)))
 
   (define-record-type preinfo
     (nongenerative #{preinfo e23pkvo5btgapnzomqgegm-2})
@@ -211,7 +211,7 @@
 
   ; source language used by the passes leading up to the compiler or interpreter
   (define-language Lsrc
-    (nongenerative-id #{Lsrc czsa1fcfzdeh493n-2})
+    (nongenerative-id #{Lsrc czsa1fcfzdeh493n-3})
     (terminals
       (preinfo (preinfo))
       ($prelex (x))
@@ -248,8 +248,8 @@
       (record-ref rtd type index e)
       (record-set! rtd type index e1 e2)
       (cte-optimization-loc box e)
-      (foreign conv name e (arg-type* ...) result-type)
-      (fcallable conv e (arg-type* ...) result-type)
+      (foreign (conv ...) name e (arg-type* ...) result-type)
+      (fcallable (conv ...) e (arg-type* ...) result-type)
       (profile src)                                         => (profile)
       ; used only in cpvalid
       (cpvalid-defer e))

--- a/s/base-lang.ss
+++ b/s/base-lang.ss
@@ -248,8 +248,8 @@
       (record-ref rtd type index e)
       (record-set! rtd type index e1 e2)
       (cte-optimization-loc box e)
-      (foreign (conv ...) name e (arg-type* ...) result-type)
-      (fcallable (conv ...) e (arg-type* ...) result-type)
+      (foreign (conv* ...) name e (arg-type* ...) result-type)
+      (fcallable (conv* ...) e (arg-type* ...) result-type)
       (profile src)                                         => (profile)
       ; used only in cpvalid
       (cpvalid-defer e))

--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -1387,6 +1387,10 @@
                  (cons (string->symbol (substring str 3 (- n 5))) params)
                  params))))))
 
+(define-constant unactivate-mode-noop       0)
+(define-constant unactivate-mode-deactivate 1)
+(define-constant unactivate-mode-destroy    2)
+
 (define-primitive-structure-disps rtd-counts type-typed-object
   ([iptr type]
    [U64 timestamp]
@@ -2624,6 +2628,9 @@
      split-and-resize
      raw-collect-cond
      raw-tc-mutex
+     activate-thread
+     deactivate-thread
+     unactivate-thread
      handle-values-error
      handle-mvlet-error
      handle-arg-error

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -949,13 +949,13 @@
               [(record-cd ,rcd ,rtd-expr ,e) (memoize (pure? e))]
               [(letrec ([,x* ,e*] ...) ,body) (memoize (and (andmap pure? e*) (pure? body)))]
               [(record-type ,rtd ,e) (memoize (pure? e))]
-              [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type) (memoize (pure? e))]
+              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (pure? e))]
               [(letrec* ([,x* ,e*] ...) ,body) (memoize (and (andmap pure? e*) (pure? body)))]
               [(immutable-list (,e* ...) ,e) (memoize (and (andmap pure? e*) (pure? e)))]
               [(profile ,src) #t]
               [(cte-optimization-loc ,box ,e) (memoize (pure? e))]
               [(moi) #t]
-              [(fcallable ,conv ,e (,arg-type* ...) ,result-type) (memoize (pure? e))]
+              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (memoize (pure? e))]
               [(pariah) #t]
               [else ($oops who "unrecognized record ~s" e)]))))
 
@@ -1008,13 +1008,13 @@
               [(record-cd ,rcd ,rtd-expr ,e) (memoize (ivory? e))]
               [(letrec ([,x* ,e*] ...) ,body) (memoize (and (andmap ivory? e*) (ivory? body)))]
               [(record-type ,rtd ,e) (memoize (ivory? e))]
-              [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type) (memoize (ivory? e))]
+              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (ivory? e))]
               [(letrec* ([,x* ,e*] ...) ,body) (memoize (and (andmap ivory? e*) (ivory? body)))]
               [(immutable-list (,e* ...) ,e) (memoize (and (andmap ivory? e*) (ivory? e)))]
               [(profile ,src) #t]
               [(cte-optimization-loc ,box ,e) (memoize (ivory? e))]
               [(moi) #t]
-              [(fcallable ,conv ,e (,arg-type* ...) ,result-type) (memoize (ivory? e))]
+              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (memoize (ivory? e))]
               [(pariah) #t]
               [else ($oops who "unrecognized record ~s" e)]))))
 
@@ -1052,14 +1052,14 @@
               [(record-cd ,rcd ,rtd-expr ,e) (memoize (simple? e))]
               [(record-ref ,rtd ,type ,index ,e) (memoize (simple? e))]
               [(record-set! ,rtd ,type ,index ,e1 ,e2) #f]
-              [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type) (memoize (simple? e))]
+              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (simple? e))]
               [(record-type ,rtd ,e) (memoize (simple? e))]
               [(record ,rtd ,rtd-expr ,e* ...) (memoize (and (simple? rtd-expr) (andmap simple? e*)))]
               [(pariah) #f]
               [(profile ,src) #f]
               [(cte-optimization-loc ,box ,e) (memoize (simple? e))]
               [(moi) #t]
-              [(fcallable ,conv ,e (,arg-type* ...) ,result-type) (memoize (simple? e))]
+              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (memoize (simple? e))]
               [else ($oops who "unrecognized record ~s" e)]))))
 
       (define-who simple/profile?
@@ -1097,14 +1097,14 @@
               [(record-cd ,rcd ,rtd-expr ,e) (memoize (simple/profile? e))]
               [(record-ref ,rtd ,type ,index ,e) (memoize (simple/profile? e))]
               [(record-set! ,rtd ,type ,index ,e1 ,e2) #f]
-              [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type) (memoize (simple/profile? e))]
+              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (simple/profile? e))]
               [(record-type ,rtd ,e) (memoize (simple/profile? e))]
               [(record ,rtd ,rtd-expr ,e* ...) (memoize (and (simple/profile? rtd-expr) (andmap simple/profile? e*)))]
               [(pariah) #t]
               [(profile ,src) #t]
               [(cte-optimization-loc ,box ,e) (memoize (simple/profile? e))]
               [(moi) #t]
-              [(fcallable ,conv ,e (,arg-type* ...) ,result-type) (memoize (simple/profile? e))]
+              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (memoize (simple/profile? e))]
               [else ($oops who "unrecognized record ~s" e)]))))
 
       (define-who boolean-valued?
@@ -1137,8 +1137,8 @@
               [(profile ,src) #f]
               [(set! ,maybe-src ,x ,e) #f]
               [(moi) #f]
-              [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type) #f]
-              [(fcallable ,conv ,e (,arg-type* ...) ,result-type) #f]
+              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) #f]
+              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) #f]
               [(pariah) #f]
               [else ($oops who "unrecognized record ~s" e)])))))
 
@@ -2058,8 +2058,8 @@
                              [(set! ,maybe-src ,x0 ,e0) (list e)]
                              [(case-lambda ,preinfo ,cl* ...) (list e)]
                              [,pr (list e)]
-                             [(foreign ,conv ,name ,e0 (,arg-type* ...) ,result-type) (list e)]
-                             [(fcallable ,conv ,e0 (,arg-type* ...) ,result-type) (list e)]
+                             [(foreign (,conv ...) ,name ,e0 (,arg-type* ...) ,result-type) (list e)]
+                             [(fcallable (,conv ...) ,e0 (,arg-type* ...) ,result-type) (list e)]
                              [(record-type ,rtd0 ,e0) (list e)]
                              [(record-cd ,rcd0 ,rtd-expr0 ,e0) (list e)]
                              [(immutable-list (,e0* ...) ,e0) (list e)]
@@ -3363,8 +3363,8 @@
             (nanopass-case (Lsrc Expr) xres
               [(case-lambda ,preinfo ,cl ...) #t]
               [,pr (all-set? (prim-mask proc) (primref-flags pr))]
-              [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type) #t]
-              [(fcallable ,conv ,e (,arg-type* ...) ,result-type) #t]
+              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) #t]
+              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) #t]
               [(record-set! ,rtd ,type ,index ,e1 ,e2) #t]
               [(immutable-list (,e* ...) ,e) #t]
               [else #f])))
@@ -4609,13 +4609,13 @@
                   true-rec
                   (begin (bump sc 1) pr))]
              [(app) (fold-primref pr ctxt sc wd name moi)])]
-      [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type)
+      [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type)
        (context-case ctxt
-         [(value app) (bump sc 1) `(foreign ,conv ,name ,(cp0 e 'value env sc wd #f moi) (,arg-type* ...) ,result-type)]
+         [(value app) (bump sc 1) `(foreign (,conv ...) ,name ,(cp0 e 'value env sc wd #f moi) (,arg-type* ...) ,result-type)]
          [(effect test) (cp0 `(seq ,e ,true-rec) ctxt env sc wd #f moi)])]
-      [(fcallable ,conv ,e (,arg-type* ...) ,result-type)
+      [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type)
        (context-case ctxt
-         [(value app) (bump sc 1) `(fcallable ,conv ,(cp0 e 'value env sc wd #f moi) (,arg-type* ...) ,result-type)]
+         [(value app) (bump sc 1) `(fcallable (,conv ...) ,(cp0 e 'value env sc wd #f moi) (,arg-type* ...) ,result-type)]
          [(effect) (cp0 e 'effect env sc wd #f moi)]
          [(test) (make-seq ctxt (cp0 e 'effect env sc wd #f moi) true-rec)])]
       [(record ,rtd ,rtd-expr ,e* ...)

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -949,13 +949,13 @@
               [(record-cd ,rcd ,rtd-expr ,e) (memoize (pure? e))]
               [(letrec ([,x* ,e*] ...) ,body) (memoize (and (andmap pure? e*) (pure? body)))]
               [(record-type ,rtd ,e) (memoize (pure? e))]
-              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (pure? e))]
+              [(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (pure? e))]
               [(letrec* ([,x* ,e*] ...) ,body) (memoize (and (andmap pure? e*) (pure? body)))]
               [(immutable-list (,e* ...) ,e) (memoize (and (andmap pure? e*) (pure? e)))]
               [(profile ,src) #t]
               [(cte-optimization-loc ,box ,e) (memoize (pure? e))]
               [(moi) #t]
-              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (memoize (pure? e))]
+              [(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type) (memoize (pure? e))]
               [(pariah) #t]
               [else ($oops who "unrecognized record ~s" e)]))))
 
@@ -1008,13 +1008,13 @@
               [(record-cd ,rcd ,rtd-expr ,e) (memoize (ivory? e))]
               [(letrec ([,x* ,e*] ...) ,body) (memoize (and (andmap ivory? e*) (ivory? body)))]
               [(record-type ,rtd ,e) (memoize (ivory? e))]
-              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (ivory? e))]
+              [(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (ivory? e))]
               [(letrec* ([,x* ,e*] ...) ,body) (memoize (and (andmap ivory? e*) (ivory? body)))]
               [(immutable-list (,e* ...) ,e) (memoize (and (andmap ivory? e*) (ivory? e)))]
               [(profile ,src) #t]
               [(cte-optimization-loc ,box ,e) (memoize (ivory? e))]
               [(moi) #t]
-              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (memoize (ivory? e))]
+              [(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type) (memoize (ivory? e))]
               [(pariah) #t]
               [else ($oops who "unrecognized record ~s" e)]))))
 
@@ -1052,14 +1052,14 @@
               [(record-cd ,rcd ,rtd-expr ,e) (memoize (simple? e))]
               [(record-ref ,rtd ,type ,index ,e) (memoize (simple? e))]
               [(record-set! ,rtd ,type ,index ,e1 ,e2) #f]
-              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (simple? e))]
+              [(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (simple? e))]
               [(record-type ,rtd ,e) (memoize (simple? e))]
               [(record ,rtd ,rtd-expr ,e* ...) (memoize (and (simple? rtd-expr) (andmap simple? e*)))]
               [(pariah) #f]
               [(profile ,src) #f]
               [(cte-optimization-loc ,box ,e) (memoize (simple? e))]
               [(moi) #t]
-              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (memoize (simple? e))]
+              [(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type) (memoize (simple? e))]
               [else ($oops who "unrecognized record ~s" e)]))))
 
       (define-who simple/profile?
@@ -1097,14 +1097,14 @@
               [(record-cd ,rcd ,rtd-expr ,e) (memoize (simple/profile? e))]
               [(record-ref ,rtd ,type ,index ,e) (memoize (simple/profile? e))]
               [(record-set! ,rtd ,type ,index ,e1 ,e2) #f]
-              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (simple/profile? e))]
+              [(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type) (memoize (simple/profile? e))]
               [(record-type ,rtd ,e) (memoize (simple/profile? e))]
               [(record ,rtd ,rtd-expr ,e* ...) (memoize (and (simple/profile? rtd-expr) (andmap simple/profile? e*)))]
               [(pariah) #t]
               [(profile ,src) #t]
               [(cte-optimization-loc ,box ,e) (memoize (simple/profile? e))]
               [(moi) #t]
-              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (memoize (simple/profile? e))]
+              [(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type) (memoize (simple/profile? e))]
               [else ($oops who "unrecognized record ~s" e)]))))
 
       (define-who boolean-valued?
@@ -1137,8 +1137,8 @@
               [(profile ,src) #f]
               [(set! ,maybe-src ,x ,e) #f]
               [(moi) #f]
-              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) #f]
-              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) #f]
+              [(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type) #f]
+              [(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type) #f]
               [(pariah) #f]
               [else ($oops who "unrecognized record ~s" e)])))))
 
@@ -2058,8 +2058,8 @@
                              [(set! ,maybe-src ,x0 ,e0) (list e)]
                              [(case-lambda ,preinfo ,cl* ...) (list e)]
                              [,pr (list e)]
-                             [(foreign (,conv ...) ,name ,e0 (,arg-type* ...) ,result-type) (list e)]
-                             [(fcallable (,conv ...) ,e0 (,arg-type* ...) ,result-type) (list e)]
+                             [(foreign (,conv* ...) ,name ,e0 (,arg-type* ...) ,result-type) (list e)]
+                             [(fcallable (,conv* ...) ,e0 (,arg-type* ...) ,result-type) (list e)]
                              [(record-type ,rtd0 ,e0) (list e)]
                              [(record-cd ,rcd0 ,rtd-expr0 ,e0) (list e)]
                              [(immutable-list (,e0* ...) ,e0) (list e)]
@@ -3363,8 +3363,8 @@
             (nanopass-case (Lsrc Expr) xres
               [(case-lambda ,preinfo ,cl ...) #t]
               [,pr (all-set? (prim-mask proc) (primref-flags pr))]
-              [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) #t]
-              [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) #t]
+              [(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type) #t]
+              [(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type) #t]
               [(record-set! ,rtd ,type ,index ,e1 ,e2) #t]
               [(immutable-list (,e* ...) ,e) #t]
               [else #f])))
@@ -4609,13 +4609,13 @@
                   true-rec
                   (begin (bump sc 1) pr))]
              [(app) (fold-primref pr ctxt sc wd name moi)])]
-      [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type)
+      [(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type)
        (context-case ctxt
-         [(value app) (bump sc 1) `(foreign (,conv ...) ,name ,(cp0 e 'value env sc wd #f moi) (,arg-type* ...) ,result-type)]
+         [(value app) (bump sc 1) `(foreign (,conv* ...) ,name ,(cp0 e 'value env sc wd #f moi) (,arg-type* ...) ,result-type)]
          [(effect test) (cp0 `(seq ,e ,true-rec) ctxt env sc wd #f moi)])]
-      [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type)
+      [(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type)
        (context-case ctxt
-         [(value app) (bump sc 1) `(fcallable (,conv ...) ,(cp0 e 'value env sc wd #f moi) (,arg-type* ...) ,result-type)]
+         [(value app) (bump sc 1) `(fcallable (,conv* ...) ,(cp0 e 'value env sc wd #f moi) (,arg-type* ...) ,result-type)]
          [(effect) (cp0 e 'effect env sc wd #f moi)]
          [(test) (make-seq ctxt (cp0 e 'effect env sc wd #f moi) true-rec)])]
       [(record ,rtd ,rtd-expr ,e* ...)

--- a/s/cpcheck.ss
+++ b/s/cpcheck.ss
@@ -130,11 +130,11 @@
       [(set! ,maybe-src ,x ,[e #f -> e]) `(set! ,maybe-src ,x ,e)]
       [(seq ,[e1 #f -> e1] ,[e2]) `(seq ,e1 ,e2)]
       [(if ,[e1 #f -> e1] ,[e2 #f -> e2] ,[e3 #f -> e3]) `(if ,e1 ,e2 ,e3)]
-      [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type)
+      [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type)
        (check! ctxt (list (length arg-type*)))
-       `(foreign ,conv ,name ,(Expr e #f) (,arg-type* ...) ,result-type)]
-      [(fcallable ,conv ,[e #f -> e] (,arg-type* ...) ,result-type)
-        `(fcallable ,conv ,e (,arg-type* ...) ,result-type)]
+       `(foreign (,conv ...) ,name ,(Expr e #f) (,arg-type* ...) ,result-type)]
+      [(fcallable (,conv ...) ,[e #f -> e] (,arg-type* ...) ,result-type)
+        `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type)]
       [(call ,preinfo0
          (case-lambda ,preinfo1
            (clause (,x* ...) ,interface ,body)

--- a/s/cpcheck.ss
+++ b/s/cpcheck.ss
@@ -130,11 +130,11 @@
       [(set! ,maybe-src ,x ,[e #f -> e]) `(set! ,maybe-src ,x ,e)]
       [(seq ,[e1 #f -> e1] ,[e2]) `(seq ,e1 ,e2)]
       [(if ,[e1 #f -> e1] ,[e2 #f -> e2] ,[e3 #f -> e3]) `(if ,e1 ,e2 ,e3)]
-      [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type)
+      [(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type)
        (check! ctxt (list (length arg-type*)))
-       `(foreign (,conv ...) ,name ,(Expr e #f) (,arg-type* ...) ,result-type)]
-      [(fcallable (,conv ...) ,[e #f -> e] (,arg-type* ...) ,result-type)
-        `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type)]
+       `(foreign (,conv* ...) ,name ,(Expr e #f) (,arg-type* ...) ,result-type)]
+      [(fcallable (,conv* ...) ,[e #f -> e] (,arg-type* ...) ,result-type)
+        `(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type)]
       [(call ,preinfo0
          (case-lambda ,preinfo1
            (clause (,x* ...) ,interface ,body)

--- a/s/cpcommonize.ss
+++ b/s/cpcommonize.ss
@@ -73,10 +73,10 @@
          (values `(seq ,e1 ,e2) (fx+ size1 size2))]
         [(if ,[e1 size1] ,[e2 size2] ,[e3 size3])
          (values `(if ,e1 ,e2 ,e3) (fx+ size1 size2 size3))]
-        [(foreign ,conv ,name ,[e size] (,arg-type* ...) ,result-type)
-         (values `(foreign ,conv ,name ,e (,arg-type* ...) ,result-type) (fx+ 1 size))]
-        [(fcallable ,conv ,[e size] (,arg-type* ...) ,result-type)
-         (values `(fcallable ,conv ,e (,arg-type* ...) ,result-type) (fx+ 1 size))]
+        [(foreign (,conv ...) ,name ,[e size] (,arg-type* ...) ,result-type)
+         (values `(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (fx+ 1 size))]
+        [(fcallable (,conv ...) ,[e size] (,arg-type* ...) ,result-type)
+         (values `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (fx+ 1 size))]
         ; ($top-level-value 'x) adds just 1 to the size
         [(call ,preinfo ,pr (quote ,d))
          (guard (eq? (primref-name pr) '$top-level-value))
@@ -379,24 +379,24 @@
                                                        (with-env x1* x2*
                                                          `(letrec ([,x1* ,(map f e1* e2*) ,size1*] ...) ,(f body1 body2))))]
                                                  [else #f])]
-                                              [(foreign ,conv1 ,name1 ,e1 (,arg-type1* ...) ,result-type1)
+                                              [(foreign (,conv1 ...) ,name1 ,e1 (,arg-type1* ...) ,result-type1)
                                                (nanopass-case (Lcommonize1 Expr) e2
-                                                 [(foreign ,conv2 ,name2 ,e2 (,arg-type2* ...) ,result-type2)
-                                                  (and (eq? conv1 conv2)
+                                                 [(foreign (,conv2 ...) ,name2 ,e2 (,arg-type2* ...) ,result-type2)
+                                                  (and (equal? conv1 conv2)
                                                        (equal? name1 name2)
                                                        (fx= (length arg-type1*) (length arg-type2*))
                                                        (andmap same-type? arg-type1* arg-type2*)
                                                        (same-type? result-type1 result-type2)
-                                                       `(foreign ,conv1 ,name1 ,(f e1 e2) (,arg-type1* ...) ,result-type1))]
+                                                       `(foreign (,conv1 ...) ,name1 ,(f e1 e2) (,arg-type1* ...) ,result-type1))]
                                                  [else #f])]
-                                              [(fcallable ,conv1 ,e1 (,arg-type1* ...) ,result-type1)
+                                              [(fcallable (,conv1 ...) ,e1 (,arg-type1* ...) ,result-type1)
                                                (nanopass-case (Lcommonize1 Expr) e2
-                                                 [(fcallable ,conv2 ,e2 (,arg-type2* ...) ,result-type2)
-                                                  (and (eq? conv1 conv2)
+                                                 [(fcallable (,conv2 ...) ,e2 (,arg-type2* ...) ,result-type2)
+                                                  (and (equal? conv1 conv2)
                                                        (fx= (length arg-type1*) (length arg-type2*))
                                                        (andmap same-type? arg-type1* arg-type2*)
                                                        (same-type? result-type1 result-type2)
-                                                       `(fcallable ,conv1 ,(f e1 e2) (,arg-type1* ...) ,result-type1))]
+                                                       `(fcallable (,conv1 ...) ,(f e1 e2) (,arg-type1* ...) ,result-type1))]
                                                  [else #f])]
                                               [(cte-optimization-loc ,box1 ,e1)
                                                (nanopass-case (Lcommonize1 Expr) e2

--- a/s/cpcommonize.ss
+++ b/s/cpcommonize.ss
@@ -73,10 +73,10 @@
          (values `(seq ,e1 ,e2) (fx+ size1 size2))]
         [(if ,[e1 size1] ,[e2 size2] ,[e3 size3])
          (values `(if ,e1 ,e2 ,e3) (fx+ size1 size2 size3))]
-        [(foreign (,conv ...) ,name ,[e size] (,arg-type* ...) ,result-type)
-         (values `(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type) (fx+ 1 size))]
-        [(fcallable (,conv ...) ,[e size] (,arg-type* ...) ,result-type)
-         (values `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type) (fx+ 1 size))]
+        [(foreign (,conv* ...) ,name ,[e size] (,arg-type* ...) ,result-type)
+         (values `(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type) (fx+ 1 size))]
+        [(fcallable (,conv* ...) ,[e size] (,arg-type* ...) ,result-type)
+         (values `(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type) (fx+ 1 size))]
         ; ($top-level-value 'x) adds just 1 to the size
         [(call ,preinfo ,pr (quote ,d))
          (guard (eq? (primref-name pr) '$top-level-value))
@@ -379,24 +379,24 @@
                                                        (with-env x1* x2*
                                                          `(letrec ([,x1* ,(map f e1* e2*) ,size1*] ...) ,(f body1 body2))))]
                                                  [else #f])]
-                                              [(foreign (,conv1 ...) ,name1 ,e1 (,arg-type1* ...) ,result-type1)
+                                              [(foreign (,conv1* ...) ,name1 ,e1 (,arg-type1* ...) ,result-type1)
                                                (nanopass-case (Lcommonize1 Expr) e2
-                                                 [(foreign (,conv2 ...) ,name2 ,e2 (,arg-type2* ...) ,result-type2)
-                                                  (and (equal? conv1 conv2)
+                                                 [(foreign (,conv2* ...) ,name2 ,e2 (,arg-type2* ...) ,result-type2)
+                                                  (and (equal? conv1* conv2*)
                                                        (equal? name1 name2)
                                                        (fx= (length arg-type1*) (length arg-type2*))
                                                        (andmap same-type? arg-type1* arg-type2*)
                                                        (same-type? result-type1 result-type2)
-                                                       `(foreign (,conv1 ...) ,name1 ,(f e1 e2) (,arg-type1* ...) ,result-type1))]
+                                                       `(foreign (,conv1* ...) ,name1 ,(f e1 e2) (,arg-type1* ...) ,result-type1))]
                                                  [else #f])]
-                                              [(fcallable (,conv1 ...) ,e1 (,arg-type1* ...) ,result-type1)
+                                              [(fcallable (,conv1* ...) ,e1 (,arg-type1* ...) ,result-type1)
                                                (nanopass-case (Lcommonize1 Expr) e2
-                                                 [(fcallable (,conv2 ...) ,e2 (,arg-type2* ...) ,result-type2)
-                                                  (and (equal? conv1 conv2)
+                                                 [(fcallable (,conv2* ...) ,e2 (,arg-type2* ...) ,result-type2)
+                                                  (and (equal? conv1* conv2*)
                                                        (fx= (length arg-type1*) (length arg-type2*))
                                                        (andmap same-type? arg-type1* arg-type2*)
                                                        (same-type? result-type1 result-type2)
-                                                       `(fcallable (,conv1 ...) ,(f e1 e2) (,arg-type1* ...) ,result-type1))]
+                                                       `(fcallable (,conv1* ...) ,(f e1 e2) (,arg-type1* ...) ,result-type1))]
                                                  [else #f])]
                                               [(cte-optimization-loc ,box1 ,e1)
                                                (nanopass-case (Lcommonize1 Expr) e2

--- a/s/cpletrec.ss
+++ b/s/cpletrec.ss
@@ -348,11 +348,11 @@ Handling letrec and letrec*
        (with-initialized-ids x*
          (lambda (x*)
            (cpletrec-letrec #t x* e* body)))]
-      [(foreign ,conv ,name ,[e pure?] (,arg-type* ...) ,result-type)
-       (values `(foreign ,conv ,name ,e (,arg-type* ...) ,result-type)
+      [(foreign (,conv ...) ,name ,[e pure?] (,arg-type* ...) ,result-type)
+       (values `(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type)
          (and (fx= (optimize-level) 3) pure?))]
-      [(fcallable ,conv ,[e pure?] (,arg-type* ...) ,result-type)
-       (values `(fcallable ,conv ,e (,arg-type* ...) ,result-type)
+      [(fcallable (,conv ...) ,[e pure?] (,arg-type* ...) ,result-type)
+       (values `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type)
          (and (fx= (optimize-level) 3) pure?))]
       [(record-ref ,rtd ,type ,index ,[e pure?])
        (values `(record-ref ,rtd ,type ,index ,e) #f)]

--- a/s/cpletrec.ss
+++ b/s/cpletrec.ss
@@ -348,11 +348,11 @@ Handling letrec and letrec*
        (with-initialized-ids x*
          (lambda (x*)
            (cpletrec-letrec #t x* e* body)))]
-      [(foreign (,conv ...) ,name ,[e pure?] (,arg-type* ...) ,result-type)
-       (values `(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type)
+      [(foreign (,conv* ...) ,name ,[e pure?] (,arg-type* ...) ,result-type)
+       (values `(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type)
          (and (fx= (optimize-level) 3) pure?))]
-      [(fcallable (,conv ...) ,[e pure?] (,arg-type* ...) ,result-type)
-       (values `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type)
+      [(fcallable (,conv* ...) ,[e pure?] (,arg-type* ...) ,result-type)
+       (values `(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type)
          (and (fx= (optimize-level) 3) pure?))]
       [(record-ref ,rtd ,type ,index ,[e pure?])
        (values `(record-ref ,rtd ,type ,index ,e) #f)]

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -1045,11 +1045,11 @@
         [(call ,preinfo ,e ,[e*] ...)
          `(call ,(make-info-call (preinfo-src preinfo) (preinfo-sexpr preinfo) (fx< (optimize-level) 3) #f #f)
             ,(Expr e) ,e* ...)]
-        [(foreign ,conv ,name ,[e] (,arg-type* ...) ,result-type)
+        [(foreign (,conv ...) ,name ,[e] (,arg-type* ...) ,result-type)
          (let ([info (make-info-foreign conv arg-type* result-type)])
            (info-foreign-name-set! info name)
            `(foreign ,info ,e))]
-        [(fcallable ,conv ,[e] (,arg-type* ...) ,result-type)
+        [(fcallable (,conv ...) ,[e] (,arg-type* ...) ,result-type)
          `(fcallable ,(make-info-foreign conv arg-type* result-type) ,e)])
       (CaseLambdaExpr ir #f))
 

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -940,11 +940,11 @@
     (define-record-type info-foreign (nongenerative)
       (parent info)
       (sealed #t)
-      (fields conv arg-type* result-type (mutable name))
+      (fields conv* arg-type* result-type (mutable name))
       (protocol
         (lambda (pargs->new)
-          (lambda (conv arg-type* result-type)
-            ((pargs->new) conv arg-type* result-type #f)))))
+          (lambda (conv* arg-type* result-type)
+            ((pargs->new) conv* arg-type* result-type #f)))))
 
     (define-record-type info-literal (nongenerative)
       (parent info)
@@ -1045,12 +1045,12 @@
         [(call ,preinfo ,e ,[e*] ...)
          `(call ,(make-info-call (preinfo-src preinfo) (preinfo-sexpr preinfo) (fx< (optimize-level) 3) #f #f)
             ,(Expr e) ,e* ...)]
-        [(foreign (,conv ...) ,name ,[e] (,arg-type* ...) ,result-type)
-         (let ([info (make-info-foreign conv arg-type* result-type)])
+        [(foreign (,conv* ...) ,name ,[e] (,arg-type* ...) ,result-type)
+         (let ([info (make-info-foreign conv* arg-type* result-type)])
            (info-foreign-name-set! info name)
            `(foreign ,info ,e))]
-        [(fcallable (,conv ...) ,[e] (,arg-type* ...) ,result-type)
-         `(fcallable ,(make-info-foreign conv arg-type* result-type) ,e)])
+        [(fcallable (,conv* ...) ,[e] (,arg-type* ...) ,result-type)
+         `(fcallable ,(make-info-foreign conv* arg-type* result-type) ,e)])
       (CaseLambdaExpr ir #f))
 
     (define find-matching-clause

--- a/s/cprep.ss
+++ b/s/cprep.ss
@@ -187,11 +187,11 @@
                [(letrec* ([,x* ,[e*]] ...) ,body)
                 `(letrec* ,(map (lambda (x e) `(,(get-name x) ,e)) x* e*)
                    ,@(uncprep-sequence body '()))]
-               [(foreign ,conv ,name ,[e] (,arg-type* ...) ,result-type)
+               [(foreign (,conv ...) ,name ,[e] (,arg-type* ...) ,result-type)
                 `($foreign-procedure ,(uncprep-fp-conv conv) ,name ,e
                    ,(map uncprep-fp-specifier arg-type*)
                    ,(uncprep-fp-specifier result-type))]
-               [(fcallable ,conv ,[e] (,arg-type* ...) ,result-type)
+               [(fcallable (,conv ...) ,[e] (,arg-type* ...) ,result-type)
                 `($foreign-callable ,(uncprep-fp-conv conv) ,e
                    ,(map uncprep-fp-specifier arg-type*)
                    ,(uncprep-fp-specifier result-type))]

--- a/s/cprep.ss
+++ b/s/cprep.ss
@@ -85,11 +85,14 @@
                   (uncprep-sequence e2 ls))]
                [else (cons (uncprep x) ls)])))
          (define uncprep-fp-conv
-           (lambda (x)
-             (case x
-               [(i3nt-stdcall) '__stdcall]
-               [(i3nt-com) '__com]
-               [else #f])))
+           (lambda (x*)
+             (map (lambda (x)
+                    (case x
+                      [(i3nt-stdcall) '__stdcall]
+                      [(i3nt-com) '__com]
+                      [(adjust-active) '__thread]
+                      [else #f]))
+                  x*)))
          (define-who uncprep-fp-specifier
            (lambda (x)
              (nanopass-case (Ltype Type) x

--- a/s/cprep.ss
+++ b/s/cprep.ss
@@ -90,7 +90,7 @@
                     (case x
                       [(i3nt-stdcall) '__stdcall]
                       [(i3nt-com) '__com]
-                      [(adjust-active) '__thread]
+                      [(adjust-active) '__collect_safe]
                       [else #f]))
                   x*)))
          (define-who uncprep-fp-specifier

--- a/s/cprep.ss
+++ b/s/cprep.ss
@@ -187,12 +187,12 @@
                [(letrec* ([,x* ,[e*]] ...) ,body)
                 `(letrec* ,(map (lambda (x e) `(,(get-name x) ,e)) x* e*)
                    ,@(uncprep-sequence body '()))]
-               [(foreign (,conv ...) ,name ,[e] (,arg-type* ...) ,result-type)
-                `($foreign-procedure ,(uncprep-fp-conv conv) ,name ,e
+               [(foreign (,conv* ...) ,name ,[e] (,arg-type* ...) ,result-type)
+                `($foreign-procedure ,(uncprep-fp-conv conv*) ,name ,e
                    ,(map uncprep-fp-specifier arg-type*)
                    ,(uncprep-fp-specifier result-type))]
-               [(fcallable (,conv ...) ,[e] (,arg-type* ...) ,result-type)
-                `($foreign-callable ,(uncprep-fp-conv conv) ,e
+               [(fcallable (,conv* ...) ,[e] (,arg-type* ...) ,result-type)
+                `($foreign-callable ,(uncprep-fp-conv conv*) ,e
                    ,(map uncprep-fp-specifier arg-type*)
                    ,(uncprep-fp-specifier result-type))]
                [(record-ref ,rtd ,type ,index ,[e]) `(record-ref ,rtd ',type ,e ,index)]

--- a/s/cpvalid.ss
+++ b/s/cpvalid.ss
@@ -328,10 +328,10 @@
        (let-values ([(e* vals-dl?) (undefer* e* proxy dl?)])
          (defer-or-not (or body-dl? vals-dl?)
            `(letrec* ([,x* ,e*] ...) ,body)))]
-      [(foreign ,conv ,name ,[undefer : e dl?] (,arg-type* ...) ,result-type)
-       (defer-or-not dl? `(foreign ,conv ,name ,e (,arg-type* ...) ,result-type))]
-      [(fcallable ,conv ,[undefer : e dl?] (,arg-type* ...) ,result-type)
-       (defer-or-not dl? `(fcallable ,conv ,e (,arg-type* ...) ,result-type))]
+      [(foreign (,conv ...) ,name ,[undefer : e dl?] (,arg-type* ...) ,result-type)
+       (defer-or-not dl? `(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type))]
+      [(fcallable (,conv ...) ,[undefer : e dl?] (,arg-type* ...) ,result-type)
+       (defer-or-not dl? `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type))]
       [(cte-optimization-loc ,box ,[undefer : e dl?])
        (defer-or-not dl? `(cte-optimization-loc ,box ,e))]
       [(pariah) (values x #f)]
@@ -547,10 +547,10 @@
        (defer-or-not (or dl0? dl1? dl2?) `(if ,e0 ,e1 ,e2))]
       [(seq ,[cpvalid : e1 dl1?] ,[cpvalid : e2 dl2?])
        (defer-or-not (or dl1? dl2?) `(seq ,e1 ,e2))]
-      [(foreign ,conv ,name ,[cpvalid : e dl?] (,arg-type* ...) ,result-type)
-       (defer-or-not dl? `(foreign ,conv ,name ,e (,arg-type* ...) ,result-type))]
-      [(fcallable ,conv ,[cpvalid : e dl?] (,arg-type* ...) ,result-type)
-       (defer-or-not dl? `(fcallable ,conv ,e (,arg-type* ...) ,result-type))]
+      [(foreign (,conv ...) ,name ,[cpvalid : e dl?] (,arg-type* ...) ,result-type)
+       (defer-or-not dl? `(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type))]
+      [(fcallable (,conv ...) ,[cpvalid : e dl?] (,arg-type* ...) ,result-type)
+       (defer-or-not dl? `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type))]
       [(cte-optimization-loc ,box ,[cpvalid : e dl?])
        (defer-or-not dl? `(cte-optimization-loc ,box ,e))]
       [(pariah) (values x #f)]

--- a/s/cpvalid.ss
+++ b/s/cpvalid.ss
@@ -328,10 +328,10 @@
        (let-values ([(e* vals-dl?) (undefer* e* proxy dl?)])
          (defer-or-not (or body-dl? vals-dl?)
            `(letrec* ([,x* ,e*] ...) ,body)))]
-      [(foreign (,conv ...) ,name ,[undefer : e dl?] (,arg-type* ...) ,result-type)
-       (defer-or-not dl? `(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type))]
-      [(fcallable (,conv ...) ,[undefer : e dl?] (,arg-type* ...) ,result-type)
-       (defer-or-not dl? `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type))]
+      [(foreign (,conv* ...) ,name ,[undefer : e dl?] (,arg-type* ...) ,result-type)
+       (defer-or-not dl? `(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type))]
+      [(fcallable (,conv* ...) ,[undefer : e dl?] (,arg-type* ...) ,result-type)
+       (defer-or-not dl? `(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type))]
       [(cte-optimization-loc ,box ,[undefer : e dl?])
        (defer-or-not dl? `(cte-optimization-loc ,box ,e))]
       [(pariah) (values x #f)]
@@ -547,10 +547,10 @@
        (defer-or-not (or dl0? dl1? dl2?) `(if ,e0 ,e1 ,e2))]
       [(seq ,[cpvalid : e1 dl1?] ,[cpvalid : e2 dl2?])
        (defer-or-not (or dl1? dl2?) `(seq ,e1 ,e2))]
-      [(foreign (,conv ...) ,name ,[cpvalid : e dl?] (,arg-type* ...) ,result-type)
-       (defer-or-not dl? `(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type))]
-      [(fcallable (,conv ...) ,[cpvalid : e dl?] (,arg-type* ...) ,result-type)
-       (defer-or-not dl? `(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type))]
+      [(foreign (,conv* ...) ,name ,[cpvalid : e dl?] (,arg-type* ...) ,result-type)
+       (defer-or-not dl? `(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type))]
+      [(fcallable (,conv* ...) ,[cpvalid : e dl?] (,arg-type* ...) ,result-type)
+       (defer-or-not dl? `(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type))]
       [(cte-optimization-loc ,box ,[cpvalid : e dl?])
        (defer-or-not dl? `(cte-optimization-loc ,box ,e))]
       [(pariah) (values x #f)]

--- a/s/ftype.ss
+++ b/s/ftype.ss
@@ -527,7 +527,7 @@ ftype operators:
                    [(function-kwd (arg-type ...) result-type)
                     (eq? (datum function-kwd) 'function)
                     (f #'(function-kwd #f (arg-type ...) result-type) #f stype funok?)]
-                   [(function-kwd conv (arg-type ...) result-type)
+                   [(function-kwd conv ... (arg-type ...) result-type)
                     (eq? (datum function-kwd) 'function)
                     (let ()
                       (define filter-type
@@ -539,7 +539,7 @@ ftype operators:
                       (make-ftd-function rtd/fptr
                         (and defid (symbol->string (syntax->datum defid)))
                         stype #f #f
-                        ($filter-conv 'function-ftype #'conv)
+                        ($filter-conv 'function-ftype #'(conv ...))
                         (map (lambda (x) (filter-type r x #f)) #'(arg-type ...))
                         (filter-type r #'result-type #t)))]
                    [(packed-kwd ftype)

--- a/s/ftype.ss
+++ b/s/ftype.ss
@@ -1197,7 +1197,7 @@ ftype operators:
                                       [(ftd-base? ftd) (do-base (filter-foreign-type (ftd-base-type ftd)) (ftd-base-swap? ftd) offset)]
                                       [(ftd-pointer? ftd) #`(#3%$fptr-fptr-ref #,fptr-expr #,offset '#,(ftd-pointer-ftd ftd))]
                                       [(ftd-function? ftd) 
-                                       ($make-foreign-procedure
+                                       ($make-foreign-procedure 'make-ftype-pointer
                                          (ftd-function-conv ftd)
                                          #f
                                          #`($fptr-offset-addr #,fptr-expr offset)

--- a/s/ftype.ss
+++ b/s/ftype.ss
@@ -56,7 +56,7 @@ ftype ->
   (array length ftype)
   (bits (field-name signedness bits) ...)
   (function (arg-type ...) result-type)
-  (function conv (arg-type ...) result-type)
+  (function conv ... (arg-type ...) result-type)
   (packed ftype)
   (unpacked ftype)
   (endian endianness ftype)
@@ -322,7 +322,7 @@ ftype operators:
   (define-ftd-record-type array #{rtd/ftd-array a9pth58056u34h517jsrqv-5} length ftd)
   (define-ftd-record-type pointer #{rtd/ftd-pointer a9pth58056u34h517jsrqv-6} (mutable ftd))
   (define-ftd-record-type bits #{rtd/ftd-ibits a9pth58056u34h517jsrqv-9} swap? field*)
-  (define-ftd-record-type function #{rtd/ftd-function a9pth58056u34h517jsrqv-10} conv arg-type* result-type)
+  (define-ftd-record-type function #{rtd/ftd-function a9pth58056u34h517jsrqv-11} conv* arg-type* result-type)
   (module (pointer-size alignment pointer-alignment native-base-ftds swap-base-ftds)
     (define alignment
       (lambda (max-alignment size)
@@ -729,7 +729,7 @@ ftype operators:
                                       ;; (foreign-callable-entry-point code-object)
                                       [(procedure? x)
                                        (let ([co #,($make-foreign-callable 'make-ftype-pointer
-                                                     (ftd-function-conv ftd)
+                                                     (ftd-function-conv* ftd)
                                                      #'x
                                                      (map indirect-ftd-pointer (ftd-function-arg-type* ftd))
                                                      (indirect-ftd-pointer (ftd-function-result-type ftd)))])
@@ -1198,7 +1198,7 @@ ftype operators:
                                       [(ftd-pointer? ftd) #`(#3%$fptr-fptr-ref #,fptr-expr #,offset '#,(ftd-pointer-ftd ftd))]
                                       [(ftd-function? ftd) 
                                        ($make-foreign-procedure 'make-ftype-pointer
-                                         (ftd-function-conv ftd)
+                                         (ftd-function-conv* ftd)
                                          #f
                                          #`($fptr-offset-addr #,fptr-expr offset)
                                          (map indirect-ftd-pointer (ftd-function-arg-type* ftd))

--- a/s/interpret.ss
+++ b/s/interpret.ss
@@ -459,7 +459,7 @@
       [(seq ,e1 ,e2)
        (let ((e1 (ip2 e1)) (e2 (ip2 e2)))
          ($rt lambda () ($rt e1) ($rt e2)))]
-      [(foreign ,conv ,name ,e (,arg-type* ...) ,result-type)
+      [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type)
        (unless $compiler-is-loaded?
          ($oops 'interpret "cannot compile foreign-procedure: compiler is not loaded"))
        (let ([p ($compile-backend
@@ -468,11 +468,11 @@
                     (with-output-language (Lsrc Expr)
                       `(case-lambda ,(make-preinfo-lambda)
                          (clause (,t) 1
-                           (foreign ,conv ,name (ref #f ,t)
+                           (foreign (,conv ...) ,name (ref #f ,t)
                              (,arg-type* ...) ,result-type))))))])
          (let ([e (ip2 e)])
            ($rt lambda () ((p) ($rt e)))))]
-      [(fcallable ,conv ,e (,arg-type* ...) ,result-type)
+      [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type)
        (unless $compiler-is-loaded?
          ($oops 'interpret "cannot compile foreign-callable: compiler is not loaded"))
        (let ([p ($compile-backend
@@ -481,7 +481,7 @@
                     (with-output-language (Lsrc Expr)
                       `(case-lambda ,(make-preinfo-lambda)
                          (clause (,t) 1
-                           (fcallable ,conv (ref #f ,t) (,arg-type* ...) ,result-type))))))])
+                           (fcallable (,conv ...) (ref #f ,t) (,arg-type* ...) ,result-type))))))])
          (let ([e (ip2 e)])
            ($rt lambda () ((p) ($rt e)))))]
       [else (unexpected-record x)])))

--- a/s/interpret.ss
+++ b/s/interpret.ss
@@ -459,7 +459,7 @@
       [(seq ,e1 ,e2)
        (let ((e1 (ip2 e1)) (e2 (ip2 e2)))
          ($rt lambda () ($rt e1) ($rt e2)))]
-      [(foreign (,conv ...) ,name ,e (,arg-type* ...) ,result-type)
+      [(foreign (,conv* ...) ,name ,e (,arg-type* ...) ,result-type)
        (unless $compiler-is-loaded?
          ($oops 'interpret "cannot compile foreign-procedure: compiler is not loaded"))
        (let ([p ($compile-backend
@@ -468,11 +468,11 @@
                     (with-output-language (Lsrc Expr)
                       `(case-lambda ,(make-preinfo-lambda)
                          (clause (,t) 1
-                           (foreign (,conv ...) ,name (ref #f ,t)
+                           (foreign (,conv* ...) ,name (ref #f ,t)
                              (,arg-type* ...) ,result-type))))))])
          (let ([e (ip2 e)])
            ($rt lambda () ((p) ($rt e)))))]
-      [(fcallable (,conv ...) ,e (,arg-type* ...) ,result-type)
+      [(fcallable (,conv* ...) ,e (,arg-type* ...) ,result-type)
        (unless $compiler-is-loaded?
          ($oops 'interpret "cannot compile foreign-callable: compiler is not loaded"))
        (let ([p ($compile-backend
@@ -481,7 +481,7 @@
                     (with-output-language (Lsrc Expr)
                       `(case-lambda ,(make-preinfo-lambda)
                          (clause (,t) 1
-                           (fcallable (,conv ...) (ref #f ,t) (,arg-type* ...) ,result-type))))))])
+                           (fcallable (,conv* ...) (ref #f ,t) (,arg-type* ...) ,result-type))))))])
          (let ([e (ip2 e)])
            ($rt lambda () ((p) ($rt e)))))]
       [else (unexpected-record x)])))

--- a/s/np-languages.ss
+++ b/s/np-languages.ss
@@ -78,9 +78,9 @@
   (import (nanopass))
   (include "base-lang.ss")
 
- ; convention is a symbol or #f (we're assuming the front end already verified
- ; the convention is a valid one for this machine-type
-  (define convention? (lambda (x) (or (symbol? x) (eq? #f x))))
+ ; convention is a list of symbols (we're assuming the front end already verified
+ ; the convention is a valid one for this machine-type)
+  (define convention? (lambda (x) (and (list? x) (andmap symbol? x))))
 
  ; r6rs says a quote subform should be a datum, not must be a datum
  ; chez scheme allows a quote subform to be any value
@@ -489,6 +489,7 @@
   (declare-primitive c-call effect #f)
   (declare-primitive c-simple-call effect #f)
   (declare-primitive c-simple-return effect #f)
+  (declare-primitive deactivate-thread effect #f) ; threaded version only
   (declare-primitive fl* effect #f)
   (declare-primitive fl+ effect #f)
   (declare-primitive fl- effect #f)
@@ -521,6 +522,7 @@
   (declare-primitive store-single effect #f)
   (declare-primitive store-single->double effect #f)
   (declare-primitive store-with-update effect #f) ; ppc
+  (declare-primitive unactivate-thread effect #f) ; threaded version only
   (declare-primitive vpush-multiple effect #f) ; arm
 
   (declare-primitive < pred #t)
@@ -550,6 +552,7 @@
   (declare-primitive fstps value #f) ; x86 only
   (declare-primitive get-double value #t) ; x86_64
   (declare-primitive get-tc value #f) ; threaded version only
+  (declare-primitive activate-thread value #f) ; threaded version only
   (declare-primitive lea1 value #t)
   (declare-primitive lea2 value #t)
   (declare-primitive load value #t)

--- a/s/np-languages.ss
+++ b/s/np-languages.ss
@@ -78,10 +78,6 @@
   (import (nanopass))
   (include "base-lang.ss")
 
- ; convention is a list of symbols (we're assuming the front end already verified
- ; the convention is a valid one for this machine-type)
-  (define convention? (lambda (x) (and (list? x) (andmap symbol? x))))
-
  ; r6rs says a quote subform should be a datum, not must be a datum
  ; chez scheme allows a quote subform to be any value
   (define datum? (lambda (x) #t))

--- a/s/ppc32.ss
+++ b/s/ppc32.ss
@@ -2461,7 +2461,7 @@
           (let* ([arg-type* (info-foreign-arg-type* info)]
 		 [result-type (info-foreign-result-type info)]
 		 [fill-result-here? (indirect-result-that-fits-in-registers? result-type)]
-		 [adjust-active? (memq 'adjust-active (info-foreign-conv info))])
+		 [adjust-active? (if-feature pthreads (memq 'adjust-active (info-foreign-conv* info)) #f)])
             (with-values (do-args (if fill-result-here? (cdr arg-type*) arg-type*))
               (lambda (orig-frame-size locs live* fp-live-count)
                 ;; NB: add 4 to frame size for CR save word
@@ -3016,7 +3016,7 @@
                                                float-reg-offset
                                                (fx+ (fx* fp-reg-count 8) float-reg-offset))]
 		       [synthesize-first-argument? (indirect-result-that-fits-in-registers? result-type)]
-		       [adjust-active? (memq 'adjust-active (info-foreign-conv info))]
+		       [adjust-active? (if-feature pthreads (memq 'adjust-active (info-foreign-conv* info)) #f)]
                        [unactivate-mode-offset (fx+ (fx* isaved 4) callee-save-offset)]
                        [return-space-offset (align 8 (fx+ unactivate-mode-offset (if adjust-active? 4 0)))]
                        [stack-size (align 16 (fx+ return-space-offset (if synthesize-first-argument? 8 0)))]

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -689,14 +689,14 @@
   (define build-foreign-procedure
     (lambda (ae conv foreign-name foreign-addr params result)
       (build-profile ae
-        `(foreign ,conv ,foreign-name ,foreign-addr
+        `(foreign (,conv ...) ,foreign-name ,foreign-addr
            (,(map (lambda (x) (build-fp-specifier 'foreign-procedure 'parameter x #f)) params) ...)
            ,(build-fp-specifier 'foreign-procedure "result" result #t)))))
 
   (define build-foreign-callable
     (lambda (ae conv proc params result)
       (build-profile ae
-        `(fcallable ,conv ,proc
+        `(fcallable (,conv ...) ,proc
            (,(map (lambda (x) (build-fp-specifier 'foreign-callable 'parameter x #f)) params) ...)
            ,(build-fp-specifier 'foreign-callable "result" result #t))))))
 

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -687,16 +687,16 @@
             ($oops #f "invalid ~a ~a specifier ~s" who what x)))))
 
   (define build-foreign-procedure
-    (lambda (ae conv foreign-name foreign-addr params result)
+    (lambda (ae conv* foreign-name foreign-addr params result)
       (build-profile ae
-        `(foreign (,conv ...) ,foreign-name ,foreign-addr
+        `(foreign (,conv* ...) ,foreign-name ,foreign-addr
            (,(map (lambda (x) (build-fp-specifier 'foreign-procedure 'parameter x #f)) params) ...)
            ,(build-fp-specifier 'foreign-procedure "result" result #t)))))
 
   (define build-foreign-callable
-    (lambda (ae conv proc params result)
+    (lambda (ae conv* proc params result)
       (build-profile ae
-        `(fcallable (,conv ...) ,proc
+        `(fcallable (,conv* ...) ,proc
            (,(map (lambda (x) (build-fp-specifier 'foreign-callable 'parameter x #f)) params) ...)
            ,(build-fp-specifier 'foreign-callable "result" result #t))))))
 
@@ -5991,9 +5991,9 @@
 (global-extend 'core '$foreign-procedure
   (lambda (e r w ae)
     (syntax-case e ()
-      ((_ conv foreign-name foreign-addr (arg ...) result)
+      ((_ conv* foreign-name foreign-addr (arg ...) result)
        (build-foreign-procedure ae
-         (strip (syntax conv) w)
+         (strip (syntax conv*) w)
          (strip (syntax foreign-name) w)
          (chi (syntax foreign-addr) r w)
          (map (lambda (x) (strip x w)) (syntax (arg ...)))
@@ -6002,9 +6002,9 @@
 (global-extend 'core '$foreign-callable
   (lambda (e r w ae)
     (syntax-case e ()
-      ((_ conv proc (arg ...) result)
+      ((_ conv* proc (arg ...) result)
        (build-foreign-callable ae
-         (strip (syntax conv) w)
+         (strip (syntax conv*) w)
          (chi (syntax proc) r w)
          (map (lambda (x) (strip x w)) (syntax (arg ...)))
          (strip (syntax result) w))))))
@@ -8540,15 +8540,15 @@
          [else ($oops '$fp-type->pred "unrecognized type ~s" type)])])))
 
 (define $filter-conv
-  (lambda (who conv)
+  (lambda (who conv*)
     (define squawk
       (lambda (x)
         (syntax-error x (format "invalid ~s convention" who))))
-    (let loop ([conv conv] [accum '()] [keep-accum '()])
+    (let loop ([conv* conv*] [accum '()] [keep-accum '()])
       (cond
-        [(null? conv) (datum->syntax #'filter-conv keep-accum)]
+        [(null? conv*) (datum->syntax #'filter-conv keep-accum)]
         [else
-         (let* ([orig-c (car conv)]
+         (let* ([orig-c (car conv*)]
                 [c (syntax->datum orig-c)]
                 [c (cond
                      [(not c) #f]
@@ -8573,18 +8573,18 @@
                        (and (eq? 'adjust-active (car accum))
                             (null? (cdr accum))))
              (syntax-error orig-c (format "conflicting ~s convention" who)))
-           (loop (cdr conv) (cons c accum)
-                 (if (and c (if-feature pthreads #t (not (eq? c 'adjust-active))))
+           (loop (cdr conv*) (cons c accum)
+                 (if c
                      (cons c keep-accum)
                      keep-accum)))]))))
 
 (define $make-foreign-procedure
-  (lambda (who conv foreign-name ?foreign-addr type* result-type)
+  (lambda (who conv* foreign-name ?foreign-addr type* result-type)
     (let ([unsafe? (= (optimize-level) 3)])
-      (define (check-strings-allowed type)
-        (when (memq 'adjust-active (syntax->datum conv))
-          ($oops who "~s argument not allowed with __collect_safe procedure" type)))
-      (with-syntax ([conv conv]
+      (define (check-strings-allowed)
+        (when (memq 'adjust-active (syntax->datum conv*))
+          ($oops who "string argument not allowed with __collect_safe procedure")))
+      (with-syntax ([conv* conv*]
                     [foreign-name foreign-name]
                     [?foreign-addr ?foreign-addr]
                     [(t ...) (generate-temporaries type*)])
@@ -8626,7 +8626,7 @@
                                                             (err ($moi) x))))
                                                (unsigned-32))])]
                                    [(utf-8)
-                                    (check-strings-allowed type)
+                                    (check-strings-allowed)
                                     #`(()
                                        ((if (eq? x #f)
                                             x
@@ -8637,7 +8637,7 @@
                                                         (err ($moi) x)))))
                                        (u8*))]
                                    [(utf-16le)
-                                    (check-strings-allowed type)
+                                    (check-strings-allowed)
                                     #`(()
                                        ((if (eq? x #f)
                                             x
@@ -8648,7 +8648,7 @@
                                                         (err ($moi) x)))))
                                        (u16*))]
                                    [(utf-16be)
-                                    (check-strings-allowed type)
+                                    (check-strings-allowed)
                                     #`(()
                                        ((if (eq? x #f)
                                             x
@@ -8659,7 +8659,7 @@
                                                         (err ($moi) x)))))
                                        (u16*))]
                                    [(utf-32le)
-                                    (check-strings-allowed type)
+                                    (check-strings-allowed)
                                     #`(()
                                        ((if (eq? x #f)
                                             x
@@ -8670,7 +8670,7 @@
                                                         (err ($moi) x)))))
                                        (u32*))]
                                    [(utf-32be)
-                                    (check-strings-allowed type)
+                                    (check-strings-allowed)
                                     #`(()
                                        ((if (eq? x #f)
                                             x
@@ -8739,7 +8739,7 @@
                                    #`[]
                                    #`[(unless (record? &-result '#,(unbox result-type)) (err ($moi) &-result))]))]
                          [else #'([] [] [])])])
-          #`(let ([p ($foreign-procedure conv foreign-name ?foreign-addr (extra-arg ... arg ... ...) result)]
+          #`(let ([p ($foreign-procedure conv* foreign-name ?foreign-addr (extra-arg ... arg ... ...) result)]
                   #,@(if unsafe?
                          #'()
                          #'([err (lambda (who x)
@@ -8766,16 +8766,16 @@
            (filter-type r #'result #t)))])))
 
 (define $make-foreign-callable
-  (lambda (who conv ?proc type* result-type)
+  (lambda (who conv* ?proc type* result-type)
     (for-each (lambda (c)
                 (when (eq? (syntax->datum c) 'i3nt-com)
                   ($oops who "unsupported convention ~s" c)))
-              (syntax->list conv))
+              (syntax->list conv*))
     (let ([unsafe? (= (optimize-level) 3)])
-      (define (check-strings-allowed result-type)
-        (when (memq 'adjust-active (syntax->datum conv))
-          ($oops who "~s result not allowed with __collect_safe callable" result-type)))
-      (with-syntax ([conv conv] [?proc ?proc])
+      (define (check-strings-allowed)
+        (when (memq 'adjust-active (syntax->datum conv*))
+          ($oops who "string result not allowed with __collect_safe callable")))
+      (with-syntax ([conv* conv*] [?proc ?proc])
         (with-syntax ([((actual (t ...) (arg ...)) ...)
                        (map
                         (lambda (type)
@@ -8905,7 +8905,7 @@
                                      unsigned-16
                                      [] [])])]
                          [(utf-8)
-                          (check-strings-allowed result-type)
+                          (check-strings-allowed)
                           #`((lambda (x)
                                (if (eq? x #f)
                                    x
@@ -8917,7 +8917,7 @@
                              u8*
                              [] [])]
                          [(utf-16le)
-                          (check-strings-allowed result-type)
+                          (check-strings-allowed)
                           #`((lambda (x)
                                (if (eq? x #f)
                                    x
@@ -8929,7 +8929,7 @@
                              u16*
                              [] [])]
                          [(utf-16be)
-                          (check-strings-allowed result-type)
+                          (check-strings-allowed)
                           #`((lambda (x)
                                (if (eq? x #f)
                                    x
@@ -8941,7 +8941,7 @@
                              u16*
                              [] [])]
                          [(utf-32le)
-                          (check-strings-allowed result-type)
+                          (check-strings-allowed)
                           #`((lambda (x)
                                (if (eq? x #f)
                                    x
@@ -8953,7 +8953,7 @@
                              u32*
                              [] [])]
                          [(utf-32be)
-                          (check-strings-allowed result-type)
+                          (check-strings-allowed)
                           #`((lambda (x)
                                (if (eq? x #f)
                                    x
@@ -8994,7 +8994,7 @@
                                   [] []))])])])
           ; use a gensym to avoid giving the procedure a confusing name
           (with-syntax ([p (datum->syntax #'foreign-callable (gensym))])
-            #`($foreign-callable conv
+            #`($foreign-callable conv*
                 (let ([p ?proc])
                   (define (err x)
                     ($oops 'foreign-callable

--- a/s/x86.ss
+++ b/s/x86.ss
@@ -2504,7 +2504,7 @@
                  ,(save-and-restore result-regs result-fp-count `(set! ,%eax ,(%inline activate-thread))))))]
            [else e]))
         (define returnem
-          (lambda (conv orig-frame-size locs result-type ccall r-loc)
+          (lambda (conv* orig-frame-size locs result-type ccall r-loc)
             (let ([frame-size (constant-case machine-type-name
                                 ; maintain 16-byte alignment not including the return address pushed
                                 ; by the call instruction, which counts as part of callee's frame
@@ -2519,7 +2519,7 @@
                 r-loc
                 ; Windows __stdcall convention requires callee to clean up
                 (lambda ()
-                  (if (or (fx= frame-size 0) (memq 'i3nt-stdcall conv) (memq 'i3nt-com conv))
+                  (if (or (fx= frame-size 0) (memq 'i3nt-stdcall conv*) (memq 'i3nt-com conv*))
                       `(nop)
                       (let ([frame-size (if (callee-pops-result-pointer? result-type)
                                             (fx- frame-size (constant ptr-bytes))
@@ -2527,20 +2527,20 @@
                         `(set! ,%sp ,(%inline + ,%sp (immediate ,frame-size))))))))))
         (lambda (info)
           (safe-assert (reg-callee-save? %tc)) ; no need to save-restore
-          (let ([conv (info-foreign-conv info)]
+          (let ([conv* (info-foreign-conv* info)]
                 [arg-type* (info-foreign-arg-type* info)]
                 [result-type (info-foreign-result-type info)])
             (with-values (do-stack arg-type* '() 0 result-type)
               (lambda (frame-size locs)
-                (returnem conv frame-size locs result-type
+                (returnem conv* frame-size locs result-type
                   (lambda (t0)
                     (let* ([fill-result-here? (fill-result-pointer-from-registers? result-type)]
-                           [adjust-active? (memq 'adjust-active conv)]
+                           [adjust-active? (if-feature pthreads (memq 'adjust-active conv*) #f)]
                            [t (if adjust-active? %edx t0)] ; need a register if `adjust-active?`
                            [call
                             (add-deactivate adjust-active? fill-result-here? t0 result-type
                               (cond
-                                [(memq 'i3nt-com conv)
+                                [(memq 'i3nt-com conv*)
                                  (when (null? arg-type*)
                                    ($oops 'foreign-procedure
                                           "__com convention requires instance argument"))
@@ -2803,8 +2803,8 @@
                    ,e
                    ,(pop-registers result-regs result-num-fp-regs 1)))))
         (lambda (info)
-          (let* ([conv (info-foreign-conv info)]
-                 [adjust-active? (memq 'adjust-active conv)]
+          (let* ([conv* (info-foreign-conv* info)]
+                 [adjust-active? (if-feature pthreads (memq 'adjust-active conv*) #f)]
                  [arg-type* (info-foreign-arg-type* info)]
                  [result-type (info-foreign-result-type info)]
                  [indirect-result-space (constant-case machine-type-name
@@ -2867,7 +2867,7 @@
                            (set! ,%ebp ,(%inline pop))
                            ; Windows __stdcall convention requires callee to clean up
                            ,((lambda (e)
-                               (if (or (memq 'i3nt-stdcall conv) (memq 'i3nt-com conv))
+                               (if (or (memq 'i3nt-stdcall conv*) (memq 'i3nt-com conv*))
                                  (let ([arg-size (fx- frame-size init-stack-offset)])
                                    (if (fx> arg-size 0)
                                        (%seq

--- a/s/x86_64.ss
+++ b/s/x86_64.ss
@@ -2883,12 +2883,12 @@
                         `(set! ,%sp ,(%inline + ,%sp (immediate ,frame-size)))))))))
           (lambda (info)
             (safe-assert (reg-callee-save? %tc)) ; no need to save-restore
-            (let* ([conv (info-foreign-conv info)]
+            (let* ([conv* (info-foreign-conv* info)]
                    [arg-type* (info-foreign-arg-type* info)]
                    [result-type (info-foreign-result-type info)]
                    [result-classes (classify-type result-type)]
                    [fill-result-here? (result-fits-in-registers? result-classes)]
-                   [adjust-active? (memq 'adjust-active conv)])
+                   [adjust-active? (if-feature pthreads (memq 'adjust-active conv*) #f)])
               (with-values (do-args (if fill-result-here? (cdr arg-type*) arg-type*) (make-vint) (make-vfp))
                 (lambda (frame-size nfp locs live*)
                   (with-values (add-save-fill-target fill-result-here? frame-size locs)
@@ -3282,11 +3282,11 @@
                    ,e
                    ,(pop-registers result-regs)))))
           (lambda (info)
-            (let ([conv (info-foreign-conv info)]
+            (let ([conv* (info-foreign-conv* info)]
                   [arg-type* (info-foreign-arg-type* info)]
                   [result-type (info-foreign-result-type info)])
               (let* ([result-classes (classify-type result-type)]
-                     [adjust-active? (memq 'adjust-active conv)]
+                     [adjust-active? (if-feature pthreads (memq 'adjust-active conv*) #f)]
                      [synthesize-first? (and result-classes
                                              (result-fits-in-registers? result-classes))]
                      [locs (do-stack (if synthesize-first? (cdr arg-type*) arg-type*) adjust-active?)])


### PR DESCRIPTION
Threads are often used in event-handling libraries like the one shown in the documentation for `foreign-callable`. Prior to this patch, activating and deactivating a thread to make an event-based pattern thread-friendly required glue C code to call `Sdeactivate_thread` and `Sactivate_thread`.

This patch adds `__thread` as a convention modifier for `foreign-procedure` and `foreign-callable`:

 * On a foreign procedure, `__thread` causes the calling thread to be deactivated (at the last moment, after arguments to the procedure are unpacked), and the thread is re-activated when the foreign procedure returns.

 * On a foreign callable, `__thread` causes the calling thread to be activated, and the activation state is reverted when the callable returns. "Reverted" has no effect if the thread was already activated, but "reverted" can mean "destroyed" if the thread had not been registered when the callable was invoked.

As an example, using a pair of `__thread` annotations in the `event-loop` example for `foreign-callable` makes the example play nicely with threads, instead of causing threads to block when they try to GC. A `__thread` annotation on a callable can also make the callable work when invoked by an unspecified thread, instead of requiring that that the thread is first activated.

This patch builds on #213. The changes could stand alone, but since the modifications overlap and since Racket needs both patches, it seems easiest to combine the changes, and it may make sense to review them together.
