### PR TITLE
Remove special case for (#2%map p '()) in cp0

### DIFF
--- a/LOG
+++ b/LOG
@@ -879,3 +879,7 @@
   $verify-ftype-address if the address expression is a call to
   ftype-pointer-address.
     ftype.ss
+- Remove special case for (#2%map p '()) in cp0
+  so the reduced version checks that p is a procedure.
+  Also make the same change for #2%for-each.
+    cp0.ss, 4.ms

--- a/mats/4.ms
+++ b/mats/4.ms
@@ -1080,6 +1080,10 @@
  ; make sure compiler doesn't bomb w/two few args
   (procedure? (lambda (x) (map x)))
   (error? ; nonprocedure
+    (map 3 '()))
+  (error? ; nonprocedure
+    (map 3 '() '()))
+  (error? ; nonprocedure
     (map 3 '(a b c)))
   (error? ; nonprocedure
     (parameterize ([optimize-level 3])
@@ -1421,6 +1425,10 @@
   (procedure? (lambda (x) (fold-left x)))
   (procedure? (lambda (x) (fold-left x y)))
   (error? ; nonprocedure
+    (for-left 3 0 '()))
+  (error? ; nonprocedure
+    (for-left 3 0 '() '()))
+  (error? ; nonprocedure
     (fold-left 3 0 '(a b c)))
   (error? ; improper list
     (fold-left cons 0 'a))
@@ -1544,6 +1552,10 @@
  ; make sure compiler doesn't bomb w/two few args
   (procedure? (lambda (x) (fold-right x)))
   (procedure? (lambda (x) (fold-right x y)))
+  (error? ; nonprocedure
+    (for-right 3 0 '()))
+  (error? ; nonprocedure
+    (for-right 3 0 '() '()))
   (error? ; nonprocedure
     (fold-right 3 0 '(a b c)))
   (error? ; improper list
@@ -1723,10 +1735,23 @@
  ; make sure compiler doesn't bomb w/two few args
   (procedure? (lambda (x) (for-each x)))
   (error? ; nonprocedure
+    (for-each 3 '()))
+  (error? ; nonprocedure
+    (for-each 3 '() '()))
+  (error? ; nonprocedure
     (for-each 3 '(a b c)))
   (error? ; nonprocedure
     (parameterize ([optimize-level 3])
       (eval '(#2%for-each 3 '(a b c)))))
+  (error? ; nonprocedure
+    (parameterize ([optimize-level 3])
+      (eval
+        '(let ()
+           (define (f p b)
+             (unbox b)
+             (#2%for-each p (if (box? b) '() '(1 2 3)))
+             (list p (procedure? p)))
+           (f 7 (box 0))))))
   (error? ; improper list
     (for-each pretty-print 'a))
   (error? ; improper list
@@ -2233,6 +2258,10 @@
  ; make sure compiler doesn't bomb w/two few args
   (procedure? (lambda (x) (ormap x)))
   (error? ; nonprocedure
+    (ormap 3 '()))
+  (error? ; nonprocedure
+    (ormap 3 '() '()))
+  (error? ; nonprocedure
     (ormap 3 '(a b c)))
   (error? ; improper list
     (ormap not 'a))
@@ -2333,6 +2362,10 @@
    (eq? (andmap (lambda (x y z) #t) '() '() '()) #t)
  ; make sure compiler doesn't bomb w/two few args
   (procedure? (lambda (x) (andmap x)))
+  (error? ; nonprocedure
+    (andmap 3 '()))
+  (error? ; nonprocedure
+    (andmap 3 '() '()))
   (error? ; nonprocedure
     (andmap 3 '(a b c)))
   (error? ; improper list
@@ -2435,6 +2468,10 @@
  ; make sure compiler doesn't bomb w/two few args
   (procedure? (lambda (x) (exists x)))
   (error? ; nonprocedure
+    (exists 3 '()))
+  (error? ; nonprocedure
+    (exists 3 '() '()))
+  (error? ; nonprocedure
     (exists 3 '(a b c)))
   (error? ; improper list
     (exists not 'a))
@@ -2535,6 +2572,10 @@
    (eq? (for-all (lambda (x y z) #t) '() '() '()) #t)
  ; make sure compiler doesn't bomb w/two few args
   (procedure? (lambda (x) (for-all x)))
+  (error? ; nonprocedure
+    (for-all 3 '()))
+  (error? ; nonprocedure
+    (for-all 3 '() '()))
   (error? ; nonprocedure
     (for-all 3 '(a b c)))
   (error? ; improper list

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -3619,14 +3619,18 @@
                                                        (cons `(call ,preinfo (ref #f ,p)
                                                                 ,(map (lambda (t*) (build-ref (car t*))) t**) ...)
                                                              (g (map cdr t**))))))])
-                                          (if (and map? (not (eq? ctxt 'effect)))
-                                              (build-primcall lvl 'list results)
-                                              (make-seq* ctxt results)))
+                                          (if (and map? (not (eq? (app-ctxt ctxt) 'effect)))
+                                              (if (null? results)
+                                                  null-rec
+                                                  (build-primcall lvl 'list results))
+                                              (if (null? results)
+                                                  void-rec
+                                                  (make-seq* (app-ctxt ctxt) results))))
                                         (non-result-exp (value-visit-operand! (car ls*))
                                           (build-let (car t**) (car e**)
                                             (f (cdr t**) (cdr e**) (cdr ls*))))))]) 
                              (if (fx= lvl 2)
-                               (make-seq ctxt
+                               (make-seq (app-ctxt ctxt)
                                  `(if ,(build-primcall 2 'procedure? (list `(ref #f ,p)))
                                       ,void-rec
                                       ,(build-primcall 3 '$oops (list `(quote ,(if map? 'map 'for-each))
@@ -3642,11 +3646,7 @@
                     [else #f])))))
         (define-inline 2 map
           [(?p ?ls . ?ls*)
-            (if (andmap null-rec? (cons ?ls ?ls*))
-                (begin
-                  (residualize-seq '() (list* ?p ?ls ?ls*) ctxt)
-                  null-rec)
-                (inline-lists ?p ?ls ?ls* 2 #t ctxt sc wd name moi))])
+           (inline-lists ?p ?ls ?ls* 2 #t ctxt sc wd name moi)])
         (define-inline 3 map
           [(?p ?ls . ?ls*)
             (cond
@@ -3725,12 +3725,7 @@
 
         (define-inline 2 for-each
           [(?p ?ls . ?ls*)
-           (cond
-             [(andmap null-rec? (cons ?ls ?ls*))
-              (residualize-seq '() (list* ?p ?ls ?ls*) ctxt)
-              void-rec]
-             [else
-             (inline-lists ?p ?ls ?ls* 2 #f ctxt sc wd name moi)])])
+           (inline-lists ?p ?ls ?ls* 2 #f ctxt sc wd name moi)])
         (define-inline 3 for-each
           [(?p ?ls . ?ls*)
            (cond


### PR DESCRIPTION
When  `(#2%map p '())` is reduced in cp0 to `'()`, the expression of p is discarded without a check that it is a procedure. But the signature of `map` in primdata.ss is `((procedure list list...) ->(list))`.

The problem is that in the [PR of cptypes #192](https://github.com/cisco/ChezScheme/pull/192) uses the signature to mark `p` as a procedure after this expression, assuming that otherwise `map` would have raise an error. 

The code to show the problem should be a mix of some reductions of cp0 and some reduction of cptypes:

    (define (f p b)
     (unbox b)
     (map p (if (box? b) '() '(1 2 3)))
     (list p (procedure? p)))
    
    (f 7 (box 0)) ;==> 
    ; ==> (7 #f) in the current version of Chez Scheme
    ; ==> [error] in Chez Schem + this patch
    ; ==> (7 #t) in Chez Scheme + cptypes [wrong]

I think that the best behavior is to raise an error. This patch removes one of the reductions in cp0 so the other reduction is triggered and an error is raised.

But I think it's also ok to not raise an error, but in this case the signature of map should be weaker, and allow the first argument to be any pointer. The patch to do this is in my [alternative branch](https://github.com/gus-massa/ChezScheme/commits/18-2-Map-Null-Alternative).

But I think that the result `(list p (procedure? p))` --> `(7 #t)` is wrong, and it can cause further problems in cptypes in more complex and realistic examples.