### PR TITLE
standalone export form now handles (import import-spec ...)

### DIFF
--- a/LOG
+++ b/LOG
@@ -897,3 +897,5 @@
     schlib.c
 - install equates.h, kernel.o, and main.o on unix-like systems
     Mf-install.in
+- standalone export form now handles (import import-spec ...)
+    8.ms, syntax.ss, release_notes.stex

--- a/mats/8.ms
+++ b/mats/8.ms
@@ -7976,6 +7976,19 @@
   (equal?
     (let () (import ($l3)) (f (f 3)))
     3)
+  (begin
+    ;; (export import-spec ...) empty case
+    (library ($empty) (export) (import (chezscheme)) (export (import)))
+    #t)
+  (begin
+    (library ($l4-A) (export a) (import (chezscheme)) (define a 1))
+    (library ($l4-B) (export b) (import (chezscheme)) (define b 2))
+    #t)
+  (equal? '(1 2) (let () (import ($l4-A) ($l4-B)) (list a b)))
+  (begin
+    ;; (export import-spec ...) multiple imports case
+    (library ($l4-C) (export) (import (chezscheme)) (export (import ($l4-A) ($l4-B))))
+    (equal? '(1 2) (let () (import ($l4-C)) (list a b))))
  )
 
 (mat library2

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1554,6 +1554,12 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Incomplete handling of import specs within standalone export forms}
+
+A bug that limited the \scheme{(import \var{import-spec} \dots)} form within a
+standalone \scheme{export} form to \scheme{(import \var{import-spec})} has been
+fixed.
+
 \subsection{Permission denied after deleting files or directories in Windows}
 
 In Windows, deleting a file or directory briefly leaves the file or

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -4280,14 +4280,18 @@
                                          (append #'(old-id ...) exports)
                                          (append #'(old-id ...) exports-to-check)
                                          (fold-right resolve&add-id new-exports #'(old-id ...) #'(new-id ...)))]
-                                      [(?import impspec)
+                                      [(?import impspec ...)
                                        (sym-kwd? ?import import)
-                                       (let-values ([(mid tid imps) (help-determine-imports #'impspec r #f)])
-                                         (let ([imps (if (import-interface? imps) (module-exports imps) imps)])
-                                           (values
-                                             (append (map car imps) exports)
-                                             exports-to-check
-                                             (fold-right add-id new-exports (map cdr imps)))))]
+                                       (let process-impspecs ([impspec* #'(impspec ...)])
+                                         (if (null? impspec*)
+                                             (values exports exports-to-check new-exports)
+                                             (let-values ([(_mid _tid imps) (help-determine-imports (car impspec*) r #f)]
+                                                          [(exports exports-to-check new-exports) (process-impspecs (cdr impspec*))])
+                                               (let ([imps (if (import-interface? imps) (module-exports imps) imps)])
+                                                 (values
+                                                  (append (map car imps) exports)
+                                                  exports-to-check
+                                                  (fold-right add-id new-exports (map cdr imps)))))))]
                                       [_ (syntax-error x "invalid export spec")])))))])
               (g (cdr expspec**) exports exports-to-check new-exports))))))
 )


### PR DESCRIPTION
The [CSUG entry](http://cisco.github.io/ChezScheme/csug9.5/libraries.html#./libraries:s17) for  standalone `export` forms permits an export-spec to take the form `(import import-spec ...)`, yet the implementation currently seems to require `(import import-spec)`.

```
> (library (Z) (export) (import (scheme)) (export (import)))
Exception: invalid export spec (import)
Type (debug) to enter the debugger.
> (library (A) (export a) (import (scheme)) (define a 1))
> (library (B) (export b) (import (scheme)) (define b 2))
> (library (C) (export) (import (scheme)) (export (import (A) (B))))
Exception: invalid export spec (import (A) (B))
Type (debug) to enter the debugger.
```

This commit tries to make the implementation consistent with CSUG on this point, but could use review by someone with more recent experience in `syntax.ss`.