### PR TITLE
handle compiled library code in boot files once base boot is loaded

### DIFF
--- a/LOG
+++ b/LOG
@@ -919,3 +919,5 @@
     8.ms
 - Added -Wno-implicit-fallthrough flag to macOS C makefiles.
     c/Mf-a6osx, c/Mf-i3osx, c/Mf-ta6osx, c/Mf-ti3osx
+- handle compiled library code in boot files once base boot is loaded
+    globals.h, scheme.c, 7.ss, 7.ms, primdata.ss

--- a/c/globals.h
+++ b/c/globals.h
@@ -73,6 +73,9 @@ EXTERN struct {
     ptr heap_reserve_ratio_id;
     IBOOL retain_static_relocation;
     IBOOL enable_object_counts;
+    ptr scheme_version_id;
+    ptr make_load_binary_id;
+    ptr load_binary;
 
   /* foreign.c */
     ptr foreign_static;

--- a/mats/7.ms
+++ b/mats/7.ms
@@ -917,10 +917,7 @@
           "testfile-5.ss"))
       (let-values ([(to-stdin from-stdout from-stderr pid)
                     (open-process-ports
-                      (format "~a -b testfile.boot -q"
-                        (if (windows?)
-                            (list->string (subst #\\ #\/ (string->list *scheme*)))
-                            *scheme*))
+                      (format "~a -b testfile.boot -q" (patch-exec-path *scheme*))
                       (buffer-mode block)
                       (native-transcoder))])
         (close-output-port to-stdin)
@@ -941,10 +938,7 @@
         (make-boot-file "testfile.boot" '("petite") "testfile-libs.so"))
       (let-values ([(to-stdin from-stdout from-stderr pid)
                     (open-process-ports
-                      (format "~a -b testfile.boot -q"
-                        (if (windows?)
-                            (list->string (subst #\\ #\/ (string->list *scheme*)))
-                            *scheme*))
+                      (format "~a -b testfile.boot -q" (patch-exec-path *scheme*))
                       (buffer-mode block)
                       (native-transcoder))])
         (pretty-print '(let () (import (B)) (printf "~s\n" b)) to-stdin)
@@ -971,10 +965,7 @@
           "testfile-5.so"))
       (let-values ([(to-stdin from-stdout from-stderr pid)
                     (open-process-ports
-                      (format "~a -b testfile.boot -q"
-                        (if (windows?)
-                            (list->string (subst #\\ #\/ (string->list *scheme*)))
-                            *scheme*))
+                      (format "~a -b testfile.boot -q" (patch-exec-path *scheme*))
                       (buffer-mode block)
                       (native-transcoder))])
         (close-output-port to-stdin)
@@ -3328,9 +3319,7 @@ evaluating module init
         'replace)
      ; compile in a separate Scheme process
       (if (windows?)
-          (system (format "echo (compile-file \"testfile\") | ~a"
-                    (list->string
-                      (subst #\\ #\/ (string->list *scheme*)))))
+          (system (format "echo (compile-file \"testfile\") | ~a" (patch-exec-path *scheme*)))
           (system (format "echo '(compile-file \"testfile\")' | ~a" *scheme*)))
       (load "testfile.so")
       (list (top-level-bound? '$notfribblefratz) (top-level-value '$notfribblefratz)))

--- a/mats/7.ms
+++ b/mats/7.ms
@@ -933,6 +933,31 @@
     "hello 1\nhello 2\nhello 3\nhello 4\nhello 5\n")
   (equal?
     (begin
+      (parameterize ([optimize-level 2])
+        (compile-to-file
+         '((library (A) (export a) (import (scheme)) (define a 'aye))
+           (library (B) (export b) (import (A) (scheme)) (define b (list a 'captain))))
+         "testfile-libs.so")
+        (make-boot-file "testfile.boot" '("petite") "testfile-libs.so"))
+      (let-values ([(to-stdin from-stdout from-stderr pid)
+                    (open-process-ports
+                      (format "~a -b testfile.boot -q"
+                        (if (windows?)
+                            (list->string (subst #\\ #\/ (string->list *scheme*)))
+                            *scheme*))
+                      (buffer-mode block)
+                      (native-transcoder))])
+        (pretty-print '(let () (import (B)) (printf "~s\n" b)) to-stdin)
+        (close-output-port to-stdin)
+        (let ([out (get-string-all from-stdout)]
+              [err (get-string-all from-stderr)])
+          (close-input-port from-stdout)
+          (close-input-port from-stderr)
+          (unless (eof-object? err) (error 'bootfile-test1 err))
+          out)))
+    "(aye captain)\n")
+  (equal?
+    (begin
       (unless (or (embedded?) (equal? *scheme* (format "../bin/~a/scheme~a" (machine-type) (if (windows?) ".exe" ""))))
         (errorf #f "not testing boot file based on ../boot/~a/petite.boot, since *scheme* isn't ../bin/~a/scheme~a"
           (machine-type) (machine-type) (if (windows?) ".exe" "")))

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1566,6 +1566,12 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Boot files containing compiled library code fail to load}
+
+Compiled library code may now appear within fasl objects loaded during
+the boot process, provided that they are appended to the end of the base boot
+file or appear within a later boot file.
+
 \subsection{Misleading cyclic dependency error (9.5)}
 
 The library system no longer reports a cyclic dependency error

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -2072,6 +2072,7 @@
   ($make-fptr [flags pure mifoldable discard true])
   ($make-graph-env [flags])
   ($make-library-requirements-options [flags pure discard true])
+  ($make-load-binary [flags])
   ($make-object-finder [flags])
   ($make-promise [flags alloc])
   ($make-read [flags])


### PR DESCRIPTION
This aims to fix the issue with compiled library code in (non-base) boot files that is described in #69.