### PR TITLE
Symbolic links must be created for the install path and not the temp root path

### DIFF
--- a/makefiles/Mf-install.in
+++ b/makefiles/Mf-install.in
@@ -122,7 +122,7 @@ libbininstall: ${LibBin}
           /bin/rm -f ${LibBin}/${InstallSchemeName}.boot;\
           ln -f ${LibBin}/scheme.boot ${LibBin}/${InstallSchemeName}.boot;\
         fi
-	ln -sf ${LibBin}/scheme.boot ${LibBin}/${InstallScriptName}.boot;
+	ln -f ${LibBin}/scheme.boot ${LibBin}/${InstallScriptName}.boot;
 	$I -m 444 ${Include}/kernel.o ${LibBin}
 	$I -m 444 ${Include}/main.o ${LibBin}
 	$I -m 444 ${Include}/scheme.h ${LibBin}


### PR DESCRIPTION
As `${LibBin}` is expanded to `${TempRoot}${InstallLibBin}`, if we create a symlink with a source pointing to the `${TempRoot}` path, once installed (for example in an RPM), the symlink will still point to the `${TempRoot}` path.

That's why we must use the final path `${InstallLibBin}`. Another solution could have been to use a relative path.