### PR TITLE
clarify "unknown module" error message; flush expand-output and expand/optimize-output

### DIFF
--- a/LOG
+++ b/LOG
@@ -999,3 +999,5 @@
     misc.ms
 - flush expand-output and expand/optimize-output ports
     compile.ss
+- clarify "unknown module" error message in determine-module-imports
+    syntax.ss

--- a/LOG
+++ b/LOG
@@ -1001,3 +1001,5 @@
     compile.ss
 - clarify "unknown module" error message in determine-module-imports
     syntax.ss
+- restore the import code on reset to provide consistent error message
+    syntax.ss, 8.ms

--- a/LOG
+++ b/LOG
@@ -997,3 +997,5 @@
   whose base and/or index is a local save.
     cpnanopass.ss,
     misc.ms
+- flush expand-output and expand/optimize-output ports
+    compile.ss

--- a/mats/8.ms
+++ b/mats/8.ms
@@ -8977,7 +8977,47 @@
                        (eval '(lookup f g) (environment '(testfile-lr-l3) '(lookup))))])
            (eval '(lookup f g) (environment '(testfile-lr-l3) '(lookup))))))
     "Exception in h: user requested failure with (make-it-fail) parameter\nException in h: user requested failure with (make-it-fail) parameter\n")
-)
+
+  ;; re-arm import code if it complains about a library that is not visible
+  (begin
+    (with-output-to-file "testfile-lr-l4.ss"
+      (lambda ()
+        (pretty-print
+         '(library (testfile-lr-l4)
+            (export x)
+            (import (chezscheme))
+            (define x 123))))
+      'replace)
+    (with-output-to-file "testfile-lr-p4.ss"
+      (lambda ()
+        (for-each pretty-print
+         '((import (testfile-lr-l4) (scheme))
+           (define (run args)
+             (guard (c [#t (display-condition c) (newline)])
+               (pretty-print (top-level-value (car args) (environment (cdr args))))))
+           (when (> x 0) ;; reference export
+             (let ([args (map string->symbol (command-line-arguments))])
+               (if (= (length args) 2)
+                   (begin
+                     (run args)
+                     (run args))
+                   (error #f "expected 2 args")))))))
+      'replace)
+    (separate-eval
+     '(parameterize ([compile-imported-libraries #t] [generate-wpo-files #t])
+        (compile-program "testfile-lr-p4.ss")
+        (compile-whole-program "testfile-lr-p4.wpo" "testfile-lr-p4-visible" #t)
+        (compile-whole-program "testfile-lr-p4.wpo" "testfile-lr-p4-not-visible" #f)))
+    (equal?
+     (separate-eval
+      '(parameterize ([command-line-arguments '("x" "testfile-lr-l4")])
+         (load-program "testfile-lr-p4-visible")
+         (load-program "testfile-lr-p4-not-visible")))
+     (string-append
+      "123\n"
+      "123\n"
+      "Exception in visit: library (testfile-lr-l4) is not visible\n"
+      "Exception in visit: library (testfile-lr-l4) is not visible\n"))))
 
 (mat cross-library-optimization
   (begin

--- a/s/compile.ss
+++ b/s/compile.ss
@@ -635,7 +635,8 @@
     (when (expand-output)
       (when source-info-string
         (fprintf (expand-output) "~%;; expand output for ~a\n" source-info-string))
-      (pretty-print ($uncprep x1) (expand-output)))
+      (pretty-print ($uncprep x1) (expand-output))
+      (flush-output-port (expand-output)))
     (let loop ([chunk* (expand-Lexpand x1)] [rx2b* '()] [rfinal* '()])
       (define finish-compile
         (lambda (x1 f)
@@ -683,7 +684,8 @@
                                      [else (sorry! who "unrecognized stuff ~s" x2b)])
                                    (finish x2b)))
                           rx2b*)])
-                (pretty-print (if (fx= (length e*) 1) (car e*) `(begin ,@(reverse e*))) (expand/optimize-output))))
+                (pretty-print (if (fx= (length e*) 1) (car e*) `(begin ,@(reverse e*))) (expand/optimize-output))
+                (flush-output-port (expand/optimize-output))))
             ($pass-time 'pfasl (lambda () (c-print-fasl `(group ,@(reverse rfinal*)) op))))
           (let ([x1 (car chunk*)])
             (cond
@@ -1479,7 +1481,8 @@
           (let* ([x1 (expand-Lexpand ($pass-time 'expand (lambda () (expand x0 env-spec #t))))]
                  [waste ($uncprep x1 #t)] ; populate preinfo sexpr fields
                  [waste (when (and (expand-output) (not ($noexpand? x0)))
-                          (pretty-print ($uncprep x1) (expand-output)))]
+                          (pretty-print ($uncprep x1) (expand-output))
+                          (flush-output-port (expand-output)))]
                  [x2 ($pass-time 'cpvalid (lambda () ($cpvalid x1)))]
                  [x2a (let ([cpletrec-ran? #f])
                         (let ([x ((run-cp0)
@@ -1492,7 +1495,8 @@
                  [x2b ($pass-time 'cpcheck (lambda () ($cpcheck x2a)))]
                  [x2b ($pass-time 'cpcommonize (lambda () ($cpcommonize x2b)))])
             (when (and (expand/optimize-output) (not ($noexpand? x0)))
-              (pretty-print ($uncprep x2b) (expand/optimize-output)))
+              (pretty-print ($uncprep x2b) (expand/optimize-output))
+              (flush-output-port (expand/optimize-output)))
             (if (and (compile-interpret-simple)
                      (not ($assembly-output))
                      (cheat? x2b))

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -4071,7 +4071,7 @@
      ;     (and <sub-version ref>*)
      ;     (or <sub-version ref>*)
      ;     (not <sub-version ref>)
-      (define (determine-module-imports what mid tid)
+      (define (determine-module-imports what who mid tid)
         (let ([binding (lookup (id->label mid empty-wrap) r)])
           (case (binding-type binding)
             [($module)
@@ -4087,7 +4087,7 @@
                (values mid tid
                  (make-import-interface x
                    (diff-marks (id-marks tid) (interface-marks (get-indirect-interface x))))))]
-            [else (syntax-error mid "unknown module")])))
+            [else (syntax-error who (format "unknown ~a" what))])))
       (define (impset x)
         (syntax-case x ()
           [(?only *x id ...)
@@ -4222,13 +4222,13 @@
                              [else (f (cdr imps) o.n* (cons a new-imps))]))))))))]
           [mid
            (and (not std?) (id? #'mid))
-           (determine-module-imports "module" #'mid #'mid)]
+           (determine-module-imports "module" #'mid #'mid #'mid)]
           [(?library-reference lr)
            (sym-kwd? ?library-reference library-reference)
            (let-values ([(mid tid) (lookup-library #'lr)])
-             (determine-module-imports "library" mid tid))]
+             (determine-module-imports "library" #'lr mid tid))]
           [lr (let-values ([(mid tid) (lookup-library #'lr)])
-                (determine-module-imports "library" mid tid))]))
+                (determine-module-imports "library" #'lr mid tid))]))
       (syntax-case impspec (for)
         [(?for *x level ...)
          (sym-kwd? ?for for)

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -5147,10 +5147,11 @@
                    (when (eq? p 'loading)
                      ($oops #f "attempt to import library ~s while it is still being loaded" (libdesc-path desc)))
                   (libdesc-import-code-set! desc #f)
-                  (for-each (lambda (req) (import-library (libreq-uid req))) (libdesc-import-req* desc))
-                  ($install-library-clo-info (libdesc-clo* desc))
-                  (libdesc-clo*-set! desc '())
-                  (p))]))]
+                  (on-reset (libdesc-import-code-set! desc p)
+                    (for-each (lambda (req) (import-library (libreq-uid req))) (libdesc-import-req* desc))
+                    ($install-library-clo-info (libdesc-clo* desc))
+                    (libdesc-clo*-set! desc '())
+                    (p)))]))]
           [else ($oops #f "library ~:s is not defined" uid)])))
   
     ; invoking or visiting a possibly unloaded library occurs in two separate steps:


### PR DESCRIPTION
#### compile.ss
Should we revise the flush-output-port change to fetch parameter values once per `(when ...)`?

#### syntax.ss
I left a WIP commit at the tip hoping that @akeep can sanity check it.

Here is the error message issue (note that it is masked by the WIP commit):
```
> (import-notify #t)
> (generate-wpo-files #t)
> (compile-imported-libraries #t)
> (with-output-to-file "B.ss"
    (lambda ()
      (pretty-print
       '(library (B) (export b) (import (scheme)) (define b 9))))
    'replace)
> (with-output-to-file "prog.ss"
    (lambda ()
      (for-each pretty-print
        `((import (B) (scheme))
          (import-notify #t)
          (define (run args)
            (guard (c [#t (display-condition c) (newline)])
              (pretty-print
               (top-level-value (car args) (environment (cdr args))))))
          (when (> b 0) ;; reference export
            (let ([args (map string->symbol (command-line-arguments))])
              (if (= (length args) 2)
                  (begin
                    (run args)
                    (run args))
                  (error #f "expected 2 args")))))))
    'replace)
> (compile-program "prog.ss")
> (compile-whole-program "prog.wpo" "prog-visible" #t)
> (compile-whole-program "prog.wpo" "prog-not-visible" #f)
```

Before:
```
$ scheme --program prog-not-visible b B
Exception in visit: library (B) is not visible
Exception: unknown module #{B b8zzvxtl8z5jmjgbh9vh6q-0}
```

After the "clarify 'unknown module' error message ..." commit:
```
$ scheme --program prog-not-visible b B
Exception in visit: library (B) is not visible
Exception: unknown library (B)
```

After the "WIP" commit:
```
$ scheme --program prog-not-visible b B
Exception in visit: library (B) is not visible
Exception in visit: library (B) is not visible
```

