### PR TITLE
library-exports raises an exception for compiled library that is not yet imported

### DIFF
--- a/mats/8.ms
+++ b/mats/8.ms
@@ -11287,6 +11287,56 @@
       (load-library "testfile-li3.so")
       (library-object-filename '(testfile-li3)))
     "testfile-li3.so")
+  (begin
+    (define (test-library-info do-load file)
+      (separate-eval
+       `(,do-load ,file)
+       ;; no import here
+       '(begin
+          (define (show f)
+            (printf "~s: " f)
+            (guard (e [else (display-condition e) (newline)])
+              (printf "~s\n" ((eval f) '(testfile-li3)))))
+          (show 'library-object-filename)
+          (show 'library-requirements)
+          (show 'library-version)
+          (show 'library-exports))
+       ;; now import
+       '(import (testfile-li3))
+       '(show 'library-exports)))
+    #t)
+  (equal?
+   (test-library-info 'load-library "testfile-li3.ss")
+   (string-append
+    "library-object-filename: #f\n"
+    "library-requirements: ((rnrs (6)))\n"
+    "library-version: ()\n"
+    "library-exports: (x)\n"
+    "library-exports: (x)\n"))
+  (equal?
+   (test-library-info 'load-library "testfile-li3.so")
+   (string-append
+    "library-object-filename: \"testfile-li3.so\"\n"
+    "library-requirements: ((rnrs (6)))\n"
+    "library-version: ()\n"
+    "library-exports: (x)\n"
+    "library-exports: (x)\n"))
+  (equal?
+   (test-library-info 'visit "testfile-li3.so")
+   (string-append
+    "library-object-filename: \"testfile-li3.so\"\n"
+    "library-requirements: Exception: run-time information for library (testfile-li3) has not been loaded\n"
+    "library-version: ()\n"
+    "library-exports: (x)\n"
+    "library-exports: (x)\n"))
+  (equal?
+   (test-library-info 'revisit "testfile-li3.so")
+   (string-append
+    "library-object-filename: \"testfile-li3.so\"\n"
+    "library-requirements: Exception: compile-time information for library (testfile-li3) has not been loaded\n"
+    "library-version: ()\n"
+    "library-exports: Exception: compile-time information for library (testfile-li3) has not been loaded\n"
+    "library-exports: (x)\n"))
 )
 
 (mat rnrs-eval

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2701,6 +2701,12 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{\scheme{library-exports} for library that is not yet imported (9.9.9)}
+
+When visiting or loading a separately compiled library,
+\scheme{library-exports} raised an exception if the library was not
+yet imported.
+
 \subsection{Incorrect code for \scheme{record?} at optimize-level 3 (9.9.9)}
 
 At optimize-level 3, the \scheme{record?} predicate could short circuit without


### PR DESCRIPTION
Calling `library-exports` on a compiled library raises an exception if the library has not yet been imported.

If we compile testfile-li3.ss and start a new session, we get:

```
> (load-library "testfile-li3.so")
> (library-exports '(testfile-li3))
Exception in library-exports: unexpected binding (global . #{testfile-li3 dxvp567u7nmy7h0a66skcx-272})
Type (debug) to enter the debugger.
```

With the change on this branch, if we recompile testfile-li3.ss and start a new session, we get: 
```
> (load-library "testfile-li3.so")
> (library-exports '(testfile-li3))
(x)
```

Is this approach misguided? If not, maybe we can tidy up and cherry-pick the next time we have a compelling reason to rebuild the boot files. (Right now it's mingled with the changes for #310.)

The original `chi-top-library` had installed the `interface-binding` with different values for `token` in the call to `$sc-put-cte` (`#f`) vs. the call to `build-cte-install` (`*system*`). I moved the work of the residual call into `import-library` and preserved the `*system*`, but perhaps that should have been `#f` originally, based on the [comment in `chi-top-library`](https://github.com/cisco/ChezScheme/blob/2230e5adcb61ac8b27c9deee682270f4e17fbafb/s/syntax.ss#L2639).
