### PR TITLE
fix OpenBSD build

### DIFF
--- a/c/Mf-a6ob
+++ b/c/Mf-a6ob
@@ -35,7 +35,7 @@ ${Kernel}: ${kernelobj} ../zlib/libz.a
 	ld -r -X -o ${Kernel} ${kernelobj} ../zlib/libz.a
 
 ${Scheme}: ${Kernel} ${Main}
-	$C -rdynamic -Wl,--export-dynamic -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
+	$C -rdynamic -Wl,--export-dynamic -Wl,-z,wxneeded -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
 
 ../zlib/configure.log:
 	(cd ../zlib; CFLAGS=-m64 ./configure --64)

--- a/c/Mf-ta6ob
+++ b/c/Mf-ta6ob
@@ -35,7 +35,7 @@ ${Kernel}: ${kernelobj} ../zlib/libz.a
 	ld -r -X -o ${Kernel} ${kernelobj} ../zlib/libz.a
 
 ${Scheme}: ${Kernel} ${Main}
-	$C -rdynamic -Wl,--export-dynamic -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
+	$C -rdynamic -Wl,--export-dynamic -Wl,-z,wxneeded -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
 
 ../zlib/configure.log:
 	(cd ../zlib; CFLAGS=-m64 ./configure --64)

--- a/c/expeditor.c
+++ b/c/expeditor.c
@@ -546,7 +546,7 @@ static void s_ee_write_char(wchar_t c) {
 #include <sys/ioctl.h>
 #include <wchar.h>
 #include <locale.h>
-#ifndef __GLIBC__
+#if !defined(__GLIBC__) && !defined(__OpenBSD__)
 #include <xlocale.h>
 #endif
 

--- a/s/a6ob.def
+++ b/s/a6ob.def
@@ -24,7 +24,7 @@
 (define-constant size_t-bits 64)
 (define-constant ptrdiff_t-bits 64)
 (define-constant wchar-bits 32)
-(define-constant time-t-bits 32)
+(define-constant time-t-bits 64)
 (define-constant max-float-alignment 8)
 (define-constant max-integer-alignment 8)
 (define-constant asm-arg-reg-max 5)

--- a/s/ta6ob.def
+++ b/s/ta6ob.def
@@ -24,7 +24,7 @@
 (define-constant size_t-bits 64)
 (define-constant ptrdiff_t-bits 64)
 (define-constant wchar-bits 32)
-(define-constant time-t-bits 32)
+(define-constant time-t-bits 64)
 (define-constant max-float-alignment 8)
 (define-constant max-integer-alignment 8)
 (define-constant asm-arg-reg-max 5)


### PR DESCRIPTION
Three issues are present and patched herein:

xlocale.h not present
time_t is 64 bits
wxneeded flag is present in scheme ELF to prevent "out of memory" (due to ENOTSUP) failure in segment.c.

When building on OpenBSD 6.2 (as tested), it is worthwhile reading this:

https://marc.info/?l=openbsd-ports&m=147060153102724&w=2

Chez must be constructed in a file system with the wxallowed flag present; this means /usr/local for the out-of-box configuration.
