### PR TITLE
fix limited mrvs case of `boot_call`

### DIFF
--- a/c/scheme.c
+++ b/c/scheme.c
@@ -340,8 +340,8 @@ static ptr boot_call(tc, p, n) ptr tc; ptr p; INT n; {
             p = Svoid;
             break;
         default:
-            p = S_get_scheme_arg(tc, 0);
-            break;
+            fprintf(stderr, "received %d values in boot_call\n", (int)(iptr)AC1(tc));
+            S_abnormal_exit();
     }
     return p;
 }

--- a/mats/7.ms
+++ b/mats/7.ms
@@ -3622,6 +3622,8 @@ evaluating module init
   (eqv? (exit-code '(exit 0)) 0)
   (eqv? (exit-code '(exit 24 7)) 24)
   (eqv? (exit-code '(exit 0 1 2)) 0)
+  (eqv? (exit-code '(exit 3.14)) 1)
+  (eqv? (exit-code '(exit 9.8 3.14)) 1)
   (begin
     (with-output-to-file "testfile-exit.ss"
       (lambda ()

--- a/mats/7.ms
+++ b/mats/7.ms
@@ -3611,6 +3611,33 @@ evaluating module init
   (error? ; unexpected return from handler
     (parameterize ([exit-handler values])
       (exit 5)))
+  (begin
+    (define (exit-code expr)
+      (if (windows?)
+          (system (format "echo ~s | ~a -q" expr (patch-exec-path *scheme*)))
+          (system (format "echo '~s' | ~a -q" expr *scheme*))))
+    #t)
+  (eqv? (exit-code '(exit)) 0)
+  (eqv? (exit-code '(exit 15)) 15)
+  (eqv? (exit-code '(exit 0)) 0)
+  (eqv? (exit-code '(exit 24 7)) 24)
+  (eqv? (exit-code '(exit 0 1 2)) 0)
+  (begin
+    (with-output-to-file "testfile-exit.ss"
+      (lambda ()
+        (for-each pretty-print
+          '((import (scheme))
+            (apply exit (map string->number (command-line-arguments))))))
+      'replace)
+    #t)
+  (eqv? (system (format "~a --script testfile-exit.ss" (patch-exec-path *scheme*))) 0)
+  (eqv? (system (format "~a --script testfile-exit.ss 5" (patch-exec-path *scheme*))) 5)
+  (eqv? (system (format "~a --script testfile-exit.ss 0 1 2" (patch-exec-path *scheme*))) 0)
+  (eqv? (system (format "~a --script testfile-exit.ss 3 4 5" (patch-exec-path *scheme*))) 3)
+  (eqv? (system (format "~a --program testfile-exit.ss" (patch-exec-path *scheme*))) 0)
+  (eqv? (system (format "~a --program testfile-exit.ss 2" (patch-exec-path *scheme*))) 2)
+  (eqv? (system (format "~a --program testfile-exit.ss 0 1 2" (patch-exec-path *scheme*))) 0)
+  (eqv? (system (format "~a --program testfile-exit.ss 6 7 8" (patch-exec-path *scheme*))) 6)
  )
 
 (mat abort

--- a/s/7.ss
+++ b/s/7.ss
@@ -825,17 +825,19 @@
         (lambda (k)
           (parameterize ([abort-handler
                           (case-lambda [() (k -1)] [(x) (k x)])]
-                         [exit-handler
-                          (case-lambda [() (k (void))] [(x . args) (k x)])]
+                         [exit-handler k]
                          [reset-handler (lambda () (k -1))])
             (apply (scheme-start) fns)))))
     (unless (suppress-greeting)
       (display ($scheme-greeting) (console-output-port))
       (newline (console-output-port))
       (flush-output-port (console-output-port)))
-    (if-feature expeditor
-      (if ($enable-expeditor) ($expeditor go) (go))
-      (go))))
+    (call-with-values
+      (lambda ()
+        (if-feature expeditor
+          (if ($enable-expeditor) ($expeditor go) (go))
+          (go)))
+      (case-lambda [() (void)] [(x . args) x]))))
 
 (set! $script
   (lambda (program? fn fns)


### PR DESCRIPTION
The mrvs case of `boot_call` uses a zero-based index when it looks like it intends a 1-based index, but fixing that doesn't help since the value it's going after isn't saved. Since `boot_call` already handles the case of zero return values and otherwise ignores all but the first return value, it seemed simpler to set up `%ac1` which is already covered by the `save-scheme-state` in the hand-coded `invoke`.

Maybe there is a better fix? Either way, perhaps we can add a fix for this the next time we have a compelling reason to rebuild the boot files. (If we take this change, we can make the obvious simplification in `boot_call`, omitted here to minimize the diff.)

Before:
```
$ echo '(exit 7)' | scheme -q; echo $?
7
$ echo '(exit 4 5 6)' | scheme -q; echo $?
1
$ echo '(exit 0 8 9)' | scheme -q; echo $?
1
```

After: the latter two print 4 and 0 respectively.

I'm not sure what to do about the additional test cases in the commit at the tip of this branch. The [documentation](http://cisco.github.io/ChezScheme/csug9.5/system.html#./system:s156) says they should return -1, but `Sscheme_start` returns 1, which is simpler in cross-platform case, so maybe it's better to update CSUG there?
