### PR TITLE
x86_64: fix foreign-procedure `&` results that are not a multiple of a word

### DIFF
--- a/LOG
+++ b/LOG
@@ -953,3 +953,6 @@
     prim5.c, scheme.c, schlib.c, schsig.c, stats.c, system.h,
     version.h, windows.c, foreign.stex, system.stex, mkheader.ss,
     prims.ss
+- Repair x86_64 `&` foreign-procedure result type handling for types of a
+  small size that is not a multiple of the word size
+    x86_64.ss, foreign.ms, foreign4.c

--- a/mats/foreign.ms
+++ b/mats/foreign.ms
@@ -2736,12 +2736,12 @@
                      (foreign-callable-code-object
                       (ftype-pointer-address id)))
                     v))]))
-           (and (let ([v (make-ftype-pointer T (foreign-alloc (ftype-sizeof T)))])
+           (and (let ([v (make-ftype-pointer T (malloc_at_boundary (ftype-sizeof T)))])
                   (get v)
                   (and (= (T-ref v) vi)
                        ...
                        (begin
-                         (foreign-free (ftype-pointer-address v))
+                         (free_at_boundary (ftype-pointer-address v))
                          #t)))
                 (let ([a (make-ftype-pointer T (malloc_at_boundary (ftype-sizeof T)))])
                   (T-set! a) ...


### PR DESCRIPTION
This is a repair for the main bug report in #320.

I have not yet run the updated tests on ppc32le, but I'll do that tomorrow.
