### PR TITLE
prefer nearest binding name for procedures

### DIFF
--- a/LOG
+++ b/LOG
@@ -960,3 +960,5 @@
     schlib.c
 - Updated csug socket code to match that in examples folder
     csug/foreign.stex, examples/socket.ss
+- Adjust cp0 to not replace a procedure name from a let wrapper
+    cp0.ss, misc.ms

--- a/mats/misc.ms
+++ b/mats/misc.ms
@@ -4948,6 +4948,23 @@
     (procedure-arity-mask 17))
   )
 
+(mat procedure-name
+  (begin
+    (define (procedure-name f)
+      (((inspect/object f) 'code) 'name))
+    (define should-be-named-f (let ([f (lambda (x) x)]) f))
+    (define should-be-named-g (letrec ([g (lambda (x) x)]) g))
+    (define should-be-named-h (let ([f (let ([h (lambda (x) x)]) h)]) f))
+    (define should-be-named-i (letrec ([f (let ([i (lambda (x) x)]) i)]) f))
+    (define should-be-named-j (let ([f (letrec ([j (lambda (x) x)]) j)]) f))
+    #t)
+  (equal? (procedure-name procedure-name) "procedure-name")
+  (equal? (procedure-name should-be-named-f) "f")
+  (equal? (procedure-name should-be-named-g) "g")
+  (equal? (procedure-name should-be-named-h) "h")
+  (equal? (procedure-name should-be-named-i) "i")
+  (equal? (procedure-name should-be-named-j) "j"))
+
 (mat fasl-immutable
   (begin
     (define immutable-objs (list (vector->immutable-vector '#(1 2 3))

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -4538,7 +4538,9 @@
          (let-values ([(e args) (lift-let e e*)])
            (cp0-call preinfo e (build-operands args env wd moi) ctxt env sc wd name moi)))]
       [(case-lambda ,preinfo ,cl* ...)
-       (when (symbol? name)
+       (when (and (symbol? name)
+                  ;; Avoid replacing a name from an optimized-away `let` pattern:
+                  (not (preinfo-lambda-name preinfo)))
          (preinfo-lambda-name-set! preinfo
            (let ([x ($symbol-name name)])
              (if (pair? x) (cdr x) x))))


### PR DESCRIPTION
A macro or compiler can generally give a name to the procedure result of a `lambda` form by wrapping it in `(let ([<name> _]) <name>)`. Currently, though, that local name can get replaced by a different name from the context. For example, in

 (define g (let ([f (lambda (x) x)]) f))

the procedure bound to `g` probably has the name "g", although it depends on whether cp0 is enabled.

In this example, the name "g" ends up being used because `letify` effectively throws away the `let` wrapper and has no way to communicate the discarded name to its context. Although using the outer name could be considered a feature, I think it's probably an intentional consequence of the transformation.

This PR adjusts cp0 so that it doesn't replace a procedure name when one has been given already, and that has the effect of preserving the inner name.