### PR TITLE
add an option `--without-x` to configure, which allows you to build ChezScheme without X11

### DIFF
--- a/LOG
+++ b/LOG
@@ -960,3 +960,5 @@
     schlib.c
 - Updated csug socket code to match that in examples folder
     csug/foreign.stex, examples/socket.ss
+- Add an option --without-x to configure, which allows you to build ChezScheme without X11
+    c/expeditor.c, configure

--- a/c/expeditor.c
+++ b/c/expeditor.c
@@ -15,6 +15,7 @@
  */
 
 #include "system.h"
+#include "config.h"
 
 #ifdef FEATURE_EXPEDITOR
 
@@ -882,6 +883,10 @@ static void s_ee_carriage_return(void) {
 static void s_ee_line_feed(void) {
   putchar(0x0a);
 }
+
+#ifdef _WITHOUT_X_
+#undef LIBX11
+#endif
 
 #ifdef LIBX11
 #include <dlfcn.h>

--- a/configure
+++ b/configure
@@ -37,6 +37,7 @@ installman=""
 installschemename="scheme"
 installpetitename="petite"
 installscriptname="scheme-script"
+withoutx=no
 : ${CC:="gcc"}
 : ${CPPFLAGS:=""}
 : ${CFLAGS:=""}
@@ -200,6 +201,9 @@ while [ $# != 0 ] ; do
     --help)
       help=yes
       ;;
+    --without-x)
+      withoutx=yes
+      ;;
     CC=*)
       CC=`echo $1 | sed -e 's/^CC=//'`
       ;;
@@ -256,6 +260,18 @@ if [ "$installman" = "" ] ; then
   installman=$installprefix/$installmansuffix
 fi
 
+if [ "$withoutx" = "yes" ]; then
+  if [ ! -f c/expeditor.c.ori ]; then
+    mv c/expeditor.c c/expeditor.c.ori    
+  fi
+  sed -e '/#ifdef LIBX11/i\
+    #undef LIBX11' c/expeditor.c.ori > c/expeditor.c
+else
+  if [ -f c/expeditor.c.ori ]; then
+    mv c/expeditor.c.ori c/expeditor.c       
+  fi
+fi
+
 if [ "$help" = "yes" ]; then
   echo "Purpose:"
   echo "  $0 determines the machine type and constructs a custom Makefile"
@@ -266,6 +282,7 @@ if [ "$help" = "yes" ]; then
   echo "  -m=<machine type>                 same as --machine <machine type> ($m)"
   echo "  --threads                         specify threaded version ($threads)"
   echo "  --32|--64                         specify 32/64-bit version ($bits)"
+  echo "  --without-x                       build without X11"
   echo "  --installprefix=<pathname>        final installation root ($installprefix)"
   echo "  --installbin=<pathname>           bin directory ($installbin)"
   echo "  --installlib=<pathname>           lib directory ($installlib)"

--- a/configure
+++ b/configure
@@ -260,18 +260,6 @@ if [ "$installman" = "" ] ; then
   installman=$installprefix/$installmansuffix
 fi
 
-if [ "$withoutx" = "yes" ]; then
-  if [ ! -f c/expeditor.c.ori ]; then
-    mv c/expeditor.c c/expeditor.c.ori    
-  fi
-  sed -e '/#ifdef LIBX11/i\
-    #undef LIBX11' c/expeditor.c.ori > c/expeditor.c
-else
-  if [ -f c/expeditor.c.ori ]; then
-    mv c/expeditor.c.ori c/expeditor.c       
-  fi
-fi
-
 if [ "$help" = "yes" ]; then
   echo "Purpose:"
   echo "  $0 determines the machine type and constructs a custom Makefile"
@@ -384,6 +372,10 @@ cat > $w/c/config.h << END
 #define DEFAULT_HEAP_PATH "$installlib/csv%v/%m"
 #endif
 END
+
+if [ "$withoutx" = "yes" ]; then
+  echo '#define _WITHOUT_X_' >> $w/c/config.h
+fi
 
 cat > $w/c/Mf-config << END
 CC=$CC


### PR DESCRIPTION
On system without X11, you can configure like this, by using the new option `--without-x`, ChezScheme can be built without X11:

```
./configure --installprefix=$HOME/scheme --without-x
make
make install
```

see the new configure's help

```
Purpose:
  ./configure determines the machine type and constructs a custom Makefile
  and Mf-install, taking into account the options below.
Options (defaults shown in parens):
  ...
  --without-x                       build without X11
  ...
```