### PR TITLE
add an option `--disable-x11` to configure, which allows you to build Chez Scheme with X11 disabled

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "system.h": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "system.h": "c"
-    }
-}

--- a/LOG
+++ b/LOG
@@ -960,3 +960,5 @@
     schlib.c
 - Updated csug socket code to match that in examples folder
     csug/foreign.stex, examples/socket.ss
+- add an option --disable-x11
+    c/version.h, configure

--- a/c/version.h
+++ b/c/version.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "config.h"
+
 #if (machine_type == machine_type_arm32le || machine_type == machine_type_tarm32le || machine_type == machine_type_arm64le || machine_type == machine_type_tarm64le)
 #if (machine_type == machine_type_tarm32le || machine_type == machine_type_tarm64le)
 #define PTHREADS
@@ -34,7 +36,9 @@ typedef int tputsputcchar;
 #define LOCKF
 #define DIRMARKERP(c) ((c) == '/')
 #define FLUSHCACHE
+#ifndef DISABLE_X11
 #define LIBX11 "libX11.so"
+#endif
 #define LSEEK lseek64
 #define OFF_T off64_t
 #define _LARGEFILE64_SOURCE
@@ -67,7 +71,9 @@ typedef int tputsputcchar;
 #define LOCKF
 #define DIRMARKERP(c) ((c) == '/')
 #define FLUSHCACHE
+#ifndef DISABLE_X11
 #define LIBX11 "libX11.so"
+#endif
 #define LSEEK lseek64
 #define OFF_T off64_t
 #define _LARGEFILE64_SOURCE
@@ -100,7 +106,9 @@ typedef char *memcpy_t;
 typedef int tputsputcchar;
 #define LOCKF
 #define DIRMARKERP(c) ((c) == '/')
+#ifndef DISABLE_X11
 #define LIBX11 "libX11.so"
+#endif
 #define LSEEK lseek64
 #define OFF_T off64_t
 #define _LARGEFILE64_SOURCE
@@ -133,7 +141,9 @@ typedef char *memcpy_t;
 typedef int tputsputcchar;
 #define LOCKF
 #define DIRMARKERP(c) ((c) == '/')
+#ifndef DISABLE_X11
 #define LIBX11 "libX11.so"
+#endif
 #define SECATIME(sb) (sb).st_atimespec.tv_sec
 #define SECCTIME(sb) (sb).st_ctimespec.tv_sec
 #define SECMTIME(sb) (sb).st_mtimespec.tv_sec
@@ -164,7 +174,9 @@ typedef char *memcpy_t;
 typedef int tputsputcchar;
 #define LOCKF
 #define DIRMARKERP(c) ((c) == '/')
+#ifndef DISABLE_X11
 #define LIBX11 "libX11.so"
+#endif
 #define SECATIME(sb) (sb).st_atimespec.tv_sec
 #define SECCTIME(sb) (sb).st_ctimespec.tv_sec
 #define SECMTIME(sb) (sb).st_mtimespec.tv_sec
@@ -248,7 +260,9 @@ typedef char *memcpy_t;
 typedef int tputsputcchar;
 #define LOCKF
 #define DIRMARKERP(c) ((c) == '/')
+#ifndef DISABLE_X11
 #define LIBX11 "libX11.so"
+#endif
 #define SECATIME(sb) (sb).st_atimespec.tv_sec
 #define SECCTIME(sb) (sb).st_ctimespec.tv_sec
 #define SECMTIME(sb) (sb).st_mtimespec.tv_sec
@@ -279,7 +293,9 @@ typedef char *memcpy_t;
 typedef int tputsputcchar;
 #define LOCKF
 #define DIRMARKERP(c) ((c) == '/')
+#ifndef DISABLE_X11
 #define LIBX11 "/usr/X11R6/lib/libX11.dylib"
+#endif
 #define _DARWIN_USE_64_BIT_INODE
 #define SECATIME(sb) (sb).st_atimespec.tv_sec
 #define SECCTIME(sb) (sb).st_ctimespec.tv_sec
@@ -346,7 +362,9 @@ typedef char *memcpy_t;
 typedef char tputsputcchar;
 #define LOCKF
 #define DIRMARKERP(c) ((c) == '/')
+#ifndef DISABLE_X11
 #define LIBX11 "libX11.so"
+#endif
 #define SECATIME(sb) (sb).st_atim.tv_sec
 #define SECCTIME(sb) (sb).st_ctim.tv_sec
 #define SECMTIME(sb) (sb).st_mtim.tv_sec

--- a/configure
+++ b/configure
@@ -37,6 +37,7 @@ installman=""
 installschemename="scheme"
 installpetitename="petite"
 installscriptname="scheme-script"
+disablex11=no
 : ${CC:="gcc"}
 : ${CPPFLAGS:=""}
 : ${CFLAGS:=""}
@@ -200,6 +201,9 @@ while [ $# != 0 ] ; do
     --help)
       help=yes
       ;;
+    --disable-x11)
+      disablex11=yes
+      ;;
     CC=*)
       CC=`echo $1 | sed -e 's/^CC=//'`
       ;;
@@ -266,6 +270,7 @@ if [ "$help" = "yes" ]; then
   echo "  -m=<machine type>                 same as --machine <machine type> ($m)"
   echo "  --threads                         specify threaded version ($threads)"
   echo "  --32|--64                         specify 32/64-bit version ($bits)"
+  echo "  --disable-x11                     disabling x11"
   echo "  --installprefix=<pathname>        final installation root ($installprefix)"
   echo "  --installbin=<pathname>           bin directory ($installbin)"
   echo "  --installlib=<pathname>           lib directory ($installlib)"
@@ -367,6 +372,10 @@ cat > $w/c/config.h << END
 #define DEFAULT_HEAP_PATH "$installlib/csv%v/%m"
 #endif
 END
+
+if [ "$disablex11" = "yes" ]; then
+  echo '#define DISABLE_X11' >> $w/c/config.h
+fi
 
 cat > $w/c/Mf-config << END
 CC=$CC


### PR DESCRIPTION
# add an option `--disable-x11` to configure, which allows you to build Chez Scheme with X11 disabled

now you can build Chez Scheme like this:

```
./configure --installprefix=$HOME/scheme --disable-x11
make
make install
```

see help by `./configure --help`