### PR TITLE
update tests for "prefer closest binding name"

### DIFF
--- a/LOG
+++ b/LOG
@@ -971,3 +971,5 @@
   bootstrap failures after small changes like the recent change to
   procedure names, so we don't have to rebuild the boot files as often.
     Mf-base
+- Fix tests for cp0 procedure-name change
+    misc.ms, patch-compile-0-f-t-f

--- a/mats/misc.ms
+++ b/mats/misc.ms
@@ -4952,18 +4952,22 @@
   (begin
     (define (procedure-name f)
       (((inspect/object f) 'code) 'name))
+    (define (ok-name? name expect)
+      (or (equal? name expect)
+          ;; interpreter currently doesn't keep names
+          (eq? (current-eval) interpret)))
     (define should-be-named-f (let ([f (lambda (x) x)]) f))
     (define should-be-named-g (letrec ([g (lambda (x) x)]) g))
     (define should-be-named-h (let ([f (let ([h (lambda (x) x)]) h)]) f))
     (define should-be-named-i (letrec ([f (let ([i (lambda (x) x)]) i)]) f))
     (define should-be-named-j (let ([f (letrec ([j (lambda (x) x)]) j)]) f))
     #t)
-  (equal? (procedure-name procedure-name) "procedure-name")
-  (equal? (procedure-name should-be-named-f) "f")
-  (equal? (procedure-name should-be-named-g) "g")
-  (equal? (procedure-name should-be-named-h) "h")
-  (equal? (procedure-name should-be-named-i) "i")
-  (equal? (procedure-name should-be-named-j) "j"))
+  (ok-name? (procedure-name procedure-name) "procedure-name")
+  (ok-name? (procedure-name should-be-named-f) "f")
+  (ok-name? (procedure-name should-be-named-g) "g")
+  (ok-name? (procedure-name should-be-named-h) "h")
+  (ok-name? (procedure-name should-be-named-i) "i")
+  (ok-name? (procedure-name should-be-named-j) "j"))
 
 (mat fasl-immutable
   (begin

--- a/mats/patch-compile-0-f-t-f
+++ b/mats/patch-compile-0-f-t-f
@@ -327,8 +327,8 @@
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure spam".
 ! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments to #<procedure n>".
 ! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments to #<procedure n>".
-  record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments to #<procedure>".
-  record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments to #<procedure>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments to #<procedure pcons>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments to #<procedure pcons>".
 ! record.mo:Expected error in mat r6rs-records-procedural: "incorrect argument count in call (ccons 1)".
 ! record.mo:Expected error in mat r6rs-records-procedural: "incorrect argument count in call (ccons 1 2 3)".
 ! record.mo:Expected error in mat r6rs-records-procedural: "incorrect argument count in call (n (+ z 7) w "what?")".


### PR DESCRIPTION
Some tests need repair for different evaluation modes – such as `interpret` instead of `compiled`, which doesn't preserve names.