### PR TITLE
Trivial change in `configure`: quoted "$m"

### DIFF
--- a/configure
+++ b/configure
@@ -261,7 +261,7 @@ if [ "$installman" = "" ] ; then
 fi
 
 if [ "$disablex11" = "no" ] ; then
-  if [ $m = a6osx ] || [ $m = ta6osx ] ; then
+  if [ "$m" = a6osx ] || [ "$m" = ta6osx ] ; then
     if [ ! -d /opt/X11/include/ ] ; then
       disablex11=yes
     fi


### PR DESCRIPTION
Trivial change in `configure`: quoted "$m" to eliminate irrelevant error messages. See #359.