### PR TITLE
Avoid reading undefined values by zero-initializing allocation

### DIFF
--- a/LOG
+++ b/LOG
@@ -1025,3 +1025,4 @@
   where the cp register copy in the thread context could be changed
   in the callable prep before S_call_help gets it
     cpnanopass.ss, x86_64.ss, x86.ss, foreign2.c, foreign.ms
+- initialize all fields of seginfo to avoid undefined values

--- a/LOG
+++ b/LOG
@@ -1025,4 +1025,5 @@
   where the cp register copy in the thread context could be changed
   in the callable prep before S_call_help gets it
     cpnanopass.ss, x86_64.ss, x86.ss, foreign2.c, foreign.ms
-- initialize all fields of seginfo to avoid undefined values
+- added initialization of seginfo sorted and trigger_ephemerons fields.
+    segment.c

--- a/c/segment.c
+++ b/c/segment.c
@@ -263,7 +263,6 @@ iptr S_find_segments(s, g, n) ISPC s; IGEN g; iptr n; {
 
         chunk->nused_segs += 1;
         initialize_seginfo(si, s, g);
-        si->sorted = 0;
         si->next = S_G.occupied_segments[s][g];
         S_G.occupied_segments[s][g] = si;
         S_G.number_of_empty_segments -= 1;
@@ -302,7 +301,6 @@ iptr S_find_segments(s, g, n) ISPC s; IGEN g; iptr n; {
                 S_G.occupied_segments[s][g] = si;
                 for (j = n, nextsi = si; j > 0; j -= 1, nextsi = nextsi->next) {
                   initialize_seginfo(nextsi, s, g);
-                  nextsi->sorted = 0;
                 }
                 S_G.number_of_empty_segments -= n;
                 return si->number;

--- a/c/segment.c
+++ b/c/segment.c
@@ -228,7 +228,9 @@ static void initialize_seginfo(seginfo *si, ISPC s, IGEN g) {
 
   si->space = s;
   si->generation = g;
+  si->sorted = 0;
   si->min_dirty_byte = 0xff;
+  si->trigger_ephemerons = NULL;
   for (d = 0; d < cards_per_segment; d += sizeof(ptr)) {
     iptr *dp = (iptr *)(si->dirty_bytes + d);
     /* fill sizeof(iptr) bytes at a time with 0xff */


### PR DESCRIPTION
When using the USE_MALLOC allocator instead of USE_MMAP, valgrind gives warnings. The merge request silences the warnings. Maybe better to initialize the relevant fields explicitly instead of zeroing the whole segment.

==16544== Conditional jump or move depends on uninitialised value(s)
==16544==    at 0x11E308: copy (in /home/chn/chez/install/bin/scheme)
==16544==    by 0x126BCD: S_gc_oce (in /home/chn/chez/install/bin/scheme)
==16544==    by 0x114A81: Scompact_heap (in /home/chn/chez/install/bin/scheme)
==16544==    by 0x13AAD7: Sbuild_heap (in /home/chn/chez/install/bin/scheme)
==16544==    by 0x10F9D9: main (in /home/chn/chez/install/bin/scheme)
==16544==  Uninitialised value was created by a heap allocation
==16544==    at 0x483577F: malloc (vg_replace_malloc.c:299)
==16544==    by 0x11071E: S_getmem (in /home/chn/chez/install/bin/scheme)
==16544==    by 0x110B31: S_find_segments (in /home/chn/chez/install/bin/scheme)
==16544==    by 0x111590: S_find_more_room (in /home/chn/chez/install/bin/scheme)
==16544==    by 0x11182F: S_alloc_init (in /home/chn/chez/install/bin/scheme)
==16544==    by 0x13A9D4: Sbuild_heap (in /home/chn/chez/install/bin/scheme)
==16544==    by 0x10F9D9: main (in /home/chn/chez/install/bin/scheme)
