### PR TITLE
avoid stack overflow on fasl-read

### DIFF
--- a/LOG
+++ b/LOG
@@ -1027,3 +1027,5 @@
     cpnanopass.ss, x86_64.ss, x86.ss, foreign2.c, foreign.ms
 - added initialization of seginfo sorted and trigger_ephemerons fields.
     segment.c
+- avoid fasl overflow of C stack
+    fasl.ss, compile.ss, cmacros.ss, fasl.c, 6.ms

--- a/boot/a6le/equates.h
+++ b/boot/a6le/equates.h
@@ -185,6 +185,7 @@ typedef unsigned long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/a6nt/equates.h
+++ b/boot/a6nt/equates.h
@@ -185,6 +185,7 @@ typedef unsigned long long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/a6osx/equates.h
+++ b/boot/a6osx/equates.h
@@ -185,6 +185,7 @@ typedef unsigned long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/i3le/equates.h
+++ b/boot/i3le/equates.h
@@ -186,6 +186,7 @@ typedef unsigned long long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/i3nt/equates.h
+++ b/boot/i3nt/equates.h
@@ -186,6 +186,7 @@ typedef unsigned __int64 U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/i3osx/equates.h
+++ b/boot/i3osx/equates.h
@@ -186,6 +186,7 @@ typedef unsigned long long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/ta6le/equates.h
+++ b/boot/ta6le/equates.h
@@ -185,6 +185,7 @@ typedef unsigned long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/ta6nt/equates.h
+++ b/boot/ta6nt/equates.h
@@ -185,6 +185,7 @@ typedef unsigned long long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/ta6osx/equates.h
+++ b/boot/ta6osx/equates.h
@@ -185,6 +185,7 @@ typedef unsigned long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/ti3le/equates.h
+++ b/boot/ti3le/equates.h
@@ -186,6 +186,7 @@ typedef unsigned long long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/ti3nt/equates.h
+++ b/boot/ti3nt/equates.h
@@ -186,6 +186,7 @@ typedef unsigned __int64 U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/boot/ti3osx/equates.h
+++ b/boot/ti3osx/equates.h
@@ -186,6 +186,7 @@ typedef unsigned long long U64;
 #define fasl_fld_u8 0x1
 #define fasl_header #vu8(0 0 0 0 99 104 101 122)
 #define fasl_type_base_rtd 0x1A
+#define fasl_type_begin 0x29
 #define fasl_type_box 0x1
 #define fasl_type_bytevector 0x1D
 #define fasl_type_closure 0x6

--- a/c/fasl.c
+++ b/c/fasl.c
@@ -961,6 +961,13 @@ static void faslin(ptr tc, ptr *x, ptr t, ptr *pstrbuf, faslFile f) {
             faslin(tc, &INITCDR(p), t, pstrbuf, f);
             return;
         }
+        case fasl_type_begin: {
+            uptr n = uptrin(f) - 1; ptr v;
+            while (n--)
+              faslin(tc, &v, t, pstrbuf, f);
+            faslin(tc, x, t, pstrbuf, f);
+            return;
+        }
         default:
             S_error2("", "invalid object type ~d in fasl file ~a", FIX(ty), f->uf->path);
     }

--- a/mats/6.ms
+++ b/mats/6.ms
@@ -970,6 +970,46 @@
     '(#t #f #t #t #f #t))
 )
 
+(mat fasl-depth
+  (begin
+    (define fasl-deep-N 100000)
+    (define (check v)
+      (let-values ([(o get) (open-bytevector-output-port)])
+        (fasl-write v o)
+        (equal? v (fasl-read (open-bytevector-input-port (get))))))
+    (define (check-mk mk)
+      (check (let loop ([n fasl-deep-N])
+               (if (zero? n)
+                   'done
+                   (mk (loop (sub1 n)))))))
+    (define-record-type other
+      (fields val))
+    (record-type-equal-procedure (record-type-descriptor other)
+                                 (lambda (a b eql?)
+                                   (eql? (other-val a) (other-val b))))
+    #t)
+
+  (check-mk vector)
+  (check-mk box)
+  (check-mk list)
+  (check-mk (lambda (v) (cons 'x v)))
+  (check-mk make-other)
+
+  ;; Generate a chain of code records:
+  (let-values ([(o get) (open-bytevector-output-port)])
+    (compile-to-port
+     (list
+      `(lambda ()
+         ,(let loop ([n fasl-deep-N])
+            (if (zero? n)
+                ''end
+                `(if (stop?)
+                     'stop
+                     ,(loop (sub1 n)))))))
+     o)
+    (fasl-read (open-bytevector-input-port (get)))
+    #t))
+
 (mat clear-output-port ; test interactively
    (procedure? clear-output-port)
  )

--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -455,6 +455,8 @@
 (define-constant fasl-type-immutable-bytevector 39)
 (define-constant fasl-type-immutable-box 40)
 
+(define-constant fasl-type-begin 41)
+
 (define-constant fasl-fld-ptr 0)
 (define-constant fasl-fld-u8 1)
 (define-constant fasl-fld-i16 2)

--- a/s/compile.ss
+++ b/s/compile.ss
@@ -229,48 +229,48 @@
 
 (define c-build-fasl
   (lambda (x t a?)
-    (let build ([x x])
+    (let build ([x x] [d 0])
       (record-case x
-         [(object) (x) ($fasl-enter x t a?)]
+         [(object) (x) ($fasl-enter x t a? d)]
          [(closure) func
-          ($fasl-bld-graph x t a?
-            (lambda (x t a?)
-              (build ($c-func-code-record func))))]
+          ($fasl-bld-graph x t a? d #f
+            (lambda (x t a? d)
+              (build ($c-func-code-record func) d)))]
          [(code) stuff
-          ($fasl-bld-graph x t a?
-            (lambda (x t a?)
+          ($fasl-bld-graph x t a? d #f
+            (lambda (x t a? d)
               (record-case x
                 [(code) (func subtype free name arity-mask size code-list info pinfo*)
-                 ($fasl-enter name t a?)
-                 ($fasl-enter arity-mask t a?)
-                 ($fasl-enter info t a?)
-                 ($fasl-enter pinfo* t a?)
+                 ($fasl-enter name t a? d)
+                 ($fasl-enter arity-mask t a? d)
+                 ($fasl-enter info t a? d)
+                 ($fasl-enter pinfo* t a? d)
                  (for-each
                    (lambda (x)
                      (record-case x
-                       [(abs) (n x) (build x)]
+                       [(abs) (n x) (build x d)]
                        [else
                         (constant-case architecture
                           [(x86)
                            (record-case x
-                             [(rel) (n x) (build x)]
+                             [(rel) (n x) (build x d)]
                              [else (void)])]
                           [(x86_64)
                            (record-case x
-                             [(x86_64-jump x86_64-call) (n x) (build x)]
+                             [(x86_64-jump x86_64-call) (n x) (build x d)]
                              [else (void)])]
                           [(arm32)
                            (record-case x
-                             [(arm32-abs arm32-call arm32-jump) (n x) (build x)]
+                             [(arm32-abs arm32-call arm32-jump) (n x) (build x d)]
                              [else (void)])]
                           [(ppc32)
                            (record-case x
-                             [(ppc32-abs ppc32-call ppc32-jump) (n x) (build x)]
+                             [(ppc32-abs ppc32-call ppc32-jump) (n x) (build x d)]
                              [else (void)])])]))
                    code-list)])))]
-         [(group) elt* (for-each build elt*)]
-         [(revisit-stuff) elt (build elt)]
-         [(visit-stuff) elt (build elt)]))))
+         [(group) elt* (for-each (lambda (elt) (build elt d)) elt*)]
+         [(revisit-stuff) elt (build elt d)]
+         [(visit-stuff) elt (build elt d)]))))
 
 (include "fasl-helpers.ss")
 
@@ -442,8 +442,8 @@
 (define (c-print-fasl x p)
   (let ([t ($fasl-table)] [a? (or (generate-inspector-information) (eq? ($compile-profile) 'source))])
      (c-build-fasl x t a?)
-     ($fasl-start p t
-       (lambda (p) (c-faslobj x t p a?)))))
+     ($fasl-start x p t
+       (lambda (x p) (c-faslobj x t p a?)))))
 
 (define-record-type visit-chunk
   (nongenerative)
@@ -611,8 +611,8 @@
                         (lambda ()
                           (parameterize ([$target-machine (machine-type)])
                             (let ([t ($fasl-table)])
-                              ($fasl-enter x1 t #t)
-                              ($fasl-start wpoop t (lambda (p) ($fasl-out x1 p t #t))))))))))
+                              ($fasl-enter x1 t #t 0)
+                              ($fasl-start x1 wpoop t (lambda (x p) ($fasl-out x p t #t))))))))))
                 (compile-file-help1 x1 op source-info-string)
                 (when hostop
                   ; the host library file contains expander output possibly augmented with
@@ -622,8 +622,8 @@
                     (lambda ()
                       (parameterize ([$target-machine (machine-type)])
                         (let ([t ($fasl-table)])
-                          ($fasl-enter x1 t #t)
-                          ($fasl-start hostop t (lambda (p) ($fasl-out x1 p t #t)))))))))
+                          ($fasl-enter x1 t #t 0)
+                          ($fasl-start x1 hostop t (lambda (x p) ($fasl-out x p t #t)))))))))
               (cfh0 (+ n 1)))))))))
 
 (define library/program-info?
@@ -1378,8 +1378,8 @@
                     (let ([t ($fasl-table)])
                       (let ([x (fold-left (lambda (outer ir) (with-output-language (Lexpand Outer) `(group ,outer ,ir)))
                                  (car ir*) (cdr ir*))])
-                        ($fasl-enter x t #t)
-                        ($fasl-start wpoop t (lambda (p) ($fasl-out x p t #t)))))))))
+                        ($fasl-enter x t #t 0)
+                        ($fasl-start x wpoop t (lambda (x p) ($fasl-out x p t #t)))))))))
             (close-port wpoop))))))
 
   (define build-required-library-list


### PR DESCRIPTION
This patch changes `fasl-write` to avoid generating a fasl content that can cause `fasl-read` to crash.

The `fasl-read` function can crash because it's implemented in the kernel using recursive C calls, which can exhaust the C stack. The change to `fasl-write` detects when nesting has gone 500 layers deep, and for each vale in the next layer, it adds a graph reference to the root of the fasl content. The graph reference has the effect of resetting nesting. (Most of the patch is propagating a depth counter through the graph-construction phase of `fasl-write`.)