### PR TITLE
record revision control information alongside boot files

### DIFF
--- a/LOG
+++ b/LOG
@@ -1247,3 +1247,7 @@
     newrelease pkg/Makefile release_notes.stex
 - update Windows spin-loop count for deleting files and directories
     windows.c
+- install a file containing revision information alongside boot files;
+  embed git revision in exported source archives
+    bintar/Makefile Mf-install.in wininstall/*nt.wxs
+    s/Mf-base s/.gitattributes s/update-revision

--- a/bintar/Makefile
+++ b/bintar/Makefile
@@ -58,7 +58,7 @@ $(R)/examples: $(R)
 
 $(R)/boot: $(R)
 	mkdir -p $(R)/boot/$(m)
-	( cd $(R)/boot/$(m) ; ln -s ../../../../boot/$(m)/{scheme.h,petite.boot,scheme.boot} . )
+	( cd $(R)/boot/$(m) ; ln -s ../../../../boot/$(m)/{scheme.h,petite.boot,scheme.boot,revision} . )
 	case $(m) in \
           *nt) \
             ( cd $R/boot/$(m) ; ln -s ../../../../boot/$(m)/{csv953md.lib,csv953mt.lib,mainmd.obj,mainmt.obj,scheme.res} . ) \

--- a/makefiles/Mf-install.in
+++ b/makefiles/Mf-install.in
@@ -59,6 +59,7 @@ Version=csv9.5.3
 Include=boot/$m
 PetiteBoot=boot/$m/petite.boot
 SchemeBoot=boot/$m/scheme.boot
+Revision=boot/$m/revision
 Scheme=bin/$m/scheme
 Petite=bin/$m/petite
 InstallLibExamples=${InstallLib}/${Version}/examples
@@ -118,6 +119,7 @@ libbininstall: ${LibBin}
 	$I -m 444 ${Include}/kernel.o ${LibBin}
 	$I -m 444 ${Include}/main.o ${LibBin}
 	$I -m 444 ${Include}/scheme.h ${LibBin}
+	$I -m 444 ${Revision} ${LibBin}/revision
 
 maninstall: scheme.1 petite.1 ${Man}
 	$I -m 444 scheme.1 ${Man}/${InstallSchemeName}.1

--- a/s/.gitattributes
+++ b/s/.gitattributes
@@ -1,0 +1,1 @@
+update-revision export-subst

--- a/s/Mf-base
+++ b/s/Mf-base
@@ -97,6 +97,7 @@ PetiteBoot = ../boot/$m/petite.boot
 SchemeBoot = ../boot/$m/scheme.boot
 Cheader = ../boot/$m/scheme.h
 Cequates = ../boot/$m/equates.h
+Revision = ../boot/$m/revision
 
 # The following controls the patch files loaded before compiling, typically used only
 # to load a new compiler for cross compilation
@@ -152,11 +153,11 @@ allsrc =\
  np-languages.ss
 
 # doit uses a different Scheme process to compile each target
-doit: ${PetiteBoot} ${SchemeBoot} ${Cheader} ${Cequates}
+doit: ${PetiteBoot} ${SchemeBoot} ${Cheader} ${Cequates} ${Revision}
 
 # all uses a single Scheme process to compile all targets.  this is typically
 # faster when most of the targets need to be recompiled.
-all: bootall ${Cheader} ${Cequates}
+all: bootall ${Cheader} ${Cequates} ${Revision}
 
 # allx runs all up to three times and checks to see if the new boot file is the
 # same as the last, i.e., the system is properly bootstrapped.
@@ -177,7 +178,7 @@ ifneq ($(OS),Windows_NT)
 endif
 
 # bootstrap runs allx if any sources have changed since the last bootstrap
-bootstrap: ${allsrc}
+bootstrap: ${allsrc} | ${Revision}
 	$(MAKE) allx
 	touch bootstrap
 
@@ -515,6 +516,10 @@ ${Cequates}: mkheader.so ${macroobj} nanopass.so base-lang.ss expand-lang.ss pri
 	(if `cmp -s ${Cequates} ${Cequates}.bak`;\
           then mv -f ${Cequates}.bak ${Cequates};\
           else rm -f ${Cequates}.bak; fi)
+
+.PHONY: ${Revision}
+${Revision}: update-revision
+	@./update-revision > ${Revision}
 
 examples:
 	( cd ../examples && ${MAKE} all Scheme="${Scheme} ../s/${patchfile}" )

--- a/s/update-revision
+++ b/s/update-revision
@@ -1,0 +1,22 @@
+#!/bin/bash
+if [ -d ../../.git ]; then
+  git describe --always --exclude='*' --abbrev=40 --dirty
+  echo 'git'
+elif [ -d ../../.hg ]; then
+  DIRTY="$(hg status -n --color never --pager never | head -1)"
+  hg log --limit 1 --template '{node}' --pager never
+  if [ -n "${DIRTY}" ]; then
+    echo '-dirty'
+  else
+    echo ''
+  fi
+  echo 'hg'
+elif [ -f ../../.hg_archival.txt ]; then
+  # hg archive and hgweb embed this file by default (see .hgrc archivemeta)
+  sed -n 's/^node: \(.*\)/\1/p' < ../../.hg_archival.txt
+  echo 'hg'
+else
+  # use export-subst git attribute to populate revision for git archive
+  echo '$Format:%H$'
+  echo 'git'
+fi

--- a/wininstall/a6nt.wxs
+++ b/wininstall/a6nt.wxs
@@ -63,6 +63,9 @@
         <Component Id="cmp2D19D4386E40826BAD887EB79EB3F163" Guid="*">
           <File Id="fil9BCC9A55DC3F2B6C3A8D1C91FEA34969" KeyPath="yes" Source="..\a6nt\boot\a6nt\scheme.res" />
         </Component>
+        <Component Id="cmp3395E9DB380C4153BF70BA8934BF21D3" Guid="*">
+          <File Id="fil77244B8601F445908549F279EDF7D53A" KeyPath="yes" Source="..\a6nt\boot\a6nt\revision" />
+        </Component>
       </Directory>
     </DirectoryRef>
     <ComponentGroup Id="a6nt">
@@ -82,6 +85,7 @@
       <ComponentRef Id="cmpFD41FA4B58A832ECA2F6DD2072FB9AF4" />
       <ComponentRef Id="cmpCF87ED4A57D979176405C247DF74C089" />
       <ComponentRef Id="cmp2D19D4386E40826BAD887EB79EB3F163" />
+      <ComponentRef Id="cmp3395E9DB380C4153BF70BA8934BF21D3" />
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/wininstall/i3nt.wxs
+++ b/wininstall/i3nt.wxs
@@ -63,6 +63,9 @@
         <Component Id="cmpA1A08D93E33D200E737ED7E9673100F8" Guid="*">
           <File Id="filF377753EF1FFEC581D561C6EB05D2FB0" KeyPath="yes" Source="..\i3nt\boot\i3nt\scheme.res" />
         </Component>
+        <Component Id="cmpFD106B9815864071BE791879BE1131D7" Guid="*">
+          <File Id="fil0461DC04F30E4D8CA37904E3EC271BCB" KeyPath="yes" Source="..\i3nt\boot\i3nt\revision" />
+        </Component>
       </Directory>
     </DirectoryRef>
     <ComponentGroup Id="i3nt">
@@ -82,6 +85,7 @@
       <ComponentRef Id="cmp155E5F6F7512A742AA9C3889EAB1E514" />
       <ComponentRef Id="cmpC59467C5684EC25FD89D53A93AECC3BB" />
       <ComponentRef Id="cmpA1A08D93E33D200E737ED7E9673100F8" />
+      <ComponentRef Id="cmpFD106B9815864071BE791879BE1131D7" />
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/wininstall/ta6nt.wxs
+++ b/wininstall/ta6nt.wxs
@@ -63,6 +63,9 @@
         <Component Id="cmp9E232A9AA21470428B81018123E55809" Guid="*">
           <File Id="fil643F2D7723E96BCA16E8A65804C66B4F" KeyPath="yes" Source="..\ta6nt\boot\ta6nt\scheme.res" />
         </Component>
+        <Component Id="cmp5DCEF420C17742FE89FA4E1EDF6D52D0" Guid="*">
+          <File Id="filBE648AB0CC9C49A7BF6AB7F900EDAC2E" KeyPath="yes" Source="..\ta6nt\boot\ta6nt\revision" />
+        </Component>
       </Directory>
     </DirectoryRef>
     <ComponentGroup Id="ta6nt">
@@ -82,6 +85,7 @@
       <ComponentRef Id="cmpA90C68A50E044FA5FC0FB07B663F6C90" />
       <ComponentRef Id="cmp36B1E9BFDE0DFCA8D1E65BBDAD82CE06" />
       <ComponentRef Id="cmp9E232A9AA21470428B81018123E55809" />
+      <ComponentRef Id="cmp5DCEF420C17742FE89FA4E1EDF6D52D0" />
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/wininstall/ti3nt.wxs
+++ b/wininstall/ti3nt.wxs
@@ -63,6 +63,9 @@
         <Component Id="cmpDEDEC747F47B5ED89E854DCF25F0E14F" Guid="*">
           <File Id="filB7A76F46E9B4F0F7F7B74FEE339025B9" KeyPath="yes" Source="..\ti3nt\boot\ti3nt\scheme.res" />
         </Component>
+        <Component Id="cmp3655144F524A4B35BDF8405560CEAB33" Guid="*">
+          <File Id="fil82E8648E5FB0461EAE31540CE784B2FF" KeyPath="yes" Source="..\ti3nt\boot\ti3nt\revision" />
+        </Component>
       </Directory>
     </DirectoryRef>
   </Fragment>
@@ -84,6 +87,7 @@
       <ComponentRef Id="cmp31F220BF3C0B1F0A17C5C676A56112E2" />
       <ComponentRef Id="cmp8689231D780F12557A0906BBB4BDDC2C" />
       <ComponentRef Id="cmpDEDEC747F47B5ED89E854DCF25F0E14F" />
+      <ComponentRef Id="cmp3655144F524A4B35BDF8405560CEAB33" />
     </ComponentGroup>
   </Fragment>
 </Wix>


### PR DESCRIPTION
This pull request aims to help answer support questions like:
1. what source did I build in this particular workarea?
1. what source was used to build this installed binary?

My original stab at this exposed a `#%$scheme-revision` that we could get at via the repl. That was convenient at run time, but the extra rounds of bootstrapping made that approach irritating at compile time.

I've since scaled back to the much simpler approach of recording minimal revision-control information in a `revision` file alongside the boot files. This seems to work well enough for my use cases.

The `update-revision` script could be extended for folks who mirror the git source in some other revision control system. The git attributes on `update-revision` insert the appropriate revision if folks export the source code via `git archive` or download a tarball or zip file from github.

The WiX updates are guesswork, but seemed to work.
