### PR TITLE
fix uses of `fxzero?` on a 32-bit immediate in 32-bit mode

### DIFF
--- a/LOG
+++ b/LOG
@@ -1353,3 +1353,6 @@
   irritants in the original call when who or message is found not to
   be of the right type.
     exceptions.ss
+- fix incorrect uses of fxzero? x86.ss backend, since a 32-bit
+  immediate is not necessarily a fixnum
+    x86.ss

--- a/s/x86.ss
+++ b/s/x86.ss
@@ -1555,13 +1555,13 @@
       (record-case dest-ea
         [(index) (size index-reg base-reg)
          (cond
-           [(and (fxzero? size) (not (eq? base-reg %ebp))) #f]
+           [(and (eqv? 0 size) (not (eq? base-reg %ebp))) #f]
            [(ax-byte-size? size) (build byte size)]
            [else (build long size)])]
         [(literal@) stuff (cons 'abs stuff)]
         [(disp) (size reg)
          (cond
-           [(and (fxzero? size) (not (eq? reg %ebp))) #f] ; indirect
+           [(and (eqv? 0 size) (not (eq? reg %ebp))) #f] ; indirect
            [(ax-byte-size? size) (build byte size)]
            [else (build long size)])]
         [(reg) r #f]
@@ -1611,13 +1611,13 @@
           (record-case dest-ea
             [(index) (size index-reg base-reg)
              (cond
-               [(and (fxzero? size) (not (eq? base-reg %ebp))) #b00]
+               [(and (eqv? 0 size) (not (eq? base-reg %ebp))) #b00]
                [(ax-byte-size? size) #b01]
                [else #b10])]
             [(literal@) stuff #b00]   
             [(disp) (size reg)
              (cond
-               [(and (fxzero? size) (not (eq? reg %ebp))) #b00] ; indirect
+               [(and (eqv? 0 size) (not (eq? reg %ebp))) #b00] ; indirect
                [(ax-byte-size? size) #b01]
                [else #b10])]
             [(reg) r #b11]


### PR DESCRIPTION
Building the compiler in safe mode for 32-bit x86 reveals incorrect uses of `fxzero?` in "x86.ss": a 32-bit immediate is not necessarily a fixnum.

For example, compilation of "newhash.ss" triggers an error, since it involves an `fx+` on 523658599 which turns into an inline `+` on the immediate 2094634396.

The misuses of `fxzero?` cause no trouble when compiled as unsafe, since that turns into a `eq?` that works as intended in this case.