### PR TITLE
Small fix in relop-length

### DIFF
--- a/LOG
+++ b/LOG
@@ -1368,3 +1368,5 @@
     primdata.ss
 - small fix in relop-length to enable the optimization
     cpnanopass.ss
+- make test for relop-length more sensitive
+    5_2.ms

--- a/mats/5_2.ms
+++ b/mats/5_2.ms
@@ -188,7 +188,7 @@
           [(_ prim)
            (let ()
              (define (f x)
-               (and
+               (list
                  (prim (#3%length x) 0)
                  (prim 0 (#3%length x))
                  (prim (#3%length x) 1)
@@ -204,7 +204,7 @@
                  (let ([n (length x)])
                    (equal?
                      (f x)
-                     (and
+                     (list
                        (prim n 0)
                        (prim 0 n)
                        (prim n 1)


### PR DESCRIPTION
Make two small fixes in `relop-length` for the mirrored case.

Also, in the test replace `(and ...)`  with `(list ...)`, so they detect any discrepancy.

---

Note: While debugging, I tried to test this in scheme.exe adding a few `(display <something>)` here and there. But I couldn't see any change in the output. Do I have to turn on some parameter like `likely-to-be-compiled`?