### PR TITLE
Fix signatures of $file-options and friends

### DIFF
--- a/LOG
+++ b/LOG
@@ -1361,3 +1361,7 @@
     BUILDING, .travis*, wininstall/Makefile
 - fix multiply of -2^30 with itself on 64-bit platforms
     number.c, 5_3.ms, release_notes.stex
+- fix signatures of $file-options and friends
+  They were defined inside a block with the `proc` flag, but they
+  are `enum-set`s.
+    primdata.ss

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1726,7 +1726,6 @@
   ($address-in-heap? [flags])
   ($address->object [flags])
   ($allocate-thread-parameter [feature pthreads] [flags alloc])
-  ($annotation-options [flags])
   ($apply [flags])
   ($assembly-output [flags])
   ($as-time-goes-by [flags])
@@ -1820,10 +1819,8 @@
   ($fasl-file-equal? #;[sig [(pathname pathname) (pathname pathname ptr) -> (boolean)]] [flags])
   ($fasl-out [flags])
   ($fasl-start [flags])
-  ($fasl-strip-options [flags])
   ($fasl-table [flags])
   ($fasl-wrf-graph [flags])
-  ($file-options [flags])
   ($filter-conv [flags])
   ($filter-foreign-type [flags])
   ($fixed-path? [flags])
@@ -2055,7 +2052,6 @@
   ($keep-live [flags])
   ($last-new-vector-element [flags])
   ($lexical-error [flags])
-  ($library-requirements-options [flags])
   ($library-search [flags])
   ($list-length [flags])
   ($load-library [flags])
@@ -2267,6 +2263,13 @@
   ($with-fasl-target [flags])
   ($write-pretty-quick [flags])
   ($xscript-port? [flags])
+)
+
+(define-symbol-flags* ([libraries] [flags system]) ; system options sets
+  ($annotation-options [flags])
+  ($fasl-strip-options [flags])
+  ($file-options [flags])
+  ($library-requirements-options [flags])
 )
 
 (define-symbol-flags* ([libraries] [flags system proc]) ; system parameters


### PR DESCRIPTION
They were defined inside a block with the `proc` flag, but they are `enum-set`s.

This confuses `cp0`. For example

    (enum-set? #3%$file-options) ; ==> #t
    (procedure? #3%$file-options) ; ==> #t (but should be #f)
    (run-cp0 (lambda (cp0 x) x)) ; disable cp0
    (procedure? #3%$file-options) ; ==> #f
