### PR TITLE
Added support for building chez with VS2019.

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -210,10 +210,10 @@ env OS=Windows_NT make
 Prerequisites:
 
 * Bash/WSL, MinGW/MSYS, or Cygwin with bash, git, grep, make, sed, etc.
-* Microsoft Visual Studio 2017 or 2015
+* Microsoft Visual Studio 2019, 2017 or, 2015
 * WiX Toolset (for making an install)
 
-Be sure that git config core.autocrlf is set to false.
+Be sure that git config core.autocrlf is set to false. If you're using VS2019 install C++ 2019 Redistributable MSMs.
 
 To run Chez Scheme or Petite Chez Scheme from a Windows command prompt,
 set PATH:

--- a/BUILDING
+++ b/BUILDING
@@ -210,10 +210,15 @@ env OS=Windows_NT make
 Prerequisites:
 
 * Bash/WSL, MinGW/MSYS, or Cygwin with bash, git, grep, make, sed, etc.
-* Microsoft Visual Studio 2019, 2017 or, 2015
+* Microsoft Visual Studio 2019, 2017, or 2015
 * WiX Toolset (for making an install)
 
-Be sure that git config core.autocrlf is set to false. If you're using VS2019 install C++ 2019 Redistributable MSMs.
+Be sure that git config core.autocrlf is set to false.
+
+If you're using Visual Studio 2019, install "Desktop development with C++"
+on the "Workloads" tabs and the "C++ 2019 Redistributable MSMs" on the
+"Individual components" tab under the "Compilers, build tools, and runtimes"
+section.
 
 To run Chez Scheme or Petite Chez Scheme from a Windows command prompt,
 set PATH:

--- a/LOG
+++ b/LOG
@@ -1370,3 +1370,5 @@
     cpnanopass.ss
 - make test for relop-length more sensitive
     5_2.ms
+- added support for Microsoft Visual Studio 2019 on Windows
+    BUILDING, c/vs.bat, wininstall/locate-vcredist.bat

--- a/c/vs.bat
+++ b/c/vs.bat
@@ -7,6 +7,22 @@ set Applications=%ProgramFiles%
 :: Set up Visual Studio command line environment variables given a
 :: machine type, e.g., amd64 or x86.
 
+:: Visual Studio 2019 Enterprise
+set BATDIR=%Applications%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
+:: Visual Studio 2019 Professional
+set BATDIR=%Applications%\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
+:: Visual Studio 2019 Community
+set BATDIR=%Applications%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
+:: Visual Studio 2019 BuildTools
+set BATDIR=%Applications%\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build
+if exist "%BATDIR%\vcvarsall.bat" goto found
+
 :: Visual Studio 2017 Enterprise
 set BATDIR=%Applications%\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build
 if exist "%BATDIR%\vcvarsall.bat" goto found

--- a/wininstall/locate-vcredist.bat
+++ b/wininstall/locate-vcredist.bat
@@ -7,7 +7,7 @@
   SET "Path64=%CommonProgramFiles(x86)%\Merge Modules\Microsoft_VC140_CRT_x64.msm"
 )
 
-@IF "%VisualStudioVersion%"=="15.0" (
+@IF "%VisualStudioVersion%"=="15.0" or "%VisualStudioVersion%"=="16.0" (
   @PUSHD "%VCINSTALLDIR%Redist\MSVC"
   @FOR /D %%D IN (*) DO (
     @PUSHD %%D


### PR DESCRIPTION
I've made the appropriate changes to support building chez with VS2019. The only problem I encountered when building is that Redistributable MSMs isn't included with any of the default workloads anymore as it's being deprecated. So, I added a note to the windows section of the building document that it needs to be installed.