### PR TITLE
Changes to allow ChezScheme to build on FreeBSD

### DIFF
--- a/c/Mf-a6fb
+++ b/c/Mf-a6fb
@@ -17,7 +17,7 @@ m = a6fb
 Cpu = X86_64
 
 mdinclude = -I/usr/local/include -I/usr/X11R6/include
-mdclib = -L/usr/local/lib -liconv -lm -lncurses
+mdclib = -L/usr/local/lib -liconv -lm -lncurses -luuid
 C = ${CC} ${CPPFLAGS} -Wpointer-arith -Wextra -Werror -O ${CFLAGS}
 o = o
 mdsrc = i3le.c

--- a/c/Mf-i3fb
+++ b/c/Mf-i3fb
@@ -17,7 +17,7 @@ m = i3fb
 Cpu = I386
 
 mdinclude = -I/usr/local/include -I/usr/X11R6/include
-mdclib = -L/usr/local/lib -liconv -lm -lncurses
+mdclib = -L/usr/local/lib -liconv -lm -lncurses -luuid
 C = ${CC} ${CPPFLAGS} -Wpointer-arith -Wextra -Werror -O ${CFLAGS}
 o = o
 mdsrc = i3le.c

--- a/c/Mf-ta6fb
+++ b/c/Mf-ta6fb
@@ -17,7 +17,7 @@ m = ta6fb
 Cpu = X86_64
 
 mdinclude = -I/usr/local/include -I/usr/X11R6/include
-mdclib = -L/usr/local/lib -liconv -lm -lncurses -lpthread
+mdclib = -L/usr/local/lib -liconv -lm -lncurses -lpthread -luuid
 C = ${CC} ${CPPFLAGS} -Wpointer-arith -Wextra -Werror -O2 -D_REENTRANT -pthread ${CFLAGS}
 o = o
 mdsrc = i3le.c

--- a/c/Mf-ti3fb
+++ b/c/Mf-ti3fb
@@ -17,7 +17,7 @@ m = ti3fb
 Cpu = I386
 
 mdinclude = -I/usr/local/include -I/usr/X11R6/include
-mdclib = -L/usr/local/lib -liconv -lm -lncurses -lpthread
+mdclib = -L/usr/local/lib -liconv -lm -lncurses -lpthread -luuid
 C = ${CC} ${CPPFLAGS} -Wpointer-arith -Wextra -Werror -O2 -D_REENTRANT -pthread ${CFLAGS}
 o = o
 mdsrc = i3le.c

--- a/c/externs.h
+++ b/c/externs.h
@@ -45,6 +45,18 @@ off64_t lseek64(int,off64_t,int);
 #include <setjmp.h>
 #endif
 
+#ifndef NORETURN
+
+#if defined(__GNUC__) || defined(__clang__)
+#define NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define NORETURN __declspec(noreturn)
+#else
+#define NORETURN
+#endif /* defined(__GNUC__) || defined(__clang__) */
+
+#endif /* NORETURN */
+
 /* external procedure declarations */
 /* prototypes gen. by ProtoGen Version 0.31 (Haydn Huntley) 1/18/93 */
 
@@ -304,14 +316,14 @@ extern void S_handle_overflow PROTO((void));
 extern void S_handle_overflood PROTO((void));
 extern void S_handle_apply_overflood PROTO((void));
 extern void S_overflow PROTO((ptr tc, iptr frame_request));
-extern void S_error_reset PROTO((const char *s));
-extern void S_error_abort PROTO((const char *s));
-extern void S_abnormal_exit PROTO((void));
-extern void S_error PROTO((const char *who, const char *s));
-extern void S_error1 PROTO((const char *who, const char *s, ptr x));
-extern void S_error2 PROTO((const char *who, const char *s, ptr x, ptr y));
-extern void S_error3 PROTO((const char *who, const char *s, ptr x, ptr y, ptr z));
-extern void S_boot_error PROTO((const ptr who, ptr s, ptr args));
+extern void S_error_reset PROTO((const char *s)) NORETURN;
+extern void S_error_abort PROTO((const char *s)) NORETURN;
+extern void S_abnormal_exit PROTO((void)) NORETURN;
+extern void S_error PROTO((const char *who, const char *s)) NORETURN;
+extern void S_error1 PROTO((const char *who, const char *s, ptr x)) NORETURN;
+extern void S_error2 PROTO((const char *who, const char *s, ptr x, ptr y)) NORETURN;
+extern void S_error3 PROTO((const char *who, const char *s, ptr x, ptr y, ptr z)) NORETURN;
+extern void S_boot_error PROTO((const ptr who, ptr s, ptr args)) NORETURN;
 extern void S_handle_docall_error PROTO((void));
 extern void S_handle_arg_error PROTO((void));
 extern void S_handle_nonprocedure_symbol PROTO((void));
@@ -319,7 +331,7 @@ extern void S_handle_values_error PROTO((void));
 extern void S_handle_mvlet_error PROTO((void));
 extern void S_register_scheme_signal PROTO((iptr sig));
 extern void S_fire_collector PROTO((void));
-extern void S_noncontinuable_interrupt PROTO((void));
+extern void S_noncontinuable_interrupt PROTO((void)) NORETURN;
 extern void S_schsig_init PROTO((void));
 #ifdef DEFINE_MATHERR
 #include <math.h>

--- a/c/externs.h
+++ b/c/externs.h
@@ -49,8 +49,6 @@ off64_t lseek64(int,off64_t,int);
 
 #if defined(__GNUC__) || defined(__clang__)
 #define NORETURN __attribute__((noreturn))
-#elif defined(_MSC_VER)
-#define NORETURN __declspec(noreturn)
 #else
 #define NORETURN
 #endif /* defined(__GNUC__) || defined(__clang__) */

--- a/c/externs.h
+++ b/c/externs.h
@@ -49,6 +49,8 @@ off64_t lseek64(int,off64_t,int);
 
 #if defined(__GNUC__) || defined(__clang__)
 #define NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define NORETURN __declspec(noreturn)
 #else
 #define NORETURN
 #endif /* defined(__GNUC__) || defined(__clang__) */
@@ -314,14 +316,14 @@ extern void S_handle_overflow PROTO((void));
 extern void S_handle_overflood PROTO((void));
 extern void S_handle_apply_overflood PROTO((void));
 extern void S_overflow PROTO((ptr tc, iptr frame_request));
-extern void S_error_reset PROTO((const char *s)) NORETURN;
-extern void S_error_abort PROTO((const char *s)) NORETURN;
-extern void S_abnormal_exit PROTO((void)) NORETURN;
-extern void S_error PROTO((const char *who, const char *s)) NORETURN;
-extern void S_error1 PROTO((const char *who, const char *s, ptr x)) NORETURN;
-extern void S_error2 PROTO((const char *who, const char *s, ptr x, ptr y)) NORETURN;
-extern void S_error3 PROTO((const char *who, const char *s, ptr x, ptr y, ptr z)) NORETURN;
-extern void S_boot_error PROTO((const ptr who, ptr s, ptr args)) NORETURN;
+NORETURN extern void S_error_reset PROTO((const char *s));
+NORETURN extern void S_error_abort PROTO((const char *s));
+NORETURN extern void S_abnormal_exit PROTO((void));
+NORETURN extern void S_error PROTO((const char *who, const char *s));
+NORETURN extern void S_error1 PROTO((const char *who, const char *s, ptr x));
+NORETURN extern void S_error2 PROTO((const char *who, const char *s, ptr x, ptr y));
+NORETURN extern void S_error3 PROTO((const char *who, const char *s, ptr x, ptr y, ptr z));
+NORETURN extern void S_boot_error PROTO((const ptr who, ptr s, ptr args));
 extern void S_handle_docall_error PROTO((void));
 extern void S_handle_arg_error PROTO((void));
 extern void S_handle_nonprocedure_symbol PROTO((void));
@@ -329,7 +331,7 @@ extern void S_handle_values_error PROTO((void));
 extern void S_handle_mvlet_error PROTO((void));
 extern void S_register_scheme_signal PROTO((iptr sig));
 extern void S_fire_collector PROTO((void));
-extern void S_noncontinuable_interrupt PROTO((void)) NORETURN;
+NORETURN extern void S_noncontinuable_interrupt PROTO((void));
 extern void S_schsig_init PROTO((void));
 #ifdef DEFINE_MATHERR
 #include <math.h>

--- a/c/schsig.c
+++ b/c/schsig.c
@@ -21,7 +21,7 @@
 static void S_promote_to_multishot PROTO((ptr k));
 static void split PROTO((ptr k, ptr *s));
 static void reset_scheme PROTO((void));
-static void do_error PROTO((iptr type, const char *who, const char *s, ptr args));
+static void do_error PROTO((iptr type, const char *who, const char *s, ptr args)) NORETURN;
 static void handle_call_error PROTO((ptr tc, iptr type, ptr x));
 static void init_signal_handlers PROTO((void));
 static void keyboard_interrupt PROTO((ptr tc));

--- a/c/schsig.c
+++ b/c/schsig.c
@@ -21,7 +21,7 @@
 static void S_promote_to_multishot PROTO((ptr k));
 static void split PROTO((ptr k, ptr *s));
 static void reset_scheme PROTO((void));
-static void do_error PROTO((iptr type, const char *who, const char *s, ptr args)) NORETURN;
+NORETURN static void do_error PROTO((iptr type, const char *who, const char *s, ptr args));
 static void handle_call_error PROTO((ptr tc, iptr type, ptr x));
 static void init_signal_handlers PROTO((void));
 static void keyboard_interrupt PROTO((ptr tc));

--- a/c/stats.c
+++ b/c/stats.c
@@ -210,7 +210,8 @@ void S_gettime(INT typeno, struct timespec *tp) {
 #ifdef CLOCK_THREAD_CPUTIME_ID
       if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, tp) == 0) return;
 #endif
-     /* fall through to utc case in case no thread timer */
+     /* fall through */
+     /* to utc case in case no thread timer */
     case time_process:
 #ifdef CLOCK_PROCESS_CPUTIME_ID
       if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, tp) == 0) return;
@@ -240,7 +241,8 @@ void S_gettime(INT typeno, struct timespec *tp) {
 #ifdef CLOCK_HIGHRES
       if (clock_gettime(CLOCK_HIGHRES, tp) == 0) return;
 #endif
-     /* fall through to utc case in case no monotonic timer */
+     /* fall through */
+     /* to utc case in case no monotonic timer */
     case time_utc:
 #ifdef CLOCK_REALTIME_HR
       if (clock_gettime(CLOCK_REALTIME_HR, tp) == 0) return;

--- a/makefiles/Makefile.in
+++ b/makefiles/Makefile.in
@@ -47,9 +47,9 @@ clean:
 	(cd $(workarea) && $(MAKE) clean)
 
 distclean:
-	(cd csug && if [ -e Makefile ] ; then make reallyreallyclean ; fi)
+	(cd csug && if [ -e Makefile ] ; then $(MAKE) reallyreallyclean ; fi)
 	rm -f csug/Makefile
-	(cd release_notes && if [ -e Makefile ] ; then make reallyreallyclean ; fi)
+	(cd release_notes && if [ -e Makefile ] ; then $(MAKE) reallyreallyclean ; fi)
 	rm -f release_notes/Makefile
 	rm -rf $(workarea)
 	rm -f Makefile

--- a/s/update-revision
+++ b/s/update-revision
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 if [ -d ../../.git ]; then
   git describe --always --exclude='*' --abbrev=40 --dirty
   echo 'git'


### PR DESCRIPTION
In this PR are commits which allow ChezScheme to build on FreeBSD successfully.

I have only tested those commits on `a6fb` and `ta6fb` variants.

Some of the changes have been motivated by gcc's `-Wimplicit-fallthrough` which is enabled by `-Wextra` in gcc 7 or above. It has been already commented in other issue tickets that the warning can be suppressed by adding `-Wno-implicit-fallthrough` to relevant Mf-* makefiles under `c` directory. I'm taking a different approach, changing the source code to resolve the warning. I think this approach is more robust because this should automatically work for all platforms and this avoids requiring people to send in makefile corrections one by one via PRs whenever they encounter the same issue for their own platform.

The main change is addition of `NORETURN` macro to `externs.h` which expand to `___attribute__((noreturn))` or `__declspec(noreturn)` depending on compiler type.

gcc 7 or above will raise implicit fallthrough warnings when certain functions are used in switch case statements. If it has no way of knowing those functions won't return then it assumes fallthrough could occur.

Based on visual inspection of the relevant definitions for the various S_error* and friends in `schsig.c` and directly calling those functions in my test cases, as far as I can tell those functions don't return. Annotating those functions with `NORETURN` help gcc' static analysis.

Also in some places I added `/* fall through */` comments as appropriate since gcc 7 or above will recognize certain comments as signaling that fallthrough is intended.

Other commits deal with fixing some things and adding `-luuid` as needed.