### PR TITLE
Use setenv rather than putenv on non WIN32 environments

### DIFF
--- a/LOG
+++ b/LOG
@@ -1374,3 +1374,4 @@
     BUILDING, c/vs.bat, wininstall/locate-vcredist.bat
 - fixed open-string-input-port on immutable strings
     cpnanopass.ss, io.ms, release_notes.stex
+- use setenv rather than putenv on non WIN32 environments

--- a/c/prim5.c
+++ b/c/prim5.c
@@ -1372,11 +1372,7 @@ static void s_putenv(name, value) char *name, *value; {
   if (rc == 0)
     S_error1("putenv", "environment extension failed: ~a", S_LastErrorString());
 #else /* WIN32 */
-  iptr n; char *s;
-  n = strlen(name) + strlen(value) + 2;
-  if ((s = malloc(n)) == (char *)NULL
-       || snprintf(s, n, "%s=%s", name, value) < 0
-       || putenv(s) != 0) {
+  if (setenv(name, value, 1) != 0) {
     ptr msg = S_strerror(errno);
 
     if (msg != Sfalse)

--- a/csug/system.stex
+++ b/csug/system.stex
@@ -5095,8 +5095,6 @@ is associated with \var{key}.
 environment of the process,
 where it is available to the current process (e.g., via \var{getenv})
 and any spawned processes.
-The key and value are copied into storage allocated outside of
-the Scheme heap; this space is never reclaimed on non-Windows systems.
 
 \schemedisplay
 (putenv "SCHEME" "rocks!")

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1695,6 +1695,12 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{\protect\code{putenv} memory leak (9.5.3)}
+
+\scheme{putenv} now calls the host system's \scheme{setenv} instead of
+\scheme{putenv} on non-Windows hosts and avoids allocating memory that
+is never freed, although \scheme{setenv} might do so.
+
 \subsection{String ports from immutable strings (9.5.4)}
 
 A bug that miscalculated the buffer size for


### PR DESCRIPTION
Signed-off-by: Alexander Shopov <ash@kambanaria.org>