### PR TITLE
Add additional check to prevent going before start of buffer

### DIFF
--- a/LOG
+++ b/LOG
@@ -1385,3 +1385,5 @@
     s/update-revision, BUILDING
 - export `ee-backward-delete-sexp` binding in the expression-editor module.
     expeditor.ss
+- prevent access before start of array
+    c/scheme.c

--- a/c/scheme.c
+++ b/c/scheme.c
@@ -530,7 +530,7 @@ static IBOOL next_path(path, name, ext, sp, dsp) char *path; const char *name, *
   /* unless entry was null, append name and ext onto path and return true with
    * updated path, sp, and possibly dsp */
     if (s != *sp) {
-      if (!DIRMARKERP(*(p - 1))) { setp(PATHSEP); }
+      if ((p > path) && !DIRMARKERP(*(p - 1))) { setp(PATHSEP); }
       t = name;
       while (*t != 0) setp(*t++);
       t = ext;


### PR DESCRIPTION
p is a pointer that iterates over path, which is buffer.
We should not try to get to an address preceding its start
Since there was an execution path that leads to that
guard against this with an additional check.

Signed-off-by: Alexander Shopov <ash@kambanaria.org>