### PR TITLE
Restore ability to build on Solaris-like systems

### DIFF
--- a/LOG
+++ b/LOG
@@ -1393,3 +1393,4 @@
     compress-io.c, new-io.c
 - fixed tab character in makefiles
     c/Mf-*nt
+- restore building on Solaris

--- a/c/Mf-a6s2
+++ b/c/Mf-a6s2
@@ -16,7 +16,7 @@
 m = a6s2
 Cpu = X86_64
 
-mdclib = -lnsl -ldl -lm ${cursesLib} -lrt
+mdclib = -lnsl -ldl -lm ${cursesLib} -lrt -luuid
 C = ${CC} ${CPPFLAGS} -m64 -Wpointer-arith -Wextra -Werror -O ${CFLAGS}
 o = o
 mdsrc = i3le.c
@@ -31,7 +31,7 @@ mdobj = i3le.o
 include Mf-base
 
 ${KernelO}: ${kernelobj} ${zlibDep} ${LZ4Dep}
-	${LD} -melf_x86_64 -r -X -o ${KernelO} ${kernelobj} ${zlibLib} ${LZ4Lib}
+	${LD} -r -o ${KernelO} ${kernelobj} ${zlibLib} ${LZ4Lib}
 
 ${KernelLib}: ${kernelobj}
 	${AR} ${ARFLAGS} ${KernelLib} ${kernelobj}

--- a/c/Mf-i3s2
+++ b/c/Mf-i3s2
@@ -16,7 +16,7 @@
 m = i3s2
 Cpu = I386
 
-mdclib = -lnsl -ldl -lm ${cursesLib} -lrt
+mdclib = -lnsl -ldl -lm ${cursesLib} -lrt -luuid
 C = ${CC} ${CFLAGS} -m32 -Wpointer-arith -Wextra -Werror -O ${CPPFLAGS}
 o = o
 mdsrc = i3le.c
@@ -31,7 +31,7 @@ mdobj = i3le.o
 include Mf-base
 
 ${KernelO}: ${kernelobj} ${zlibDep} ${LZ4Dep}
-	${LD} -melf_i386 -r -X -o ${KernelO} ${kernelobj} ${zlibLib} ${LZ4Lib}
+	${LD} -r -o ${KernelO} ${kernelobj} ${zlibLib} ${LZ4Lib}
 
 ${KernelLib}: ${kernelobj}
 	${AR} ${ARFLAGS} ${KernelLib} ${kernelobj}

--- a/c/Mf-ta6s2
+++ b/c/Mf-ta6s2
@@ -16,7 +16,7 @@
 m = ta6s2
 Cpu = X86_64
 
-mdclib = -lnsl -ldl -lm -lpthread ${cursesLib} -lrt
+mdclib = -lnsl -ldl -lm -lpthread ${cursesLib} -lrt -luuid
 C = ${CC} ${CPPFLAGS} -m64 -Wpointer-arith -Wextra -Werror -O2 -D_REENTRANT ${CFLAGS}
 o = o
 mdsrc = i3le.c
@@ -31,7 +31,7 @@ mdobj = i3le.o
 include Mf-base
 
 ${KernelO}: ${kernelobj} ${zlibDep} ${LZ4Dep}
-	${LD} -melf_x86_64 -r -X -o ${KernelO} ${kernelobj} ${zlibLib} ${LZ4Lib}
+	${LD} -r -o ${KernelO} ${kernelobj} ${zlibLib} ${LZ4Lib}
 
 ${KernelLib}: ${kernelobj}
 	${AR} ${ARFLAGS} ${KernelLib} ${kernelobj}

--- a/c/Mf-ti3s2
+++ b/c/Mf-ti3s2
@@ -16,7 +16,7 @@
 m = ti3s2
 Cpu = I386
 
-mdclib = -lnsl -ldl -lm -lpthread ${cursesLib} -lrt
+mdclib = -lnsl -ldl -lm -lpthread ${cursesLib} -lrt -luuid
 C = ${CC} ${CPPFLAGS} -m32 -Wpointer-arith -Wextra -Werror -O2 -D_REENTRANT ${CFLAGS}
 o = o
 mdsrc = i3le.c
@@ -31,7 +31,7 @@ mdobj = i3le.o
 include Mf-base
 
 ${KernelO}: ${kernelobj} ${zlibDep} ${LZ4Dep}
-	${LD} -melf_i386 -r -X -o ${KernelO} ${kernelobj} ${zlibLib} ${LZ4Lib}
+	${LD} -r -o ${KernelO} ${kernelobj} ${zlibLib} ${LZ4Lib}
 
 ${KernelLib}: ${kernelobj}
 	${AR} ${ARFLAGS} ${KernelLib} ${kernelobj}

--- a/c/stats.c
+++ b/c/stats.c
@@ -462,7 +462,11 @@ static long adjust_time_zone(ptr dtvec, struct tm *tmxp, ptr given_tzoff) {
     }
   }
 #else
+# if defined(SOLARIS)
+  tzoff = tmxp->tm_isdst ? -altzone : -timezone;
+# else
   tzoff = tmxp->tm_gmtoff;
+# endif
   if (given_tzoff == Sfalse) {
 # if defined(__linux__) || defined(SOLARIS)
     /* Linux and Solaris set `tzname`: */


### PR DESCRIPTION
- Need `-luuid` for `uuid_generate`
- Use the native `ld(1)` instead of GNU.  If this is undesirable, the machine specification needs to be changed to `elf_i386_sol2` and `elf_x86_64_sol2`, which I can do instead
- Use the libc global `timezone` and `altzone` to make up for the lack of `tm_gmtoff`.

Even after this, there are two classes of problems in the tests, one, from the summary file, is

```
> io.mo:Error in mat iconv-codec clause 6: "transcoded-port: unsupported encoding GB18030" at line 688, char 7 of io.ms
> io.mo:Error in mat iconv-codec clause 14: "put-string: iconv UTF-8 codec cannot encode #\xFFFE" at line 979, char 7 of io.ms
> io.mo:Bug in mat iconv-codec clause 10 at line 788, char 7 of io.ms
> io.mo:Bug in mat iconv-codec clause 11 at line 813, char 7 of io.ms
> io.mo:Bug in mat iconv-codec clause 12 at line 824, char 7 of io.ms
6607,6608d6611
< io.mo:Expected error in mat iconv-codec: "close-port: iconv CP1252 codec cannot encode #\x3BB".
< io.mo:Expected error in mat iconv-codec: "close-port: iconv CP1252 codec cannot encode #\newline with eol-style ls".
```

This seems entirely due to the different behaviour of the iconv implementation on Solaris-like systems.

The other problem is a deadlock running the tests with `eval=interpret`, where both parent and child process are waiting on a `read()` from a pipe between them.  This seems likely to be the classic deadlock brought on by the unusually (for the times) small buffer used for `pipe(2)` on Solaris-like systems, but I'm not sure how to break into either scheme process to get the scheme stack at the time to narrow down exactly where it is.