### PR TITLE
Initialize n to 0

### DIFF
--- a/LOG
+++ b/LOG
@@ -1759,3 +1759,5 @@
 - used with-object-file to restore accidentally dropped close-port in
   compile-whole-program and compile-whole-library
     compile.ss
+- initialized variable to enable compilation with 9.1.0 at -O3
+    c/scheme.c

--- a/c/scheme.c
+++ b/c/scheme.c
@@ -572,7 +572,8 @@ static void check_boot_file_state PROTO((const char *who));
 
 static IBOOL find_boot(name, ext, fd, errorp) const char *name, *ext; int fd; IBOOL errorp; {
   char pathbuf[PATH_MAX], buf[PATH_MAX];
-  uptr n; INT c;
+  uptr n = 0;
+  INT c;
   const char *path;
 #ifdef WIN32
   wchar_t *expandedpath;


### PR DESCRIPTION
gcc 9.1.0 fails to compile with -Werror and -O3 because it detects that `n` might be used uninitialize in line
`if (n != scheme_version) {`

We do know that `n` will be initialized in `if (zget_uptr(file, &n) != 0) {` but gcc doesn't know that unless compiled with LTO.