### PR TITLE
close port in compile-whole-program and compile-whole-library

### DIFF
--- a/LOG
+++ b/LOG
@@ -1756,3 +1756,6 @@
   argument-type-check error messages, for Windows multibyte->string
   and string->multibyte.
     primvars.ms
+- used with-object-file to restore accidentally dropped close-port in
+  compile-whole-program and compile-whole-library
+    compile.ss

--- a/s/compile.ss
+++ b/s/compile.ss
@@ -1495,21 +1495,20 @@
 
   (define finish-compile
     (lambda (who msg ifn ofn hash-bang-line x1)
-      (let ([op ($open-file-output-port who ofn (file-options replace))])
-        (on-reset (delete-file ofn #f)
-          (on-reset (close-port op)
-            (with-coverage-file who ofn
-              (lambda (source-table)
-                (when hash-bang-line (put-bytevector op hash-bang-line))
-                (when (compile-compressed) (port-file-compressed! op))
-                (parameterize ([$target-machine (constant machine-type-name)]
-                               ; dummy sfd for block-profile optimization
-                               [$sfd (make-source-file-descriptor ifn #xc7 #xc7c7)]
-                               [$block-counter 0])
-                  (when source-table ($insert-profile-src! source-table x1))
-                  (emit-header op (constant machine-type))
-                  (let-values ([(rcinfo* final*) (compile-file-help1 x1 msg)])
-                    (compile-file-help2 op (list rcinfo*) (list final*)))))))))))
+      (with-object-file who ofn #f
+        (lambda (op)
+          (with-coverage-file who ofn
+            (lambda (source-table)
+              (when hash-bang-line (put-bytevector op hash-bang-line))
+              (when (compile-compressed) (port-file-compressed! op))
+              (parameterize ([$target-machine (constant machine-type-name)]
+                             ; dummy sfd for block-profile optimization
+                             [$sfd (make-source-file-descriptor ifn #xc7 #xc7c7)]
+                             [$block-counter 0])
+                (when source-table ($insert-profile-src! source-table x1))
+                (emit-header op (constant machine-type))
+                (let-values ([(rcinfo* final*) (compile-file-help1 x1 msg)])
+                  (compile-file-help2 op (list rcinfo*) (list final*))))))))))
 
   (define write-wpo-file
     (lambda (who ofn ir*)


### PR DESCRIPTION
The `(close-port op)` in the `finish-compile` called by `compile-whole-program` and friends appears to have been dropped during the recent reorganization.

I don't have a simple test program, but changing this fixed some issues for me in the Swish mats (some are still broken since we relied on concatenating .so files).

Edit: updated branch to use the new-fangled with-object-file. Seemed to work for me.