### PR TITLE
fix typo in WIPECLEAN

### DIFF
--- a/c/gc.c
+++ b/c/gc.c
@@ -1179,7 +1179,7 @@ void GCENTRY(ptr tc, IGEN mcg, IGEN tg) {
         si->next = chunk->unused_segs;
         chunk->unused_segs = si;
 #ifdef WIPECLEAN
-        memset((void *)build_ptr(seg,0), 0xc7, bytes_per_segment);
+        memset((void *)build_ptr(si->number,0), 0xc7, bytes_per_segment);
 #endif
         if ((chunk->nused_segs -= 1) == 0) {
           if (chunk->bytes != (minimum_segment_request + 1) * bytes_per_segment) {


### PR DESCRIPTION
It looks like the WIPECLEAN code got out of date. Not sure if my attempted fix is on target.