### PR TITLE
fix missing continuation call in `cp-push-mvrs`

### DIFF
--- a/LOG
+++ b/LOG
@@ -1769,3 +1769,7 @@
   is enabled, so local transformer code can be profiled.
     syntax.ss,
     profile.ms
+- fix compiler bug related to call-with-values and a first argument
+  whose body result is compiled to an allocation, inline form, or
+  foreign call
+    cpnanopass.ss, 3.ms

--- a/mats/3.ms
+++ b/mats/3.ms
@@ -2069,6 +2069,24 @@
         (lambda l (equal? l '((7)))))
       #t
       #f)
+
+  ; regression test for handling mvcall with inline form
+  (equal?
+   '(result x)
+   (let ([bx (box #f)])
+     (define-record-type thing
+       (fields pos)
+       (nongenerative #{thing hlg584lmg5htbdauw7dkid2sh-0}))
+     (set-box! bx (make-thing 'x))
+     (let ([posx (unbox bx)])
+       (cons 'result
+             (call-with-values
+                 (lambda ()
+                   (if (thing? posx)
+                       ;; compiled as inline load:
+                       (thing-pos posx)
+                       (do-something-else)))
+               list)))))
 )
 
 (mat let-values

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -9738,7 +9738,7 @@
                  (let ([tmp (make-tmp 't)])
                    `(seq
                       (set! ,tmp ,rhs)
-                      (mvcall ,(make-info-call (info-call-src info) (info-call-sexpr info) #f #f #f) #f ,consumer ,tmp ())))]
+                      ,(k `(mvcall ,(make-info-call (info-call-src info) (info-call-sexpr info) #f #f #f) #f ,consumer ,tmp ()))))]
                 [else ; set! & mvset
                  `(seq ,e ,(k `(mvcall ,(make-info-call (info-call-src info) (info-call-sexpr info) #f #f #f) #f ,consumer ,(%constant svoid) ())))])))))
       (CaseLambdaClause : CaseLambdaClause (ir) -> CaseLambdaClause ()


### PR DESCRIPTION
In `np-push-mrvs`'s `Mvcall`, the continuation `k` wasn't used in the case for alloc, inline, and foreign-call expressions, so the result of a `call-with-values` form could get lost in a non-tail position. In the example below, the result of `(thing-pos posx)` gets lost.

```
;; cp0 is needed to expose `record-ref`:
(run-cp0 (lambda (cp0 x)
           (let ([r (cp0 x)])
             r)))

(define miscompiled
  (lambda (bx)
    (define-record-type thing
      (fields pos)
      (nongenerative #{thing hlg584lmg5htbdauw7dkid2sh-0}))
    (set-box! bx (make-thing 'x))
    (let ([posx (unbox bx)])
      (cons 'result
            (call-with-values
                (lambda ()
                  (if (thing? posx)
                      ;; compiled as inline load:
                      (thing-pos posx)
                      (do-something-else)))
              list)))))

;; Should print`(result x)`
(printf "~s\n" (miscompiled (box #f)))
```
