### PR TITLE
Exclude unresolved symbol scheme_signals_registered on Win32 builds

### DIFF
--- a/c/schsig.c
+++ b/c/schsig.c
@@ -770,7 +770,9 @@ void S_schsig_init() {
 
         S_protect(&S_G.error_id);
         S_G.error_id = S_intern((const unsigned char *)"$c-error");
+#ifndef WIN32
         scheme_signals_registered = 0;
+#endif
     }
 
 


### PR DESCRIPTION
Commit 72d90e4c67849908da900d0b6249a1dedb5f8c7f ("library-manager, numeric, and bytevector-compres
improvements") introduced a regression causing Win32 nmake builds to
fail due to an undefined symbol in c\schsig.c.

This symbol (scheme_signals_registered) is defined in a preprocessor-
conditional code block excluding WIN32 between lines 544 and 737.

This commit bypasses the build regression by enclosing the unresolved
expression in a preprocessor conditional excluding WIN32.

See GitHub Issue #497 for more details:
https://github.com/cisco/ChezScheme/issues/497