### PR TITLE
Fix fasl-read signature

### DIFF
--- a/LOG
+++ b/LOG
@@ -1945,3 +1945,5 @@
     compress_io.c, new_io.c, externs.h,
     bytevector.ms, mats/Mf-base, root-experr*
     io.stex, objects.stex, release_notes.stex
+- fix fasl-read signature
+    primdata.ss

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1284,7 +1284,7 @@
   (expand/optimize [sig [(ptr) (ptr environment) -> (ptr)]] [flags])
   (expt-mod [sig [(integer integer integer) -> (integer)]] [flags arith-op mifoldable discard])
   (fasl-file [sig [(pathname pathname) -> (void)]] [flags true])
-  (fasl-read [sig [(binary-input-port) (binary-input-port sub-symbol) -> (ptr)]] [flags true])
+  (fasl-read [sig [(binary-input-port) (binary-input-port sub-symbol) -> (ptr)]] [flags])
   (fasl-write [sig [(sub-ptr binary-output-port) -> (void)]] [flags true])
   (file-access-time [sig [(pathname) (pathname ptr) -> (time)]] [flags discard])
   (file-change-time [sig [(pathname) (pathname ptr) -> (time)]] [flags discard])


### PR DESCRIPTION
The result of `fasl-read` may be `#f`.

Example from @mflatt :

    (let-values ([(o get) (open-bytevector-output-port)])
      (fasl-write #f o)
      (if (fasl-read (open-bytevector-input-port (get)))
          'wrong
          'correct))