### PR TITLE
Fix makefile for MSYS2

### DIFF
--- a/LOG
+++ b/LOG
@@ -1997,3 +1997,6 @@
 - fixed csug copyright year substititions and changed revisiondate
   to not be generated, making the csug build reproducible
     newrelease csug/csug.stex
+- fixed Windows build using MSYS2
+    c/Mf-a6nt, c/Mf-i3nt, c/Mf-ta6nt, c/Mf-ti3nt, mats/Mf-a6nt,
+    mats/Mf-i3nt, mats/Mf-ta6nt, mats/Mf-ti3nt 

--- a/c/Mf-a6nt
+++ b/c/Mf-a6nt
@@ -25,6 +25,9 @@ cross=f
 
 include Mf-base
 
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL=*
+
 ${Scheme}${cross:f=}: make.bat
 	cmd.exe /c make.bat
 	cp ../bin/$m/scheme.exe ../bin/$m/petite.exe

--- a/c/Mf-i3nt
+++ b/c/Mf-i3nt
@@ -25,6 +25,9 @@ cross=f
 
 include Mf-base
 
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL=*
+
 ${Scheme}${cross:f=}: make.bat
 	cmd.exe /c make.bat
 	cp ../bin/$m/scheme.exe ../bin/$m/petite.exe

--- a/c/Mf-ta6nt
+++ b/c/Mf-ta6nt
@@ -25,6 +25,9 @@ cross=f
 
 include Mf-base
 
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL=*
+
 ${Scheme}${cross:f=}: make.bat
 	cmd.exe /c make.bat
 	cp ../bin/$m/scheme.exe ../bin/$m/petite.exe

--- a/c/Mf-ti3nt
+++ b/c/Mf-ti3nt
@@ -25,6 +25,9 @@ cross=f
 
 include Mf-base
 
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL=*
+
 ${Scheme}${cross:f=}: make.bat
 	cmd.exe /c make.bat
 	cp ../bin/$m/scheme.exe ../bin/$m/petite.exe

--- a/mats/Mf-a6nt
+++ b/mats/Mf-a6nt
@@ -22,6 +22,7 @@ mdclean = cat_flush.exe cat_flush.obj foreign1.exp foreign1.lib foreign1.obj for
 include Mf-base
 
 export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL=*
 
 foreign1.so: $(fsrc)
 	cmd.exe /c "vs.bat amd64 && cl /DWIN32 /DX86_64 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv953.lib $(fsrc)"

--- a/mats/Mf-i3nt
+++ b/mats/Mf-i3nt
@@ -22,6 +22,7 @@ mdclean = cat_flush.exe cat_flush.obj foreign1.exp foreign1.lib foreign1.obj for
 include Mf-base
 
 export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL=*
 
 foreign1.so: $(fsrc)
 	cmd.exe /c "vs.bat x86 && cl /DWIN32 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv953.lib $(fsrc)"

--- a/mats/Mf-ta6nt
+++ b/mats/Mf-ta6nt
@@ -22,6 +22,7 @@ mdclean = cat_flush.exe cat_flush.obj foreign1.exp foreign1.lib foreign1.obj for
 include Mf-base
 
 export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL=*
 
 foreign1.so: $(fsrc)
 	cmd.exe /c "vs.bat amd64 && cl /DWIN32 /DX86_64 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv953.lib $(fsrc)"

--- a/mats/Mf-ti3nt
+++ b/mats/Mf-ti3nt
@@ -22,6 +22,7 @@ mdclean = cat_flush.exe cat_flush.obj foreign1.exp foreign1.lib foreign1.obj for
 include Mf-base
 
 export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL=*
 
 foreign1.so: $(fsrc)
 	cmd.exe /c "vs.bat x86 && cl /DWIN32 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv953.lib $(fsrc)"


### PR DESCRIPTION
When MSYS2 bash sees the command "cmd.exe /c make.bat" it will
silently convert the /c into c:\, as it translates unixy paths
to Windows paths. This can be disabled by setting the environment
variable MSYS2_ARG_CONV_EXCL to *. So do that for this particular
command. It will be harmless in other environments like Cygwin.