### PR TITLE
Fix build on Linux with musl libc

### DIFF
--- a/LOG
+++ b/LOG
@@ -2000,3 +2000,5 @@
 - fixed Windows build using MSYS2
     c/Mf-a6nt, c/Mf-i3nt, c/Mf-ta6nt, c/Mf-ti3nt, mats/Mf-a6nt,
     mats/Mf-i3nt, mats/Mf-ta6nt, mats/Mf-ti3nt 
+- fixed build on Linux with musl libc
+    expeditor.c

--- a/c/expeditor.c
+++ b/c/expeditor.c
@@ -552,7 +552,7 @@ static void s_ee_write_char(wchar_t c) {
 #include <sys/ioctl.h>
 #include <wchar.h>
 #include <locale.h>
-#if !defined(__GLIBC__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
+#if !defined(__linux__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
 #include <xlocale.h>
 #endif
 


### PR DESCRIPTION
Distributions that use musl libc, such as Alpine, doesn't define
`__GLIBC__` yet still doesn't have xlocale.h.