### PR TITLE
fix foreign-callable handling of bytevector arguments

### DIFF
--- a/LOG
+++ b/LOG
@@ -2006,3 +2006,8 @@
   values.
     cp0.ss, primdata.ss,
     cp0.ms
+- fix handling of calling code's address for locking around a callable
+  that has a u8*, u16*, or u32* argument, which could cause the
+  cp register copy in the thread context to be changed before
+  S_call_help gets it
+    cpnanopass.ss, schlib.c, foreign2.c, foreign.ms

--- a/c/schlib.c
+++ b/c/schlib.c
@@ -216,6 +216,8 @@ void S_call_help(tc_in, singlep, lock_ts) ptr tc_in; IBOOL singlep; IBOOL lock_t
      the C stack and we may end up in a garbage collection */
     code = CP(tc);
     if (Sprocedurep(code)) code = CLOSCODE(code);
+    if (!IMMEDIATE(code) && !Scodep(code))
+      S_error_abort("S_call_help: invalid code pointer");
     Slock_object(code);
 
     CP(tc) = AC1(tc);

--- a/mats/foreign.ms
+++ b/mats/foreign.ms
@@ -2536,8 +2536,32 @@
      (define handler (foreign-callable work (long) void))
      (lock-object handler)
      (call_many_times (foreign-callable-entry-point handler))
+     (unlock-object handler)
      v)
    14995143)
+
+  (equal?
+   (let ()
+     (define v 0)
+     (define call_many_times_bv (foreign-procedure "call_many_times_bv" (void*) void))
+     (define work
+       (lambda (bv)
+         (set! v (+ v (bytevector-u8-ref bv 0)))
+         ;; Varying work, as above:
+         (let loop ([n (bitwise-and (bytevector-u8-ref bv 1) #xFFFF)])
+           (unless (zero? n)
+             (set! v (add1 v))
+             (loop (bitwise-arithmetic-shift-right n 1))))))
+     (define handlers (list (foreign-callable work (u8*) void)
+                            (foreign-callable work (u16*) void)
+                            (foreign-callable work (u32*) void)))
+     (map lock-object handlers)
+     (for-each (lambda (handler)
+                 (call_many_times_bv (foreign-callable-entry-point handler)))
+               handlers)
+     (map unlock-object handlers)
+     v)
+   103500000)
 
   ;; regression test related to saving registers that hold allocated
   ;; callable argument

--- a/mats/foreign2.c
+++ b/mats/foreign2.c
@@ -444,6 +444,18 @@ EXPORT void call_many_times(void (*f)(iptr))
   }
 }
 
+EXPORT void call_many_times_bv(void (*f)(char *s))
+{
+  /* make this sensible as u8*, u16*, and u32* */
+  char buf[8] = { 1, 2, 3, 4, 0, 0, 0, 0 };
+  int x;
+
+  for (x = 0; x < 1000000; x++) {
+    buf[0] = (x & 63) + 1;
+    f(buf);
+  }
+}
+
 typedef void (*many_arg_callback_t)(int i, const char* s1, const char* s2, const char* s3,
                                     const char* s4, int i2, const char* s6, const char* s7, int i3);
 EXPORT void call_with_many_args(many_arg_callback_t callback)


### PR DESCRIPTION
This patch is a follow-up to #364 and commit 4cd942be6a, where `(%tc-ref cp)` was supposed to be preserved by moving it into `%cp` — but intrinisics used for bytevector argument types like `u8*` can kill `%cp`. This commit uses a temporary to expose things properly to the register allocator.