### PR TITLE
Change includes <Win[bB]ase.h> => <winbase.h>

### DIFF
--- a/LOG
+++ b/LOG
@@ -2077,3 +2077,5 @@
     gc.c
 - updated Windows makefiles
     c/Makefile.*nt
+- use lowercase for Windows include files
+    segment.c, windows.c

--- a/c/segment.c
+++ b/c/segment.c
@@ -89,7 +89,7 @@ void S_freemem(void *addr, iptr bytes) {
 #endif
 
 #if defined(USE_VIRTUAL_ALLOC)
-#include <WinBase.h>
+#include <winbase.h>
 void *S_getmem(iptr bytes, IBOOL zerofill) {
   void *addr;
 

--- a/c/windows.c
+++ b/c/windows.c
@@ -307,7 +307,7 @@ int S_windows_open_exclusive(char *who, char *path, int flags) {
 }
 #endif
 
-#include <Winbase.h>
+#include <winbase.h>
 
 /* primitive version of flock compatible with Windows 95/98/ME.  A better
    version could be implemented for Windows NT/2000/XP using LockFileEx. */


### PR DESCRIPTION
When handling paths, Windows is case-insensitive, but unices are case-sensitive.

This simple patch facilitates cross-compiling the Windows version on a Unix system, and doesn't affect at all the native, Windows compilation.

To be more explicit, on a Linux system with an appropriate cross-compiler installed,
```
    ./configure -m=ta6nt --threads --toolprefix=x86_64-w64-mingw32-
    ./workarea ta6nt
    make -C ta6nt/c -f Mf-ta6nt cross=t o=o
```
will fail with:
```
segment.c:92:10: fatal error: WinBase.h: No such file or directory
   92 | #include <WinBase.h>
      |          ^~~~~~~~~~~
compilation terminated.
```
(and another similar error in windows.c) unless this present patch is applied.
