### PR TITLE
Small refactoring and proper unicode handling of error messages.

### DIFF
--- a/LOG
+++ b/LOG
@@ -2079,3 +2079,6 @@
     c/Makefile.*nt
 - use lowercase for Windows include files
     segment.c, windows.c
+- proper unicode handling when retrieving error messages from the OS
+  on Windows
+    windows.c

--- a/c/externs.h
+++ b/c/externs.h
@@ -386,7 +386,7 @@ extern INT S_getpagesize(void);
 extern ptr S_LastErrorString(void);
 extern void *S_ntdlopen(const char *path);
 extern void *S_ntdlsym(void *h, const char *s);
-extern char *S_ntdlerror(void);
+extern ptr S_ntdlerror(void);
 extern int S_windows_flock(int fd, int operation);
 extern int S_windows_chdir(const char *pathname);
 extern int S_windows_chmod(const char *pathname, int mode);

--- a/c/foreign.c
+++ b/c/foreign.c
@@ -36,13 +36,14 @@
 #if defined(HPUX)
 #include <dl.h>
 #define dlopen(path,flags) (void *)shl_load(path, BIND_IMMEDIATE, 0L)
-#define dlerror() strerror(errno)
+#define s_dlerror() Sstring_utf8(strerror(errno), -1)
 #elif defined(WIN32)
 #define dlopen(path,flags) S_ntdlopen(path)
 #define dlsym(h,s) S_ntdlsym(h,s)
-#define dlerror() S_ntdlerror()
+#define s_dlerror() S_ntdlerror()
 #else
 #include <dlfcn.h>
+#define s_dlerror() Sstring_utf8(dlerror(), -1)
 #ifndef RTLD_NOW
 #define RTLD_NOW 2
 #endif /* RTLD_NOW */
@@ -229,8 +230,7 @@ static void load_shared_object(path) const char *path; {
 
     handle = dlopen(path, RTLD_NOW);
     if (handle == (void *)NULL)
-        S_error2("", "(while loading ~a) ~a", Sstring_utf8(path, -1),
-                    Sstring_utf8(dlerror(), -1));
+        S_error2("", "(while loading ~a) ~a", Sstring_utf8(path, -1), s_dlerror());
     S_foreign_dynamic = Scons(addr_to_ptr(handle), S_foreign_dynamic);
 
     tc_mutex_release()

--- a/c/windows.c
+++ b/c/windows.c
@@ -55,18 +55,11 @@ void *S_ntdlsym(void *h, const char *s) {
 
 /* Initial version of S_ntdlerror courtesy of Bob Burger, burgerrg@sagian.com
  * Modifications by James-Adam Renquinha Henri, jarhmander@gmail.com */
-char *S_ntdlerror(void) {
-    static char *s = NULL;
-    /*
-     * The caller does not expect to have to free the memory returned by this
-     * function (because normally, you shouldn't free the result of dlerror).
-     * But to properly support Unicode on Windows, we have to allocate memory to
-     * hold a utf-8 string. Hence, we have this semi-leak situation, where we
-     * always hold the last error string, and free the previous one, each time
-     * we call this function.
-     */
+ptr S_ntdlerror(void) {
+    ptr ret;
+    char *s = s_ErrorStringImp(GetLastError(), "unable to load library");
+    ret = Sstring_utf8(s, -1);
     free(s);
-    s = s_ErrorStringImp(GetLastError(), "unable to load library");
     return s;
 }
 

--- a/c/windows.c
+++ b/c/windows.c
@@ -265,7 +265,7 @@ static ptr s_ErrorStringImp(DWORD dwMessageId, const char *lpcDefault) {
 
         do {
             c = *--endstr;
-        } while (--wlen  && (c == L'\n' || c == L'\r'));
+        } while (endstr != str && (c == L'\n' || c == L'\r'));
 
         endstr[c != L'.'] = 0;
 
@@ -274,6 +274,18 @@ static ptr s_ErrorStringImp(DWORD dwMessageId, const char *lpcDefault) {
         result = Sstring_utf8(u8str, -1);
         free(u8str);
     }
+    endstr = lpMsgBuf + len;
+    /* Otherwise remove trailing newlines & returns and strip trailing period. */
+    while (lpMsgBuf != endstr) {
+        wchar_t c = *--endstr;
+        if (c == L'.') {
+            *endstr = 0;
+            break;
+        }
+        else if (c != L'\n' && c != L'\r') break;
+    }
+    result = Swide_to_utf8(lpMsgBuf);
+    LocalFree(lpMsgBuf);
     return result;
 }
 


### PR DESCRIPTION
On a Windows system, error messages from the OS were not unicode-aware, and messages were not properly read back.

Example transcript from a french OS:
```
> (load-shared-object "not a dll")
Exception: (while loading not a dll) Le module sp�cifi� est introuvable
Type (debug) to enter the debugger.
```

This patch fixes this, and with a bonus refactoring in windows.c to avoid duplicating code in `S_ntdlerror` and `s_ErrorString`.