### PR TITLE
Uniform (load-shared-object #f) handling across platforms

### DIFF
--- a/LOG
+++ b/LOG
@@ -2166,3 +2166,5 @@
     configure
 - maybe-compile-program now returns void
     compile.ss 7.ms
+- more consistent behavior of (load-shared-object #f) across platforms
+    foreign.c windows.c

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -975,6 +975,44 @@ Although the second definition is more constraining on the load order
 of foreign files, it is more efficient since the entry resolution need
 be done only once.
 
+With the following macro, procedures can be defined to lazily resolve foreign
+entries upon application:
+
+\schemedisplay
+(define-syntax lazy-foreign-procedure
+  (lambda (x)
+    (syntax-case x ()
+      [(_ conv ... entry (p-type ...) ret)
+       (with-syntax ([(f-args ...) (generate-temporaries #'(p-type ...))])
+         #'(letrec ([proc
+                      (lambda (f-args ...)
+                        (let ([ff (foreign-procedure conv ...
+                                    entry (p-type ...) ret)])
+                          (set! proc ff)
+                          (ff f-args ...)))])
+             (lambda (f-args ...)
+               (proc f-args ...))))])))
+\endschemedisplay
+
+\noindent
+If \scheme{doit} is modified to use the previous macro, as in
+
+\schemedisplay
+(define doit
+  (lazy-foreign-procedure "doit" () void))
+\endschemedisplay
+
+\noindent
+then \scheme{doit} will be bound to a procedure that invokes another one,
+initially bound to a \emph{resolution procedure}; the resolution procedure
+first perform the lookup for the foreign entry, then caches the result before
+invoking it.
+Future applications of \scheme{doit} will simply directly call the cached
+procedure.
+This definition is almost as efficient as the previous one, yet does not require
+to have a foreign entry for \scheme{"doit"} immediately upon definition, but
+simply before its first execution.
+
 It is often useful to define a template to be used
 in the creation of several foreign procedures with similar argument
 types and return values.
@@ -2489,7 +2527,7 @@ On MacOS X systems:
 On Windows:
 
 \schemedisplay
-(load-shared-object "crtdll.dll")
+(load-shared-object "msvcrt.dll")
 \endschemedisplay
 
 Once the C library has been loaded, \scheme{getenv} should be available
@@ -2677,6 +2715,10 @@ The filename is given as \scheme{"./evenodd.so"} rather than simply
 in a standard set of system directories that does not include the
 current directory.
 
+Currently, {\ChezScheme} never unload shared object files nor checks if they
+were already loaded, and never collects the ``handles'' to them.
+Repeated use of this function in a loop may exhaust all the available memory and
+cause {\ChezScheme} to abort.
 
 %----------------------------------------------------------------------------
 \entryheader

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -2412,20 +2412,38 @@ via one of the other methods described in this section.
 \endentryheader
 
 \noindent
-\var{path} must be a string.
-\scheme{load-shared-object} loads the shared object named by \var{path}.
+\var{path} must be a string or \scheme{#f}.
+If \var{path} is a string, \scheme{load-shared-object} loads the shared object
+named by \var{path}.
 Shared objects may be system libraries or files created from ordinary
 C programs.
 All external symbols in the shared object, along with external symbols
-available in other shared objects linked with the shared object,
-are made available as foreign entries. 
-
+available in other shared objects linked with the shared object, are made
+available as foreign entries.
+If \var{path} is \scheme{#f}, external symbols in the executable itself (if
+any), as well as those found in dependent shared objects, are also made
+available as foreign entries.
 This procedure is supported for most platforms upon which {\ChezScheme}
 runs.
 
 If \var{path} does not begin with a ``.'' or ``/'', the shared
 object is searched for in a default set of directories determined
 by the system.
+
+Usually, executables do not export symbols, but can be instructed to do so with
+proper compilation flags.
+One may thus create an executable based on {\ChezScheme}, and have Scheme code
+access expressely exported symbols from it.
+
+Because {\ChezScheme} is (usually!) dynamically linked to the operating system's
+C library, all C functions are also accessible after evaluation of
+\scheme{(load-shared-object #f)}.
+This provides a simple way to gain access to standard C functions (such as
+\var{memcpy} or \var{strlen}), which may be very convenient for Scheme programs
+intended to be portable across different systems.
+One downside of not directly naming the shared object file is that the set of
+accessible foreign entries as well as their resolution among them is
+unspecified.
 
 On most Unix systems, \scheme{load-shared-object} is based on the
 system routine \scheme{dlopen}.


### PR DESCRIPTION
This is a request to make an undocumented feature… documented, and work correctly.

`load-shared-object` is a foreign function, so it accepts `#f` as well as strings as an argument. On e.g. Linux, `(load-shared-object #f)` does something very useful: it essentially calls `dlopen(NULL, RTLD_NOW)`, which makes especially easy to get regular C functions like `memcpy` available as foreign entries, but also _any_ linked shared objects and even external symbols for the executable itself. This can be a very effective simplification if one intends to make a portable, single file binary from Chez Scheme.

On Windows, `(load-shared-object #f)`… crashes. Obviously, `Sutf8_to_wide` doesn't like getting a NULL pointer. Rather than simply fix this, this PR goes quite a bit further by attempting to emulate the useful behavior of `dlopen(NULL, ....)` from UNIX. Doing so is not so simple apparently, as there no direct equivalent, and the code ends up enumerating the loaded DLLs of the current process and add all of them to the `S_foreign_dynamic` list.

I'm aware that the approach taken here might be against the core principle of being efficient in one particular case for a particular platform, but it's for the benefit of usability.

Also, I'm aware that this PR is likely not acceptable, as there is no tests written to the added functionality. This is an area I need a bit of guidance, as I'm not sure what other files besides `mats/foreign.ms` I have to modify.

Finally, note that I put some unrelated changes to the documentation in a separate commit. Review these carefully.