### PR TITLE
continuation repair for return-arity error

### DIFF
--- a/LOG
+++ b/LOG
@@ -2132,3 +2132,6 @@
     wininstall/ta6nt.wxs wininstall/ti3nt.wxs
 - newrelease no longer logs as updated files with no actual changes
     newrelease
+- repaired continuation for exception handler of error for reurning
+  the wrong number of values to a multiple-value context
+    cpnanopass.ss, np-languages.ss, 3.ms

--- a/mats/3.ms
+++ b/mats/3.ms
@@ -2087,6 +2087,31 @@
                        (thing-pos posx)
                        (do-something-else)))
                list)))))
+
+  ;; regression test to make sure the continuation is well formed when
+  ;; an exception handler is call for a wrong number of values are
+  ;; returned to a multi-value context
+  (begin
+    (define ($go-fail-to-get-two-values)
+      (call-with-values (lambda () ($get-one-value))
+        (lambda (a b) (list a b))))
+    (define ($get-one-value)
+      (call/cc ; copies return address off stack
+       (lambda (k)
+         (collect) ; do something non-trivial
+         k)))
+    (#%$continuation?
+     (call/cc
+      (lambda (esc)
+        (car
+          (with-exception-handler
+           (lambda (exn)
+             (call/cc
+              (lambda (k) ; this continuation used to be broken, and
+                (collect) ; a GC was the simplest way of detecting it
+                (esc k))))
+           $go-fail-to-get-two-values))))))
+
 )
 
 (mat let-values

--- a/s/np-languages.ss
+++ b/s/np-languages.ss
@@ -775,9 +775,10 @@
       (- (mvset info (mdcl (maybe t0) t1 ...) (t* ...) ((x** ...) interface* l*) ...))
       (+ (do-rest fixed-args)
          (mvset info (mdcl (maybe t0) t1 ...) (t* ...) ((x** ...) ...) ebody)
-         ; mventry-point can appear only within an mvset ebody
+         ; mventry-point and mverror-point can appear only within an mvset ebody
          ; ideally, grammar would reflect this
-         (mventry-point (x* ...) l))))
+         (mventry-point (x* ...) l)
+         (mverror-point))))
 
   (define exact-integer?
     (lambda (x)


### PR DESCRIPTION
When the wrong number of values are returned to a multiple-value context, the stack pointer is left as-is while calling the exception handler. The intent is to keep the current procedure's frame in place for debugging. However, there's no guarantee that the return address is still on the stack (much less in a return register, when there is one); for example, the continuation starting with the current frame may have been captured and just restored. If the return address is not in place, then the current continuation is ill-formed in the exception handler.

For example, this program tends to crash:

```
(define (go)
  (call-with-values get
    (lambda (a b) (list a b))))

;; returns just one value after capturing the continuation:
(define (get)
  (call/cc
   (lambda (k)
     (collect) ; do something non-trivial
     k)))

(with-exception-handler
 (lambda (exn)
   (call/cc
    (lambda (k)
      (collect) ; detect broken `k`
      k)))
 go)
```

This patch repairs the problem by always reinstalling the return address before jumping to the mvlet error function.