### PR TITLE
make arm32 return-address encoding size montonic w.r.t. offset

### DIFF
--- a/LOG
+++ b/LOG
@@ -2135,3 +2135,6 @@
 - repaired continuation for exception handler of error for reurning
   the wrong number of values to a multiple-value context
     cpnanopass.ss, np-languages.ss, 3.ms
+- adjust arm32 backend to not choose shorter instructions for larger
+  return-address offsets, which breaks label address assignment
+    arm32.ss


### PR DESCRIPTION
Changes in #530 created (exposed?) problems with the arm32 implementation of return-address label references. 

Currently, building arm32le boot files gets stuck. The problem is with the "funky12" encoding of immediates in A32, where a load of a larger immediate value can end up fitting in a smaller instruction encoding. The backwards references for return-arity errors get large enough that this matters: as code gets further away due to various label calculations, the return-address instructions can get shorter, pulling the code closer together again, and that push-and-pull effect can prevent the label-address assignment from terminating. The encoding problem might not have been a problem prior to #530, where return-address label references were always forward references, but I'm not sure.

The solution here is to constrain `asm-return-address` to a funky12 subset that doesn't have that property. It encodes
0-1023 the compact way (assuming a multiple of 4), and as soon as the offset difference is greater than 1023, it sticks to the larger encoding.