### PR TITLE
NOTICE: Mention LZ4

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -28,3 +28,6 @@ Builds of this product incorporate separately copyrighted code from:
 
 * the Zlib compression library, developed by Jean-loup Gailly and
   Mark Adler
+
+* the LZ4 compression library, developed by Yann Collet and
+  contributors.


### PR DESCRIPTION
Commit 8858b34bd92ac8d2b6511dc9ca17ebfa06a1bd93 ("Add LZ4 support and
use it by default for compressing files") added LZ4 support and the
lz4 submodule, but did not update the NOTICE file, unlike zlib support
is handled.