### PR TITLE
Add special case in cpnanopass for (eq? (ftype-pointer-address x) 0)

### DIFF
--- a/LOG
+++ b/LOG
@@ -2140,3 +2140,5 @@
     arm32.ss
 - repair remainder and modulo on flonums by using fmod
     prim5.c, 5_3.ss, 5_3.ms
+- add special case in cpnanopass.ss for (eq? (ftype-pointer-address x) 0)
+    cpnanopass.ss

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -3812,7 +3812,8 @@
           [e* `(values ,(make-info-call src sexpr #f #f #f) ,e* ...)])
         (define-inline 2 eq?
           [(e1 e2)
-           (or (relop-length RELOP= e1 e2)
+           (or (eqvop-null-fptr e1 e2)
+               (relop-length RELOP= e1 e2)
                (%inline eq? ,e1 ,e2))])
         (define-inline 2 $keep-live
           [(e) (%seq ,(%inline keep-live ,e) ,(%constant svoid))])


### PR DESCRIPTION
Add a special case in cpnanopass.ss for `(eq? (ftype-pointer-address x) 0)`. 

`eqv?`, `equal?` already have the same special case. 