### PR TITLE
Fix signature of generate-temporaries

### DIFF
--- a/LOG
+++ b/LOG
@@ -2142,3 +2142,5 @@
     prim5.c, 5_3.ss, 5_3.ms
 - add special case in cpnanopass.ss for (eq? (ftype-pointer-address x) 0)
     cpnanopass.ss
+- fix signature of generate-temporaries
+    primdata.ss primvars.ss

--- a/mats/primvars.ms
+++ b/mats/primvars.ms
@@ -415,7 +415,7 @@
               [(length) 0 -1 (+ (most-positive-fixnum) 1) 'a #f]
               [(library-path) '(a) "hereiam" #f]
               [(library-requirements-options) (library-requirements-options import invoke) 1/2 #f]
-              [(list) '(a) '#1=(a . #1#) 17 '#() #f]
+              [(list) '(a) '#1=(a . #1#) 17 '#() #'(1 2 3) #f]
               [(list-of-string-pairs) '(("a" . "b")) '("a") #f]
               [(list-of-symbols) '(a b c) '("a") #f]
               [(maybe-binary-output-port) *binary-output-port *binary-input-port (current-output-port)]

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -799,7 +799,7 @@
   (free-identifier=? [sig [(identifier identifier) -> (boolean)]] [flags pure mifoldable discard cp03])
   (syntax->datum [sig [(ptr) -> (ptr)]] [flags pure unrestricted mifoldable discard])
   (datum->syntax [sig [(identifier ptr) -> (ptr)]] [flags pure mifoldable discard])
-  (generate-temporaries [sig [(list) -> (list)]] [flags alloc])
+  (generate-temporaries [sig [(ptr) -> (list)]] [flags alloc]) ; the argument can be a list, a syntax with a list or an annotation
   (syntax-violation [sig [(who string ptr) (who string ptr ptr) -> (bottom)]] [flags abort-op])
 )
 


### PR DESCRIPTION
Fix signature of `generate-temporaries`. The argument can be a list, a syntax with a list or an annotation. 

