### PR TITLE
Fix missing include in externs.h

### DIFF
--- a/LOG
+++ b/LOG
@@ -2142,3 +2142,5 @@
     prim5.c, 5_3.ss, 5_3.ms
 - add special case in cpnanopass.ss for (eq? (ftype-pointer-address x) 0)
     cpnanopass.ss
+- fix missing include in externs.h for struct timespec
+    c/expeditor.c, c/externs.h, c/prim5.c, c/scheme.c, c/stats.c

--- a/c/expeditor.c
+++ b/c/expeditor.c
@@ -547,7 +547,6 @@ static void s_ee_write_char(wchar_t c) {
 #endif /* SOLARIS */
 #include <termios.h>
 #include <signal.h>
-#include <time.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <wchar.h>

--- a/c/externs.h
+++ b/c/externs.h
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #ifndef WIN32
 #include <unistd.h>

--- a/c/prim5.c
+++ b/c/prim5.c
@@ -21,7 +21,6 @@
 #include <sys/stat.h>
 #include <limits.h>
 #include <ctype.h>
-#include <time.h>
 
 /* locally defined functions */
 static INT s_errno PROTO((void));

--- a/c/scheme.c
+++ b/c/scheme.c
@@ -20,7 +20,6 @@
 #include <limits.h>
 #ifdef WIN32
 #include <io.h>
-#include <time.h>
 #else
 #include <sys/time.h>
 #endif

--- a/c/stats.c
+++ b/c/stats.c
@@ -34,8 +34,6 @@
 #include <sys/resource.h>
 #endif
 
-#include <time.h>
-
 static struct timespec starting_mono_tp;
 
 static long adjust_time_zone(ptr dtvec, struct tm *tmxp, ptr given_tzoff);


### PR DESCRIPTION
The time.h header is required to make the timespec struct available for
the prototypes.

Fixes: https://github.com/cisco/ChezScheme/issues/281