### PR TITLE
Doc updates

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -149,13 +149,13 @@ The make file supports several targets:
 'sudo make install'
   runs the build plus installs the resulting executables, boot files,
   example files, and manual pages.  If the installprefix used with
-  './configure' is writable by the current user then 'sudo' is not
+  './configure' is writable by the current user, then 'sudo' is not
   necessary.
 
 'sudo make uninstall'
   uninstalls the executables, boot files, example files, and manual pages.
   As with 'make install', if the installprefix used with './configure' is
-  writable by the current user then 'sudo' is not necessary.
+  writable by the current user, then 'sudo' is not necessary.
 
 'make test'
   runs the build plus runs a set of test programs in various different
@@ -216,9 +216,9 @@ The make file supports several targets:
   'rgb.txt' file, which it will automatically locate in the common
   X11 installation locations.  If ppmtogif fails because it cannot find
   an rgb.txt file, you can use the RGBDEF environment variable to
-  specify the path to a file.  If your system has an emacs installation
+  specify the path to a file.  If your system has an emacs installation,
   then you can find an rgb.txt file in the 'etc' directory of the emacs
-  installation.  If your system has a vim installation then it might
+  installation.  If your system has a vim installation, then it might
   contain an rgb.txt in $VIMRUNTIME.
 
 'make clean'

--- a/BUILDING
+++ b/BUILDING
@@ -148,10 +148,14 @@ The make file supports several targets:
 
 'sudo make install'
   runs the build plus installs the resulting executables, boot files,
-  example files, and manual pages.
+  example files, and manual pages.  If the installprefix used with
+  './configure' is writable by the current user then 'sudo' is not
+  necessary.
 
 'sudo make uninstall'
   uninstalls the executables, boot files, example files, and manual pages.
+  As with 'make install', if the installprefix used with './configure' is
+  writable by the current user then 'sudo' is not necessary.
 
 'make test'
   runs the build plus runs a set of test programs in various different
@@ -197,11 +201,31 @@ The make file supports several targets:
   of a built work area for the host machine type, to build just the
   boot files for machine-type M.
 
+'make docs'
+  runs the build plus generates HTML and PDF versions of the Chez Scheme
+  Users Guide and the release notes.  Unlike the other build targets,
+  the documentation is not built in the workarea, but rather in the
+  'csug' and 'release_notes' directories.
+
+  Building the documentation requires a few prerequisites not required
+  to build the rest of Chez Scheme.  The following must be available
+  in your PATH:
+    * A TeX distribution (including latex, pdflatex, dvips, and gs)
+    * ppmtogif and pnmcrop (from Netpbm)
+  An X11 installation is not required, but ppmtogif does require an
+  'rgb.txt' file, which it will automatically locate in the common
+  X11 installation locations.  If ppmtogif fails because it cannot find
+  an rgb.txt file, you can use the RGBDEF environment variable to
+  specify the path to a file.  If your system has an emacs installation
+  then you can find an rgb.txt file in the 'etc' directory of the emacs
+  installation.  If your system has a vim installation then it might
+  contain an rgb.txt in $VIMRUNTIME.
+
 'make clean'
   removes binaries from the workarea.
 
 'make distclean'
-  removes nanopass, Makefile, and all workareas.
+  removes nanopass, Makefile, built documentation, and all workareas.
 
 OTHER UNIX VARIANTS
 

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -595,26 +595,27 @@ the endianness of the target machine.
 For example, \scheme{wstring} is equivalent to \scheme{utf-16le}
 under Windows running on Intel hardware.
 
-\foreigntype{\scheme{(* \var{ftype})}}
+\foreigntype{\scheme{(* \var{ftype-name})}}
 \index{ftype}This type allows a pointer to a foreign
 type (ftype) to be passed.
-The argument must be an ftype pointer of type \var{ftype},
+The argument must be an ftype pointer of the type identified by
+\var{ftype-name},
 and the actual argument is the address encapsulated in the
 ftype pointer.
 See Section~\ref{SECTFOREIGNDATA} for a description of
 foreign types.
 
-\foreigntype{\scheme{(& \var{ftype})}}
+\foreigntype{\scheme{(& \var{ftype-name})}}
 \index{ftype}This type allows a foreign
 type (ftype) to be passed as a value, but represented
 on the Scheme side as a pointer to the foreign-type data.
-That is, a \scheme{(& \var{ftype})} argument is represented on
-the Scheme side the same as a \scheme{(* \var{ftype})} argument,
-but a \scheme{(& \var{ftype})} argument is passed to the foreign procedure as the
+That is, a \scheme{(& \var{ftype-name})} argument is represented on
+the Scheme side the same as a \scheme{(* \var{ftype-name})} argument,
+but a \scheme{(& \var{ftype-name})} argument is passed to the foreign procedure as the
 content at the foreign pointer's address instead of as the
-address. For example, if \var{ftype} is a \scheme{struct} type,
-then \scheme{(& \var{ftype})} passes a struct argument instead of
-a struct-pointer argument. The \var{ftype} cannot refer to an array type.
+address. For example, if \var{ftype-name} identifies a \scheme{struct} type,
+then \scheme{(& \var{ftype-name})} passes a struct argument instead of
+a struct-pointer argument. The \var{ftype-name} cannot refer to an array type.
 
 \medskip\noindent
 The result types are similar to the parameter types with the addition of a
@@ -867,22 +868,22 @@ the endianness of the target machine.
 For example, \scheme{wstring} is equivalent to \scheme{utf-16le}
 under Windows running on Intel hardware.
 
-\foreigntype{\scheme{(* \var{ftype})}}
+\foreigntype{\scheme{(* \var{ftype-name})}}
 \index{ftype}The result is interpreted as the address of a foreign object
-whose structure is described by \var{ftype}, and a freshly allocated
+whose structure is described by the ftype identified by \var{ftype-name}, and a freshly allocated
 ftype pointer encapsulating the address is returned.
 See Section~\ref{SECTFOREIGNDATA} for a description of
 foreign types.
 
-\foreigntype{\scheme{(& \var{ftype})}}
+\foreigntype{\scheme{(& \var{ftype-name})}}
 \index{ftype}The result is interpreted as a foreign object
-whose structure is described by \var{ftype}, where the foreign
-procedure returns a \var{ftype} result, but the caller
-must provide an extra \scheme{(* \var{ftype})} argument before
+whose structure is described by the ftype identified by \var{ftype-name}, where the foreign
+procedure returns a \var{ftype-name} result, but the caller
+must provide an extra \scheme{(* \var{ftype-name})} argument before
 all other arguments to receive the result. An unspecified Scheme object
 is returned when the foreign procedure is called, since the result
 is instead written into storage referenced by the extra argument.
- The \var{ftype} cannot refer to an array type.
+ The \var{ftype-name} cannot refer to an array type.
 
 \medskip\noindent
 Consider a C identity procedure:


### PR DESCRIPTION
Adds information on building docs to `BUILDING`; updates docs on ftype pointer types in `foreign-procedure` to be more precise (as inspired by #557).