### PR TITLE
Ported "Small fixes to enable LTO compilation" from racket/ChezScheme

### DIFF
--- a/c/new-io.c
+++ b/c/new-io.c
@@ -77,7 +77,7 @@ static int is_valid_lz4_length(iptr count);
   do { body;                                            \
     if (ok) { flag = 0; }                               \
     else {                                              \
-      INT errnum;                                       \
+      INT errnum = 0;                                       \
       S_glzerror((fd),&errnum);                         \
       S_glzclearerr((fd));                              \
       if (errnum == Z_ERRNO) {                          \
@@ -98,7 +98,7 @@ static int is_valid_lz4_length(iptr count);
   do { body;                                            \
     if (ok) { flag = 0; break; }                        \
     else {                                              \
-      INT errnum;                                       \
+      INT errnum = 0;                                       \
       S_glzerror((fd),&errnum);                         \
       S_glzclearerr((fd));                              \
       if (errnum == Z_ERRNO) {                          \
@@ -116,7 +116,7 @@ static int is_valid_lz4_length(iptr count);
   do { body;                                            \
     if (ok) { flag = 0; }                               \
     else {                                              \
-      INT errnum;                                       \
+      INT errnum = 0;                                       \
       S_glzerror((fd),&errnum);                         \
       S_glzclearerr((fd));                              \
       if (errnum == Z_ERRNO) { flag = 1; }              \


### PR DESCRIPTION
Ported racket/ChezScheme@497fbcac13dd24a1113d8b288836c65aee8ea517 (Small fixes to enable LTO compilation) from racket/ChezScheme