### PR TITLE
repair bignum shift right

### DIFF
--- a/LOG
+++ b/LOG
@@ -2166,3 +2166,5 @@
     configure
 - maybe-compile-program now returns void
     compile.ss 7.ms
+- fixed right shift of a negative bignum by a multiple of 32
+    number.c 5_3.ms

--- a/c/number.c
+++ b/c/number.c
@@ -1314,7 +1314,7 @@ static ptr s_big_ash(tc, xp, xl, sign, cnt) ptr tc; bigit *xp; iptr xl; IBOOL si
     cnt -= whole_bigits * bigit_bits;
 
     /* shift by remaining count to scratch bignum, tracking bits shifted off to the right;
-       prepare a bignum one large than probably needed, in case we have to deal with a
+       prepare a bignum one larger than probably needed, in case we have to deal with a
        carry bit when rounding down for a negative number */
     PREPARE_BIGNUM(tc, W(tc),xl+1)
     p1 = &BIGIT(W(tc), 0);
@@ -1348,7 +1348,7 @@ static ptr s_big_ash(tc, xp, xl, sign, cnt) ptr tc; bigit *xp; iptr xl; IBOOL si
           EADDC(0, *p1, p1, &k)
         if (k) {
           /* add carry bit back; we prepared a large enough bignum,
-             and since of all the middle are zero, we don't have to reshift */
+             and since all of the middle are zero, we don't have to reshift */
           BIGIT(W(tc), xl) = 0;
           BIGIT(W(tc), 0) = 1;
           xl++;

--- a/c/number.c
+++ b/c/number.c
@@ -1313,8 +1313,10 @@ static ptr s_big_ash(tc, xp, xl, sign, cnt) ptr tc; bigit *xp; iptr xl; IBOOL si
     if ((xl -= (whole_bigits = (cnt = -cnt) / bigit_bits)) <= 0) return sign ? FIX(-1) : FIX(0);
     cnt -= whole_bigits * bigit_bits;
 
-    /* shift by remaining count to scratch bignum, tracking bits shifted off to the right */
-    PREPARE_BIGNUM(tc, W(tc),xl)
+    /* shift by remaining count to scratch bignum, tracking bits shifted off to the right;
+       prepare a bignum one large than probably needed, in case we have to deal with a
+       carry bit when rounding down for a negative number */
+    PREPARE_BIGNUM(tc, W(tc),xl+1)
     p1 = &BIGIT(W(tc), 0);
     p2 = xp;
     k = 0;
@@ -1344,6 +1346,13 @@ static ptr s_big_ash(tc, xp, xl, sign, cnt) ptr tc; bigit *xp; iptr xl; IBOOL si
         p1 = &BIGIT(W(tc), xl - 1);
         for (i = xl, k = 1; k != 0 && i-- > 0; p1 -= 1)
           EADDC(0, *p1, p1, &k)
+        if (k) {
+          /* add carry bit back; we prepared a large enough bignum,
+             and since of all the middle are zero, we don't have to reshift */
+          BIGIT(W(tc), xl) = 0;
+          BIGIT(W(tc), 0) = 1;
+          xl++;
+        }
       }
     }
 

--- a/mats/5_3.ms
+++ b/mats/5_3.ms
@@ -3061,6 +3061,7 @@
    (eqv? (bitwise-arithmetic-shift #x-8000000000000000 -31) #x-100000000)
    (eqv? (bitwise-arithmetic-shift #x-8000000000000000 -32) #x-80000000)
    (eqv? (bitwise-arithmetic-shift #x-8000000000000000 -33) #x-40000000)
+   (eqv? (- (expt 16 232)) (bitwise-arithmetic-shift (- 307 (expt 16 240)) -32))
    ($test-right-shift (lambda (x n) (bitwise-arithmetic-shift x (- n))))
 )
 
@@ -3107,6 +3108,7 @@
    (eqv? (bitwise-arithmetic-shift-right #x-8000000000000000 31) #x-100000000)
    (eqv? (bitwise-arithmetic-shift-right #x-8000000000000000 32) #x-80000000)
    (eqv? (bitwise-arithmetic-shift-right #x-8000000000000000 33) #x-40000000)
+   (eqv? (- (expt 16 232)) (bitwise-arithmetic-shift-right (- 307 (expt 16 240)) 32))
    ($test-right-shift (lambda (x n) (bitwise-arithmetic-shift-right x n)))
 )
 

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1906,14 +1906,16 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
-\subsection{Bitwise right shoft of negative fixnum (9.5.5)}
+\subsection{Bitwise right shift of negative bignum (9.5.5)}
 
 When a negative bignum is shifted right by a multiple of the big-digit
-bit size (which is 32), when a shifted-off bit is non-0, and when the
-result would be a sequence of big-digits with all 1 bits before
-rounding to deal with the dropped bits, a carry that should have been
-delivered to a new high digit was dropped, producing 0 instead of a
-negative number.
+bit size (32), a shifted-off bit is non-zero, and the result would be
+a sequence of big digits with all one bits before rounding to deal
+with the dropped bits, then a carry that should have been delivered to
+a new high digit was dropped, producing 0 instead of a negative
+number.
+
+For example, \scheme{(ash (- 1 (ash 1 64)) -32)} no longer returns 0.
 
 \subsection{\protect\scheme{sleep} with negative duration (9.5.5)}
 

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1906,6 +1906,15 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Bitwise right shoft of negative fixnum (9.5.5)}
+
+When a negative bignum is shifted right by a multiple of the big-digit
+bit size (which is 32), when a shifted-off bit is non-0, and when the
+result would be a sequence of big-digits with all 1 bits before
+rounding to deal with the dropped bits, a carry that should have been
+delivered to a new high digit was dropped, producing 0 instead of a
+negative number.
+
 \subsection{\protect\scheme{sleep} with negative duration (9.5.5)}
 
 Prior to this release, \scheme{sleep} of a negative duration would


### PR DESCRIPTION
When a negative bignum is shifted right by a multiple of the bigit bit size (which is 32), when a shifted-off bit is non-0, and when the result would be a sequence of bigits with all 1 bits before rounding to deal with the dropped bits, a carry that should have been delivered to a new high bigit was dropped.

Old behavior:
```
> (bitwise-arithmetic-shift (- 307 (expt 16 240)) -32)
0
```

Corrected behavior:
```
> (bitwise-arithmetic-shift (- 307 (expt 16 240)) -32)
-2269007733883335972287082669296112915239349672942191252221331572442536403137824056312817862695551072066953619064625508194663368599769448406663254670871573830845597595897613333042429214224697474472410882236254024057110212260250671521235807709272244389361641091086035023229622419456
```

This bug was discovered by @samth and originally reported as racket/racket#3794, and the example above is by @gus-massa.
