### PR TITLE
Mention an up-to-date DLL for Windows

### DIFF
--- a/LOG
+++ b/LOG
@@ -2168,3 +2168,6 @@
     compile.ss 7.ms
 - fixed right shift of a negative bignum by a multiple of 32
     number.c 5_3.ms
+- fixed the documentation of load-shared-object to mention an up-to-date
+  dll for Windows
+    foreign.stex

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -2471,7 +2471,7 @@ On MacOS X systems:
 On Windows:
 
 \schemedisplay
-(load-shared-object "crtdll.dll")
+(load-shared-object "msvcrt.dll")
 \endschemedisplay
 
 Once the C library has been loaded, \scheme{getenv} should be available


### PR DESCRIPTION
The user guide mention an outdated DLL which does not necessarily exist in recent installments of Windows 10. [According to Wikipedia](https://en.wikipedia.org/wiki/Microsoft_Windows_library_files#MSVCRT.DLL,_MSVCP*.DLL_and_CRTDLL.DLL), `MSVCRT.DLL` exists since Windows 95, and I tested on a Windows XP VM that it does exist in that (unsupported) Windows version.