### PR TITLE
x86_64: fix corner case of foreign calls for signed 8-bit or 16-bit integers with &

### DIFF
--- a/LOG
+++ b/LOG
@@ -2185,3 +2185,6 @@
     mats/{5_4,6,7,8,bytevector,examples,foreign}.ms
     mats/{ftype,hash,io,misc,primvars,profile,record}.ms
     mats/Mf-base mats/Mf-*nt mats/mat.ss mats/patch-interpret*
+- fix x86_64 (& integer-8) and (& integer-16) foreign-call argument
+  passing
+    x86_64, s/Mf-[t]a6{le,osx}

--- a/mats/Mf-a6le
+++ b/mats/Mf-a6le
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	$(CC) -m64 -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	$(CC) -m64 -fPIC -shared -O2 -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	$(CC) -o cat_flush cat_flush.c

--- a/mats/Mf-a6osx
+++ b/mats/Mf-a6osx
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	$(CC) -m64 -dynamiclib -undefined dynamic_lookup -I${Include} -o foreign1.so ${fsrc}
+	$(CC) -m64 -dynamiclib -undefined dynamic_lookup -O2 -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	$(CC) -o cat_flush cat_flush.c

--- a/mats/Mf-ta6le
+++ b/mats/Mf-ta6le
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	$(CC) -m64 -pthread -fPIC -shared -I${Include} -o foreign1.so ${fsrc}
+	$(CC) -m64 -pthread -fPIC -shared -O2 -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	$(CC) -o cat_flush cat_flush.c

--- a/mats/Mf-ta6osx
+++ b/mats/Mf-ta6osx
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	$(CC) -m64 -pthread -dynamiclib -undefined dynamic_lookup -I${Include} -o foreign1.so ${fsrc}
+	$(CC) -m64 -pthread -dynamiclib -undefined dynamic_lookup -O2 -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
 	$(CC) -o cat_flush cat_flush.c

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1912,6 +1912,12 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Certain foreign calls with signed 8- and 16-bit integers on x86_64 (9.5.5)}
+
+The x86_64 code generator now properly sign-extends foreign-call
+arguments passed in registers via \scheme{(& integer-8)} and \code{(&
+integer-16)}.
+
 \subsection{Bitwise right shift of negative bignum (9.5.5)}
 
 When a negative bignum is shifted right by a multiple of the big-digit

--- a/s/x86_64.ss
+++ b/s/x86_64.ss
@@ -2669,7 +2669,7 @@
                           `(set! ,(%mref ,%sp ,offset) (inline ,(make-info-load 'integer-8 #f)
                                                                ,%load ,x ,%zero (immediate ,x-offset)))]))))]
                  [load-content-regs
-                  (lambda (classes size iint ifp vint vfp)
+                  (lambda (classes size unsigned? iint ifp vint vfp)
                     (lambda (x) ; requires var
                       (let loop ([size size] [iint iint] [ifp ifp] [classes classes] [x-offset 0])
                         (cond
@@ -2694,13 +2694,13 @@
                           (let loop ([reg (vector-ref vint iint)] [size size] [x-offset x-offset])
                             (cond
                              [(= size 4)
-                              `(set! ,reg (inline ,(make-info-load 'unsigned-32 #f)
+                              `(set! ,reg (inline ,(make-info-load (if unsigned? 'unsigned-32 'integer-32) #f)
                                                   ,%load ,x ,%zero (immediate ,x-offset)))]
                              [(= size 2)
-                              `(set! ,reg (inline ,(make-info-load 'unsigned-16 #f)
+                              `(set! ,reg (inline ,(make-info-load (if unsigned? 'unsigned-16 'integer-16) #f)
                                                   ,%load ,x ,%zero (immediate ,x-offset)))]
                              [(= size 1)
-                              `(set! ,reg (inline ,(make-info-load 'unsigned-8 #f)
+                              `(set! ,reg (inline ,(make-info-load (if unsigned? 'unsigned-8 'integer-8) #f)
                                                   ,%load ,x ,%zero (immediate ,x-offset)))]
                              [(> size 4)
                               ;; 5, 6, or 7: multiple steps to avoid reading too many bytes
@@ -2761,12 +2761,12 @@
                                           (eq? 'float (caar ($ftd->members ftd))))
                                      ;; float or double
                                      (loop (cdr types)
-                                       (cons (load-content-regs '(sse) ($ftd-size ftd) i i vint vfp) locs)
+                                       (cons (load-content-regs '(sse) ($ftd-size ftd) #t i i vint vfp) locs)
                                        (add-regs 1 i vint regs) (add-regs 1 i vfp fp-regs) (fx+ i 1) isp)]
                                     [else
                                      ;; integer
                                      (loop (cdr types)
-                                       (cons (load-content-regs '(integer) ($ftd-size ftd) i i vint vfp) locs)
+                                       (cons (load-content-regs '(integer) ($ftd-size ftd) ($ftd-unsigned? ftd) i i vint vfp) locs)
                                        (add-regs 1 i vint regs) fp-regs(fx+ i 1) isp)])]
                                   [else
                                    ;; pass as value on the stack
@@ -2830,7 +2830,7 @@
                                   [else
                                    ;; pass in registers
                                    (loop (cdr types)
-                                         (cons (load-content-regs classes ($ftd-size ftd) iint ifp vint vfp) locs)
+                                         (cons (load-content-regs classes ($ftd-size ftd) ($ftd-unsigned? ftd) iint ifp vint vfp) locs)
                                          (add-regs ints iint vint regs) (add-regs fps ifp vfp fp-regs)
                                          (fx+ iint ints) (fx+ ifp fps) isp)]))]
                               [else


### PR DESCRIPTION
For x86_64, it seems that integer values passed in registers should be sign-extended to at least 32 bits. In the case that a foreign-call argument is passed via `(& integer-8)` or `(& integer-16)` — which no one is likely to do in practice! — the sign extension didn't happen.

Clang on macOS apparently only takes advantage of the sign extension when compiling with optimization, but  "foreign1.mo" is compiled without optimization, so the existing test didn't find the problem. This patch changes the "s/Mf-..." files for x86_64 macOS and Linux to include `-O2` when compiling, but a more consistent change probably would be better. (For the Racket branch of Chez Scheme, the makefiles have been revised so that flags used for compiling the kernel are also used to compile `foreign1.mo`, and that's how the bug was exposed.)
