### PR TITLE
fix misnamed pattern variables in bytevector-*-ref

### DIFF
--- a/LOG
+++ b/LOG
@@ -2188,3 +2188,5 @@
 - fix x86_64 (& integer-8) and (& integer-16) foreign-call argument
   passing
     x86_64, s/Mf-[t]a6{le,osx}
+- fixed misnamed pattern variables in bytevector-*-ref
+    bytevector.ss

--- a/s/bytevector.ss
+++ b/s/bytevector.ss
@@ -296,8 +296,8 @@
           [(kwd s/u bits)
            (with-syntax ([prim-name (construct-name #'kwd "bytevector-" #'s/u #'bits "-ref")]
                          [native-name (construct-name #'kwd "bytevector-" #'s/u #'bits "-native-ref")]
-                         [little-set! (construct-name #'kwd "little-ref-" #'s/u #'bits)]
-                         [big-set! (construct-name #'kwd "big-ref-" #'s/u #'bits)])
+                         [little-ref (construct-name #'kwd "little-ref-" #'s/u #'bits)]
+                         [big-ref (construct-name #'kwd "big-ref-" #'s/u #'bits)])
              #`(lambda (v i eness who)
                  (unless (bytevector? v) (not-a-bytevector who v))
                  (unaligned-ref-check who (fxquotient bits 8) v i)


### PR DESCRIPTION
This fixes misnamed pattern variables in bytevector-*-ref. It appears to be a cut & paste bug since before open-sourcing.

Practically, this has no effect as the affected code is avoided by `unaligned-integers` which appears to be `#t` for all currently supported platforms.  Flipping `unaligned-integers` to `#f` appears to emit the proper code, but there are other compile errors down the chain.  There may be a larger issue here of whether `unaligned-integers` should be supported option.