### PR TITLE
makefile updates

### DIFF
--- a/LOG
+++ b/LOG
@@ -2188,3 +2188,9 @@
 - fix x86_64 (& integer-8) and (& integer-16) foreign-call argument
   passing
     x86_64, s/Mf-[t]a6{le,osx}
+- escape $(MAKE) to fix parallel mat issue observed with GNU Make 4.2.1:
+  "make[1]: warning: jobserver unavailable: using -j1."
+    mats/Mf-base
+- export some Mf-config variables and include Mf-config in mats to support
+  arm32le cross-compilation
+    c/Mf-base, mats/Mf-arm32le, mats/Mf-base

--- a/c/Mf-base
+++ b/c/Mf-base
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 include Mf-config
+export CC CFLAGS LD LDFLAGS
 
 Include=../boot/$m
 PetiteBoot=../boot/$m/petite.boot

--- a/mats/Mf-arm32le
+++ b/mats/Mf-arm32le
@@ -21,7 +21,7 @@ fobj = foreign1.so
 include Mf-base
 
 foreign1.so: ${fsrc} ../boot/$m/scheme.h
-	$(CC) -fPIC -fomit-frame-pointer -shared -I${Include} -o foreign1.so ${fsrc}
+	$(CC) ${CFLAGS} -fPIC -fomit-frame-pointer -shared -I${Include} -o foreign1.so ${fsrc}
 
 cat_flush: cat_flush.c
-	$(CC) -o cat_flush cat_flush.c
+	$(CC) ${CFLAGS} -o cat_flush cat_flush.c

--- a/mats/Mf-base
+++ b/mats/Mf-base
@@ -55,6 +55,8 @@ else
   ExeSuffix =
 endif
 
+include ../c/Mf-config
+
 # Scheme is the scheme executable to test, SCHEMEHEAPDIRS tells
 # it where to find its boot files, and CHEZSCHEMELIBDIRS tells
 # it where to find libraries.
@@ -259,9 +261,9 @@ doallcoverage: mat.so
 
 define parallel-config-template
 parallel$(1)-0:
-	-@$(MAKE) allxphelp outdir=output-$(1)-0 objdir=output-$(1)-0 o=0 $(2)
+	-@$$(MAKE) allxphelp outdir=output-$(1)-0 objdir=output-$(1)-0 o=0 $(2)
 parallel$(1)-3:
-	-@$(MAKE) allxphelp outdir=output-$(1)-3 objdir=output-$(1)-3 o=3 $(2)
+	-@$$(MAKE) allxphelp outdir=output-$(1)-3 objdir=output-$(1)-3 o=3 $(2)
 endef
 
 #configs from partialx and allx
@@ -298,9 +300,9 @@ define parallel-target-template
 $(1)-targets: $($(1)-confs:%=parallel%)
 $(1): prettyclean
 	@echo building prereqs with output to Make.out
-	@$(MAKE) parallel-prereqs > Make.out 2>&1
-	@$(MAKE) $(1)-targets
-	$(if $(2),@$(MAKE) $(2))
+	@$$(MAKE) parallel-prereqs > Make.out 2>&1
+	@$$(MAKE) $(1)-targets
+	$(if $(2),@$$(MAKE) $(2))
 	cat $($(1)-confs:%=output-%/summary) > summary && cat summary
 endef
 


### PR DESCRIPTION
### Overview

These updates support cross-compiling arm32le and fix an issue with `make -j 8 partialx` for recent GNU Make.

* Escape `$(MAKE)` to fix parallel mat issue observed with GNU Make 4.2.1:
"make[1]: warning: jobserver unavailable: using -j1."
  mats/Mf-base
* Export some Mf-config variables and include Mf-config in mats to support
arm32le cross-compilation
  c/Mf-base, mats/Mf-arm32le, mats/Mf-base

### Cross-compiling ARM32 in a Ubuntu 20.04 VM or container

#### Install arm32 cross-complilation tools:
``` sh
$ sudo apt install binutils-arm-linux-gnueabihf gcc-arm-linux-gnueabihf
```
#### Install arm32 libraries
``` sh
$ sudo dpkg --add-architecture armhf
$ sudo vi /etc/apt/sources.list
```
Add the following lines to /etc/apt/sources.list:
```
deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ focal main restricted
deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted
deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted
```
The following gives some "Failed to fetch ..." error messages, but the rest seems to work.
``` sh
$ sudo apt update
$ sudo apt install uuid-dev:armhf libncurses-dev:armhf libx11-dev:armhf
```
#### Cross-compile arm32le Chez Scheme boot file on a6le host

1. cd ChezScheme
2. ./configure
3. make
4. cd a6le
5. make -f Mf-boot arm32le.boot
6. cd ..
7. ./configure -m=arm32le --workarea=arm32le --toolprefix=arm-linux-gnueabihf- CFLAGS=-marm
8. cd arm32le/c
9. make
#### Install qemu-user-binfmt
Install qemu-user or qemu-user-binfmt (if supported on your platform). The latter lets you
run arm32 binaries transparently, which is really slick.
``` sh
$ sudo apt install qemu-user qemu-user-binfmt
```
#### Run arm32 Chez Scheme
I had to set `QEMU_RESERVED_VA` to prevent qemu from aborting with "Unable to reserve 0xffff0000 bytes of virtual address space for use as guest address space".
``` sh
$ export QEMU_RESERVED_VA=2147483648
$ ../bin/scheme -b ../boot/arm32le/petite.boot -b ../boot/arm32le/scheme.boot
```
#### Mat errors
With `qemu-arm` version 4.2.1 on Ubuntu 20.04 there are some "illegal instruction" errors in foreign.mo and ftype.mo that seem to involve `ftype-lock!` operations. Guessing this is an issue with `ldrex` / `strex`, perhaps only in emulation.