### PR TITLE
add workaround for Rosetta 2 bug in [t]a6osx builds

### DIFF
--- a/LOG
+++ b/LOG
@@ -2190,3 +2190,9 @@
     x86_64, s/Mf-[t]a6{le,osx}
 - fixed misnamed pattern variables in bytevector-*-ref
     bytevector.ss
+- add workaround for Rosetta 2 bug in [t]a6osx builds.  The overhead
+  during native (x86) execution is the addition of a single int compare
+  and branch in S_bytevector_read, plus a small amount of work at startup
+  to determine whether we are running under Rosetta translation.
+    c/new-io.c c/scheme.c c/version.h
+

--- a/c/scheme.c
+++ b/c/scheme.c
@@ -976,8 +976,10 @@ extern void Sscheme_init(abnormal_exit) void (*abnormal_exit) PROTO((void)); {
   S_pagesize = GETPAGESIZE();
 
   idiot_checks();
+#if defined(CHECK_FOR_ROSETTA)
   init_rosetta_check();
-
+#endif
+  
   switch (current_state) {
     case RUNNING:
       fprintf(stderr, "error (Sscheme_init): call Sscheme_deinit first to terminate\n");

--- a/c/scheme.c
+++ b/c/scheme.c
@@ -939,6 +939,27 @@ extern void Sretain_static_relocation(void) {
   S_G.retain_static_relocation = 1;
 }
 
+#if defined(CHECK_FOR_ROSETTA)
+#include <sys/sysctl.h>
+int is_rosetta = 0;
+static void init_rosetta_check() {
+  int val = 0;
+  size_t size = sizeof(val);
+  if (sysctlbyname("sysctl.proc_translated", &val, &size, NULL, 0) != 0) {
+    if (errno == ENOENT) {
+         is_rosetta = 0;
+    } else {
+      perror("checking to see if running under Rosetta");
+      // if for some reason we can't tell whether we are running under Rosetta or not,
+      // default to the safer choice.  It doesn't impact correctness to do the Rosetta
+      // workarounds when they are not needed.
+      is_rosetta = 1;
+    }
+  }
+  is_rosetta = val;
+}
+#endif
+
 #ifdef ITEST
 #include "itest.c"
 #endif
@@ -955,6 +976,7 @@ extern void Sscheme_init(abnormal_exit) void (*abnormal_exit) PROTO((void)); {
   S_pagesize = GETPAGESIZE();
 
   idiot_checks();
+  init_rosetta_check();
 
   switch (current_state) {
     case RUNNING:

--- a/c/version.h
+++ b/c/version.h
@@ -291,6 +291,12 @@ typedef int tputsputcchar;
 #if (machine_type == machine_type_ti3osx || machine_type == machine_type_ta6osx)
 #define PTHREADS
 #endif
+#if (machine_type == machine_type_a6osx || machine_type == machine_type_ta6osx)
+#ifndef NO_ROSETTA_CHECK
+#define CHECK_FOR_ROSETTA
+extern int is_rosetta;
+#endif
+#endif
 #define MACOSX
 #define NOBLOCK O_NONBLOCK
 #define LOAD_SHARED_OBJECT


### PR DESCRIPTION
From the description in S_bytevector_read in c/new-io.c:
  /* If we are running on Apple Silicon under Rosetta 2 translation, work around
     a bug (present in 11.3.1 at least) in its handling of memory page protection
     bits.  One of the tasks that Rosetta handles is to appropriately twiddle the
     execute and write bits based on what's happinging to the memory in order to
     preserve the illusion that the pages have RWX permissions, whereas Apple
     Silicon enforces a W^X (write XOR execute) model.  For some reason, this
     bit-twiddling sometimes fails when the bytevector passed to `read` extends
     onto a page that's currently R-X, causing the `read` to fail with EFAULT
     ("bad address").  By writing to each subsequent page, we force Rosetta to
     do the right magic to the protection bits.  (Or at least it makes the error
     go away and all the mats pass.)
     */

This workaround can be removed completely by building with
NO_ROSETTA_CHECK defined.

If NO_ROSETTA_CHECK is not defined and we are building a6osx or ta6osx
then a new global variable `is_rosetta` is added and intitialized during
s_init.  This variable is consulted in S_bytevector_read.