### PR TITLE
Separate code allocation segments

### DIFF
--- a/LOG
+++ b/LOG
@@ -2190,3 +2190,5 @@
     x86_64, s/Mf-[t]a6{le,osx}
 - fixed misnamed pattern variables in bytevector-*-ref
     bytevector.ss
+- distinguish code vs non-code allocation segments.  This will be
+  required to port to architectures that enforce W^X semantics.

--- a/c/externs.h
+++ b/c/externs.h
@@ -341,7 +341,7 @@ extern INT matherr PROTO((struct exception *x));
 
 /* segment.c */
 extern void S_segment_init PROTO((void));
-extern void *S_getmem PROTO((iptr bytes, IBOOL zerofill));
+extern void *S_getmem PROTO((iptr bytes, IBOOL zerofill, IBOOL for_code));
 extern void S_freemem PROTO((void *addr, iptr bytes));
 extern iptr S_find_segments PROTO((ISPC s, IGEN g, iptr n));
 extern void S_free_chunk PROTO((chunkinfo *chunk));
@@ -350,6 +350,8 @@ extern uptr S_curmembytes PROTO((void));
 extern uptr S_maxmembytes PROTO((void));
 extern void S_resetmaxmembytes PROTO((void));
 extern void S_move_to_chunk_list PROTO((chunkinfo *chunk, chunkinfo **pchunk_list));
+extern void S_thread_start_code_write(void);
+extern void S_thread_end_code_write(void);
 
 /* stats.c */
 extern void S_stats_init PROTO((void));

--- a/c/fasl.c
+++ b/c/fasl.c
@@ -470,6 +470,9 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf) {
       struct faslFileObj ffo;
 
       ty = uf_bytein(uf);
+
+      S_thread_start_code_write();
+
       switch (ty) {
         case fasl_type_gzip:
         case fasl_type_lz4: {
@@ -505,6 +508,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf) {
       }
       faslin(tc, &x, S_G.null_vector, &strbuf, &ffo);
       S_flush_instruction_cache(tc);
+      S_thread_end_code_write();
       return x;
     } else {
       uf_skipbytes(uf, size);

--- a/c/gc.c
+++ b/c/gc.c
@@ -779,6 +779,8 @@ void GCENTRY GCENTRY_PROTO(ptr tc, IGEN max_cg, IGEN min_tg, IGEN max_tg) {
 #endif /* !NO_LOCKED_OLDSPACE_OBJECTS */
     DECLARE_CTGS(max_cg, min_tg, max_tg);
 
+    S_thread_start_code_write();
+
    /* flush instruction cache: effectively clear_code_mod but safer */
     for (ls = S_threads; ls != Snil; ls = Scdr(ls)) {
       ptr tc = (ptr)THREADTC(Scar(ls));
@@ -1312,6 +1314,7 @@ void GCENTRY GCENTRY_PROTO(ptr tc, IGEN max_cg, IGEN min_tg, IGEN max_tg) {
     if (max_cg >= S_G.min_free_gen) S_free_chunks();
 
     S_flush_instruction_cache(tc);
+    S_thread_end_code_write();
 
 #ifndef NO_DIRTY_NEWSPACE_POINTERS
     /* mark dirty those newspace cards to which we've added wrong-way pointers */

--- a/c/gc.c
+++ b/c/gc.c
@@ -1286,7 +1286,7 @@ void GCENTRY GCENTRY_PROTO(ptr tc, IGEN max_cg, IGEN min_tg, IGEN max_tg) {
         si->next = S_G.occupied_segments[g][s];
         S_G.occupied_segments[g][s] = si;
       } else {
-        chunkinfo *chunk = si->chunk;
+        chunkinfo *chunk = si->chunk, **chunks = ((si->space == space_code) ? S_code_chunks : S_chunks);
         if (si->generation != static_generation) S_G.number_of_nonstatic_segments -= 1;
         S_G.number_of_empty_segments += 1;
         si->space = space_empty;
@@ -1301,10 +1301,10 @@ void GCENTRY GCENTRY_PROTO(ptr tc, IGEN max_cg, IGEN min_tg, IGEN max_tg) {
              * small stuff into them and thereby invite fragmentation */
             S_free_chunk(chunk);
           } else {
-            S_move_to_chunk_list(chunk, &S_chunks[PARTIAL_CHUNK_POOLS]);
+            S_move_to_chunk_list(chunk, &chunks[PARTIAL_CHUNK_POOLS]);
           }
         } else {
-          S_move_to_chunk_list(chunk, &S_chunks[PARTIAL_CHUNK_POOLS-1]);
+          S_move_to_chunk_list(chunk, &chunks[PARTIAL_CHUNK_POOLS-1]);
         }
       }
     }

--- a/c/globals.h
+++ b/c/globals.h
@@ -53,6 +53,8 @@ EXTERN seginfo *S_segment_info[1<<segment_t1_bits];
 
 EXTERN chunkinfo *S_chunks_full;
 EXTERN chunkinfo *S_chunks[PARTIAL_CHUNK_POOLS+1];
+EXTERN chunkinfo *S_code_chunks_full;
+EXTERN chunkinfo *S_code_chunks[PARTIAL_CHUNK_POOLS+1];
 
 /* schsig.c */
 EXTERN IBOOL S_pants_down;

--- a/c/intern.c
+++ b/c/intern.c
@@ -115,7 +115,7 @@ void S_intern_init() {
     S_G.oblist_length_pointer = &oblist_lengths[3];
     S_G.oblist_length = *S_G.oblist_length_pointer;
     S_G.oblist_count = 0;
-    S_G.oblist = S_getmem(S_G.oblist_length * sizeof(bucket *), 1);
+    S_G.oblist = S_getmem(S_G.oblist_length * sizeof(bucket *), 1, 0);
     for (g = 0; g < static_generation; g += 1) S_G.buckets_of_generation[g] = NULL;
 }
 
@@ -165,7 +165,7 @@ void S_resize_oblist(void) {
   if (new_oblist_length_pointer == S_G.oblist_length_pointer) return;
 
   new_oblist_length = *new_oblist_length_pointer;
-  new_oblist = S_getmem(new_oblist_length * sizeof(bucket *), 1);
+  new_oblist = S_getmem(new_oblist_length * sizeof(bucket *), 1, 0);
 
   for (i = 0; i < S_G.oblist_length; i += 1) {
     for (b = S_G.oblist[i]; b != NULL; b = bnext) {

--- a/c/prim.c
+++ b/c/prim.c
@@ -200,6 +200,9 @@ static void s_instantiate_code_object() {
     proc = S_get_scheme_arg(tc, 3);
 
     tc_mutex_acquire()
+
+    S_thread_start_code_write();
+
     new = S_code(tc, CODETYPE(old), CODELEN(old));
     tc_mutex_release()
 
@@ -248,6 +251,8 @@ static void s_instantiate_code_object() {
            S_set_code_obj("fcallable", RELOC_TYPE(entry), new, a, obj, item_off);
     }
     S_flush_instruction_cache(tc);
+
+    S_thread_end_code_write();
 
     AC0(tc) = new;
 }

--- a/c/prim5.c
+++ b/c/prim5.c
@@ -232,7 +232,7 @@ static ptr sorted_chunk_list(void) {
       n += 1;
     }
     for (chunk = (i == -1) ? S_code_chunks_full : S_code_chunks[i]; chunk != NULL; chunk = chunk->next) {
-      ls = Scons(TO_PTR(chunk), ls);
+      ls = Scons(chunk, ls);
       n += 1;
     }
   }

--- a/c/prim5.c
+++ b/c/prim5.c
@@ -231,6 +231,10 @@ static ptr sorted_chunk_list(void) {
       ls = Scons(chunk, ls);
       n += 1;
     }
+    for (chunk = (i == -1) ? S_code_chunks_full : S_code_chunks[i]; chunk != NULL; chunk = chunk->next) {
+      ls = Scons(TO_PTR(chunk), ls);
+      n += 1;
+    }
   }
 
   return sort_chunks(ls, n);

--- a/c/segment.c
+++ b/c/segment.c
@@ -38,7 +38,7 @@ Low-level Memory management strategy:
 
 static void out_of_memory PROTO((void));
 static void initialize_seginfo PROTO((seginfo *si, ISPC s, IGEN g));
-static seginfo *allocate_segments PROTO((uptr nreq));
+static seginfo *allocate_segments PROTO((uptr nreq, IBOOL for_code));
 static void expand_segment_table PROTO((uptr base, uptr end, seginfo *si));
 static void contract_segment_table PROTO((uptr base, uptr end));
 static void add_to_chunk_list PROTO((chunkinfo *chunk, chunkinfo **pchunk_list));
@@ -51,7 +51,11 @@ void S_segment_init() {
   if (!S_boot_time) return;
 
   S_chunks_full = NULL;
-  for (i = PARTIAL_CHUNK_POOLS; i >= 0; i -= 1) S_chunks[i] = NULL;
+  S_code_chunks_full = NULL;
+  for (i = PARTIAL_CHUNK_POOLS; i >= 0; i -= 1) {
+    S_chunks[i] = NULL;
+    S_code_chunks[i] = NULL;
+  }
   for (g = 0; g <= static_generation; g++) {
     for (s = 0; s <= max_real_space; s++) {
       S_G.occupied_segments[g][s] = NULL;
@@ -70,7 +74,7 @@ static void out_of_memory(void) {
 }
 
 #if defined(USE_MALLOC)
-void *S_getmem(iptr bytes, IBOOL zerofill) {
+void *S_getmem(iptr bytes, IBOOL zerofill, UNUSED IBOOL for_code) {
   void *addr;
 
   if ((addr = malloc(bytes)) == (void *)0) out_of_memory();
@@ -90,7 +94,7 @@ void S_freemem(void *addr, iptr bytes) {
 
 #if defined(USE_VIRTUAL_ALLOC)
 #include <winbase.h>
-void *S_getmem(iptr bytes, IBOOL zerofill) {
+void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
   void *addr;
 
   if ((uptr)bytes < S_pagesize) {
@@ -100,7 +104,8 @@ void *S_getmem(iptr bytes, IBOOL zerofill) {
     if (zerofill) memset(addr, 0, bytes);
   } else {
     uptr n = S_pagesize - 1; iptr p_bytes = (iptr)(((uptr)bytes + n) & ~n);
-    if ((addr = VirtualAlloc((void *)0, (SIZE_T)p_bytes, MEM_COMMIT, PAGE_EXECUTE_READWRITE)) == (void *)0) out_of_memory();
+    int perm = (for_code ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
+    if ((addr = VirtualAlloc((void *)0, (SIZE_T)p_bytes, MEM_COMMIT, perm)) == (void *)0) out_of_memory();
     if ((membytes += p_bytes) > maxmembytes) maxmembytes = membytes;
     debug(printf("getmem VirtualAlloc(%p => %p) -> %p\n", bytes, p_bytes, addr))
   }
@@ -127,7 +132,7 @@ void S_freemem(void *addr, iptr bytes) {
 #ifndef MAP_ANONYMOUS
 #define MAP_ANONYMOUS MAP_ANON
 #endif
-void *S_getmem(iptr bytes, IBOOL zerofill) {
+void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
   void *addr;
 
   if ((uptr)bytes < S_pagesize) {
@@ -137,12 +142,14 @@ void *S_getmem(iptr bytes, IBOOL zerofill) {
     if (zerofill) memset(addr, 0, bytes);
   } else {
     uptr n = S_pagesize - 1; iptr p_bytes = (iptr)(((uptr)bytes + n) & ~n);
+    int perm = (for_code ? S_PROT_CODE : (PROT_WRITE | PROT_READ));
+    int flags = (MAP_PRIVATE | MAP_ANONYMOUS) | (for_code ? S_MAP_CODE : 0);
 #ifdef MAP_32BIT
     /* try for first 2GB of the memory space first of x86_64 so that we have a
        better chance of having short jump instructions */
-    if ((addr = mmap(NULL, p_bytes, PROT_EXEC|PROT_WRITE|PROT_READ, MAP_PRIVATE|MAP_ANONYMOUS|MAP_32BIT, -1, 0)) == (void *)-1) {
+    if ((addr = mmap(NULL, p_bytes, perm, flags|MAP_32BIT, -1, 0)) == (void *)-1) {
 #endif
-      if ((addr = mmap(NULL, p_bytes, PROT_EXEC|PROT_WRITE|PROT_READ, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)) == (void *)-1) {
+      if ((addr = mmap(NULL, p_bytes, perm, flags, -1, 0)) == (void *)-1) {
         out_of_memory();
         debug(printf("getmem mmap(%p) -> %p\n", bytes, addr))
       }
@@ -232,26 +239,29 @@ static void initialize_seginfo(seginfo *si, ISPC s, IGEN g) {
 }
 
 iptr S_find_segments(s, g, n) ISPC s; IGEN g; iptr n; {
-  chunkinfo *chunk, *nextchunk;
+  chunkinfo *chunk, *nextchunk, **chunks;
   seginfo *si, *nextsi, **prevsi;
   iptr nunused_segs, j;
   INT i, loser_index;
+  IBOOL for_code = ((s == space_code));
 
   if (g != static_generation) S_G.number_of_nonstatic_segments += n;
 
   debug(printf("attempting to find %d segments for space %d, generation %d\n", n, s, g))
 
+  chunks = (for_code ? S_code_chunks : S_chunks);
+
   if (n == 1) {
     for (i = 0; i <= PARTIAL_CHUNK_POOLS; i++) {
-      chunk = S_chunks[i];
+      chunk = chunks[i];
       if (chunk != NULL) {
         si = chunk->unused_segs;
         chunk->unused_segs = si->next;
 
         if (chunk->unused_segs == NULL) {
-          S_move_to_chunk_list(chunk, &S_chunks_full);
+          S_move_to_chunk_list(chunk, (for_code ? &S_code_chunks_full : &S_chunks_full));
         } else if (i == PARTIAL_CHUNK_POOLS) {
-          S_move_to_chunk_list(chunk, &S_chunks[PARTIAL_CHUNK_POOLS-1]);
+          S_move_to_chunk_list(chunk, &chunks[PARTIAL_CHUNK_POOLS-1]);
         }
 
         chunk->nused_segs += 1;
@@ -265,7 +275,7 @@ iptr S_find_segments(s, g, n) ISPC s; IGEN g; iptr n; {
   } else {
     loser_index = (n == 2) ? 0 : find_index(n-1);
     for (i = find_index(n); i <= PARTIAL_CHUNK_POOLS; i += 1) {
-      chunk = S_chunks[i];
+      chunk = chunks[i];
       while (chunk != NULL) {
         if (n < (nunused_segs = (chunk->segs - chunk->nused_segs))) {
           sort_chunk_unused_segments(chunk);
@@ -285,9 +295,9 @@ iptr S_find_segments(s, g, n) ISPC s; IGEN g; iptr n; {
               if (--j == 0) {
                 *prevsi = nextsi->next;
                 if (chunk->unused_segs == NULL) {
-                  S_move_to_chunk_list(chunk, &S_chunks_full);
+                  S_move_to_chunk_list(chunk, (for_code ? &S_code_chunks_full : &S_chunks_full));
                 } else if (i == PARTIAL_CHUNK_POOLS) {
-                  S_move_to_chunk_list(chunk, &S_chunks[PARTIAL_CHUNK_POOLS-1]);
+                  S_move_to_chunk_list(chunk, &chunks[PARTIAL_CHUNK_POOLS-1]);
                 }
                 chunk->nused_segs += n;
                 nextsi->next = S_G.occupied_segments[g][s];
@@ -303,7 +313,7 @@ iptr S_find_segments(s, g, n) ISPC s; IGEN g; iptr n; {
         }
         nextchunk = chunk->next;
         if (i != loser_index && i != PARTIAL_CHUNK_POOLS) {
-          S_move_to_chunk_list(chunk, &S_chunks[loser_index]);
+          S_move_to_chunk_list(chunk, &chunks[loser_index]);
         }
         chunk = nextchunk;
       }
@@ -311,7 +321,7 @@ iptr S_find_segments(s, g, n) ISPC s; IGEN g; iptr n; {
   }
 
   /* we couldn't find space, so ask for more */
-  si = allocate_segments(n);
+  si = allocate_segments(n, for_code);
   for (nextsi = si; n > 0; n -= 1, nextsi += 1) {
     initialize_seginfo(nextsi, s, g);
     /* add segment to appropriate list of occupied segments */
@@ -325,7 +335,7 @@ iptr S_find_segments(s, g, n) ISPC s; IGEN g; iptr n; {
  * allocates a group of n contiguous fresh segments, returning the
  * segment number of the first segment of the group.
  */
-static seginfo *allocate_segments(nreq) uptr nreq; {
+static seginfo *allocate_segments(uptr nreq, UNUSED IBOOL for_code) {
   uptr nact, bytes, base; void *addr;
   iptr i;
   chunkinfo *chunk; seginfo *si;
@@ -333,7 +343,7 @@ static seginfo *allocate_segments(nreq) uptr nreq; {
   nact = nreq < minimum_segment_request ? minimum_segment_request : nreq;
 
   bytes = (nact + 1) * bytes_per_segment;
-  addr = S_getmem(bytes, 0);
+  addr = S_getmem(bytes, 0, for_code);
   debug(printf("allocate_segments addr = %p\n", addr))
 
   base = addr_get_segment((uptr)addr + bytes_per_segment - 1);
@@ -343,7 +353,7 @@ static seginfo *allocate_segments(nreq) uptr nreq; {
   if (build_ptr(base, 0) == addr && base + nact != ((uptr)1 << (ptr_bits - segment_offset_bits)) - 1)
     nact += 1;
 
-  chunk = S_getmem(sizeof(chunkinfo) + sizeof(seginfo) * nact, 0);
+  chunk = S_getmem(sizeof(chunkinfo) + sizeof(seginfo) * nact, 0, 0);
   debug(printf("allocate_segments chunk = %p\n", chunk))
   chunk->addr = addr;
   chunk->base = base;
@@ -371,9 +381,9 @@ static seginfo *allocate_segments(nreq) uptr nreq; {
  /* account for trailing empty segments */
   if (nact > nreq) {
     S_G.number_of_empty_segments += nact - nreq;
-    add_to_chunk_list(chunk, &S_chunks[PARTIAL_CHUNK_POOLS-1]);
+    add_to_chunk_list(chunk, &((for_code ? S_code_chunks : S_chunks)[PARTIAL_CHUNK_POOLS-1]));
   } else {
-    add_to_chunk_list(chunk, &S_chunks_full);
+    add_to_chunk_list(chunk, (for_code ? &S_code_chunks_full : &S_chunks_full));
   }
 
   return &chunk->sis[0];
@@ -393,15 +403,24 @@ void S_free_chunk(chunkinfo *chunk) {
  * nonempty nonstatic segment. */
 void S_free_chunks(void) {
   iptr ntofree;
-  chunkinfo *chunk, *nextchunk;
+  chunkinfo *chunk, *code_chunk, *nextchunk= NULL, *code_nextchunk = NULL;
 
   ntofree = S_G.number_of_empty_segments -
     (iptr)(Sflonum_value(SYMVAL(S_G.heap_reserve_ratio_id)) * S_G.number_of_nonstatic_segments);
 
-  for (chunk = S_chunks[PARTIAL_CHUNK_POOLS]; ntofree > 0 && chunk != NULL; chunk = nextchunk) {
-    nextchunk = chunk->next;
-    ntofree -= chunk->segs;
-    S_free_chunk(chunk);
+  for (chunk = S_chunks[PARTIAL_CHUNK_POOLS], code_chunk = S_code_chunks[PARTIAL_CHUNK_POOLS];
+       ntofree > 0 && ((chunk != NULL) || (code_chunk != NULL));
+       chunk = nextchunk, code_chunk = code_nextchunk) {
+    if (chunk) {
+      nextchunk = chunk->next;
+      ntofree -= chunk->segs;
+      S_free_chunk(chunk);
+    }
+    if (code_chunk) {
+      code_nextchunk = code_chunk->next;
+      ntofree -= code_chunk->segs;
+      S_free_chunk(code_chunk);
+    }
   }
 }
 
@@ -430,14 +449,14 @@ static void expand_segment_table(uptr base, uptr end, seginfo *si) {
   while (base != end) {
 #ifdef segment_t3_bits
     if ((t2i = S_segment_info[SEGMENT_T3_IDX(base)]) == NULL) {
-      S_segment_info[SEGMENT_T3_IDX(base)] = t2i = (t2table *)S_getmem(sizeof(t2table), 1);
+      S_segment_info[SEGMENT_T3_IDX(base)] = t2i = (t2table *)S_getmem(sizeof(t2table), 1, 0);
     }
     t2 = t2i->t2;
 #else
     t2 = S_segment_info;
 #endif
     if ((t1i = t2[SEGMENT_T2_IDX(base)]) == NULL) {
-      t2[SEGMENT_T2_IDX(base)] = t1i = (t1table *)S_getmem(sizeof(t1table), 1);
+      t2[SEGMENT_T2_IDX(base)] = t1i = (t1table *)S_getmem(sizeof(t1table), 1, 0);
 #ifdef segment_t3_bits
       t2i->refcount += 1;
 #endif
@@ -500,4 +519,28 @@ static void contract_segment_table(uptr base, uptr end) {
   t1end = t1 + end - base;
   while (t1 < t1end) *t1++ = NULL;
 #endif
+}
+
+/* Bracket all writes to `space_code` memory with calls to
+   `S_thread_start_code_write` and `S_thread_start_code_write'.
+
+   On a platform where a page cannot be both writable and executable
+   at the same time (a.k.a. W^X), AND assuming that the disposition is
+   thread-specific, the bracketing functions disable execution of the
+   code's memory while enabling writing.
+
+   Note that these function will not work for a W^X implementation
+   where each page's disposition is process-wide. Indeed, a
+   process-wide W^X disposition seems incompatible with the Chez
+   Scheme rule that a foreign thread is allowed to invoke a callback
+   (as long as the callback is immobile/locked) at any time --- even,
+   say, while Scheme is collecting garbage and needs to write to
+   executable pages. */
+
+void S_thread_start_code_write(void) {
+  S_ENABLE_CODE_WRITE(1);
+}
+
+void S_thread_end_code_write(void) {
+  S_ENABLE_CODE_WRITE(0);
 }

--- a/c/version.h
+++ b/c/version.h
@@ -85,6 +85,14 @@ typedef int tputsputcchar;
 #define NSECMTIME(sb) (sb).st_mtim.tv_nsec
 #define ICONV_INBUF_TYPE char **
 #define UNUSED __attribute__((__unused__))
+
+#if (machine_type == machine_type_arm64osx || machine_type == machine_type_tarm64osx)
+# define OS_ANY_MACOSX
+# if (machine_type == machine_type_tarm64osx)
+#  define PTHREADS
+# endif
+# define S_MAP_CODE  MAP_JIT
+# define S_ENABLE_CODE_WRITE(on) pthread_jit_write_protect_np(!(on))
 #endif
 
 #if (machine_type == machine_type_i3le || machine_type == machine_type_ti3le || machine_type == machine_type_a6le || machine_type == machine_type_ta6le)
@@ -451,3 +459,14 @@ typedef char tputsputcchar;
 #ifndef WRITE
 # define WRITE write
 #endif
+
+#ifndef S_PROT_CODE
+# define S_PROT_CODE (PROT_READ | PROT_WRITE | PROT_EXEC)
+#endif
+#ifndef S_MAP_CODE
+# define S_MAP_CODE 0
+#endif
+#ifndef S_ENABLE_CODE_WRITE
+# define S_ENABLE_CODE_WRITE(on) do { } while (0)
+#endif
+

--- a/c/version.h
+++ b/c/version.h
@@ -85,6 +85,7 @@ typedef int tputsputcchar;
 #define NSECMTIME(sb) (sb).st_mtim.tv_nsec
 #define ICONV_INBUF_TYPE char **
 #define UNUSED __attribute__((__unused__))
+#endif
 
 #if (machine_type == machine_type_arm64osx || machine_type == machine_type_tarm64osx)
 # define OS_ANY_MACOSX


### PR DESCRIPTION
Backport from Racket - distinguish code vs. non-code allocation segments.  This will be required to port to architectures that enforce W^X semantics (e.g., Apple Silicon).  At least I'm pretty sure it's required.  We can always wait until we have the rest of arm64osx implemented to see if it really is required before merging this in.

Requires through review.  All `bullyx` mats pass, but I'm not entirely sure that the code in `gcwrapper.c` does the right thing (since one of the comments says `space_code` is not supported in whatever that section of code is doing).  The Racket GC appears to have been largely rewritten, so comparing to that was not helpful.