### PR TITLE
Fix the release notes so `make docs` succeed

### DIFF
--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1912,11 +1912,10 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
-\subsection{Certain foreign calls with signed 8- and 16-bit integers on x86_64 (9.5.5)}
+\subsection{Certain foreign calls with signed 8- and 16-bit integers on x86\_64 (9.5.5)}
 
-The x86_64 code generator now properly sign-extends foreign-call
-arguments passed in registers via \scheme{(& integer-8)} and \code{(&
-integer-16)}.
+The x86\_64 code generator now properly sign-extends foreign-call
+arguments passed in registers via \scheme{(& integer-8)} and \scheme{(& integer-16)}.
 
 \subsection{Bitwise right shift of negative bignum (9.5.5)}
 


### PR DESCRIPTION
Commit 0d5ec1da7 broke the release notes, so a fix is needed in order to generate the docs.