### PR TITLE
include an identifier name in the syntax error for missing ellipsis

### DIFF
--- a/LOG
+++ b/LOG
@@ -2213,3 +2213,7 @@
     mats/6.ms, mats/root-experr-compile-0-f-f-f,
     mats/root-experr-compile-2-f-f-f, release_notes/release_notes.stex,
     s/read.ss
+- include an identifier name in the syntax error for missing ellipsis
+    mats/8.ms, mats/root-experr-compile-0-f-f-f,
+    mats/root-experr-compile-2-f-f-f, release_notes/release_notes.stex,
+    s/syntax.ss

--- a/mats/8.ms
+++ b/mats/8.ms
@@ -249,6 +249,10 @@
   (equal? ($dsmat-bar $dsmat-y) '(10 77))
   (error? ; misplaced ellipsis
     (with-syntax ([x 3]) #'#(... (x))))
+  (error? ; missing ellipsis
+    (syntax-case '((1 2) (3 4)) () [((x y) ...) #'(quote (x y ...))]))
+  (error? ; missing ellipsis
+    (syntax-case '((1 2) (3 4)) () [((v w) ...) #'(quote (v ... w))]))
   (equal?
     (let ()
       (define b)

--- a/mats/root-experr-compile-0-f-f-f
+++ b/mats/root-experr-compile-0-f-f-f
@@ -8191,6 +8191,8 @@ enum.mo:Expected error in mat enumeration: "make-record-type: cannot extend seal
 8.mo:Expected error in mat define-syntax: "extra ellipsis in syntax form (syntax (z ...))".
 8.mo:Expected error in mat define-syntax: "variable $dsmat-y is not bound".
 8.mo:Expected error in mat define-syntax: "misplaced ellipsis in syntax template (syntax #(... (x)))".
+8.mo:Expected error in mat define-syntax: "missing ellipsis for x in syntax form (syntax (quote (x y ...)))".
+8.mo:Expected error in mat define-syntax: "missing ellipsis for w in syntax form (syntax (quote (v ... w)))".
 8.mo:Expected error in mat r6rs:syntax-rules: "invalid syntax-rules clause ((_ a b) (identifier? (syntax a)) (let ((...)) (* a b)))".
 8.mo:Expected error in mat r6rs:syntax-rules: "invalid literals list in (syntax-rules (_))".
 8.mo:Expected error in mat r6rs:syntax-rules: "invalid literals list in (syntax-rules (_))".

--- a/mats/root-experr-compile-2-f-f-f
+++ b/mats/root-experr-compile-2-f-f-f
@@ -8191,6 +8191,8 @@ enum.mo:Expected error in mat enumeration: "make-record-type: cannot extend seal
 8.mo:Expected error in mat define-syntax: "extra ellipsis in syntax form (syntax (z ...))".
 8.mo:Expected error in mat define-syntax: "variable $dsmat-y is not bound".
 8.mo:Expected error in mat define-syntax: "misplaced ellipsis in syntax template (syntax #(... (x)))".
+8.mo:Expected error in mat define-syntax: "missing ellipsis for x in syntax form (syntax (quote (x y ...)))".
+8.mo:Expected error in mat define-syntax: "missing ellipsis for w in syntax form (syntax (quote (v ... w)))".
 8.mo:Expected error in mat r6rs:syntax-rules: "invalid syntax-rules clause ((_ a b) (identifier? (syntax a)) (let ((...)) (* a b)))".
 8.mo:Expected error in mat r6rs:syntax-rules: "invalid literals list in (syntax-rules (_))".
 8.mo:Expected error in mat r6rs:syntax-rules: "invalid literals list in (syntax-rules (_))".

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -63,6 +63,10 @@ Online versions of both books can be found at
 When the reader reports an invalid bytevector element, the error
 message now includes the token value only if the token type is atomic.
 
+When the expander reports that an ellipsis is missing in a syntax form,
+it now includes the name of an identifier that is missing an ellipsis
+within that form.
+
 \subsection{Additional reader syntax for booleans (9.5.5)}
 
 The reader now case-insensitively accepts \scheme{#true} and

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -6056,7 +6056,7 @@
         (if (fx= level 0)
             (values var maps)
             (if (null? maps)
-                (syntax-error src "missing ellipsis in syntax form")
+                (syntax-error src (format "missing ellipsis for ~s in syntax form" var))
                 (let-values ([(outer-var outer-maps) (gen-ref src var (fx- level 1) (cdr maps))])
                   (let ((b (assq outer-var (car maps))))
                     (if b


### PR DESCRIPTION
The expander now includes the name of an affected identifier when reporting than an ellipsis is missing within a syntax form.