### PR TITLE
Fix bug in printf with certain control strings and argument counts

### DIFF
--- a/LOG
+++ b/LOG
@@ -2239,3 +2239,6 @@
     csug/csug.stex bintar/Makefile rpm/Makefile pkg/Makefile
     wininstall/Makefile wininstall/a6nt.wxs wininstall/i3nt.wxs
     wininstall/ta6nt.wxs wininstall/ti3nt.wxs
+- fix bug in printf with certain control strings and argument counts
+    s/format.ss mats/format.ms mats/root-experr-compile-{0,2}-fff
+    release_notes/release_notes.stex

--- a/mats/format.ms
+++ b/mats/format.ms
@@ -42,6 +42,7 @@
   (error? (fprintf 'not-a-port "~a ~s" 17 34))
   (error? (format 'not-a-string-port-or-boolean "~a ~s" 17 34))
   (error? (format "bad~\rdirective"))
+  (error? (printf "~a~:*"))
 )
 
 (mat format-continuation ; like slib tests, but with \r\n for DOS

--- a/mats/root-experr-compile-0-f-f-f
+++ b/mats/root-experr-compile-0-f-f-f
@@ -7248,6 +7248,7 @@ format.mo:Expected error in mat format-errors: "printf: hello is not a string".
 format.mo:Expected error in mat format-errors: "fprintf: not-a-port is not a textual output port".
 format.mo:Expected error in mat format-errors: "format: not-a-string-port-or-boolean is not a string".
 format.mo:Expected error in mat format-errors: "format: unrecognized directive ~<return>".
+format.mo:Expected error in mat format-errors: "printf: too few arguments for control string "~a~:*"".
 format.mo:Expected error in mat format-plural: "format: too many arguments for control string "abc~:p"".
 format.mo:Expected error in mat format-plural: "format: no previous argument for ~:p".
 format.mo:Expected error in mat format-plural: "format: no previous argument for ~:@p".

--- a/mats/root-experr-compile-2-f-f-f
+++ b/mats/root-experr-compile-2-f-f-f
@@ -7248,6 +7248,7 @@ format.mo:Expected error in mat format-errors: "printf: hello is not a string".
 format.mo:Expected error in mat format-errors: "fprintf: not-a-port is not a textual output port".
 format.mo:Expected error in mat format-errors: "format: not-a-string-port-or-boolean is not a string".
 format.mo:Expected error in mat format-errors: "format: unrecognized directive ~<return>".
+format.mo:Expected error in mat format-errors: "printf: too few arguments for control string "~a~:*"".
 format.mo:Expected error in mat format-plural: "format: too many arguments for control string "abc~:p"".
 format.mo:Expected error in mat format-plural: "format: no previous argument for ~:p".
 format.mo:Expected error in mat format-plural: "format: no previous argument for ~:@p".

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1927,6 +1927,13 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Calls to \protect\scheme{printf} may cause an invalid memory reference at
+compile time (9.5.8)}
+
+A bug in the compiler that causes an invalid memory reference with particular
+\scheme{printf} control strings and argument counts has been fixed. One example is
+\scheme{(printf "~a~:*")}.
+
 \subsection{Certain foreign calls with signed 8- and 16-bit integers on x86\_64 (9.5.6)}
 
 The x86\_64 code generator now properly sign-extends foreign-call

--- a/s/format.ss
+++ b/s/format.ss
@@ -765,25 +765,26 @@
                 (let ([cmd (car cmd*)] [cmd* (cdr cmd*)])
                   (cond
                     [(string? cmd)
-                     (make-seq (make-call src display-string (build-quote cmd)  op)
+                     (make-seq (make-call src display-string (build-quote cmd) op)
                        (f cmd* arg* #f))]
                     [(char? cmd)
-                     (make-seq (make-call src write-char (build-quote cmd)  op)
+                     (make-seq (make-call src write-char (build-quote cmd) op)
                        (f cmd* arg* #f))]
                     [(fmt? cmd)
-                     (fmt-case cmd
-                       [simple-display ()
-                         (make-seq (make-call src display (car arg*) op)
-                           (f cmd* (cdr arg*) #f))]
-                       [simple-write ()
-                         (make-seq (make-call src write (car arg*) op)
-                           (f cmd* (cdr arg*) #f))]
-                       [cwrite (colon? at?)
-                         (and (not colon?)
-                              (not at?)
-                              (make-seq (make-call src write-char (car arg*) op)
-                                (f cmd* (cdr arg*) #f)))]
-                       [else #f])]
+                     (and (not (null? arg*))
+                          (fmt-case cmd
+                            [simple-display ()
+                              (make-seq (make-call src display (car arg*) op)
+                                (f cmd* (cdr arg*) #f))]
+                            [simple-write ()
+                              (make-seq (make-call src write (car arg*) op)
+                                (f cmd* (cdr arg*) #f))]
+                            [cwrite (colon? at?)
+                              (and (not colon?)
+                                   (not at?)
+                                   (make-seq (make-call src write-char (car arg*) op)
+                                     (f cmd* (cdr arg*) #f)))]
+                            [else #f]))]
                     [else ($oops 'fmt->expr "internal error: ~s" cmd)])))))))
 
   ;;; perform formatting operation from parsed string (cmd*)


### PR DESCRIPTION
`(lambda () (printf "~a~:*"))`