### PR TITLE
github workflow update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,13 @@ jobs:
       - name: Build Chez Scheme
         run: .github/workflows/build.sh
       - name: Run tests
+        timeout-minutes: 45
         run: .github/workflows/test.sh
       - name: Archive workspace
+        if: always()
         run: tar -c -h -z -f $TARGET_MACHINE.tgz $TARGET_MACHINE
       - name: Upload archive
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.config.machine }}


### PR DESCRIPTION
Always run the archive/upload workspace steps (even if previous
steps failed or timed out).

Set an explicit timeout for the "Run tests" step.  (Avoid waiting
for the default job-wide 6 hour timeout if the tests hang.)