### PR TITLE
Fix mats on Windows with MSYS

### DIFF
--- a/LOG
+++ b/LOG
@@ -2259,3 +2259,5 @@
     BUILDING, c/vs.bat, wininstall/locate-vcredist.bat
 - make threaded foreign mats more robust
     mats/foreign.ms
+- fix running mats on Windows
+    mats/Mf-a6nt mats mats/Mf-i3nt mats/Mf-ta6nt mats-Mf-ti6nt

--- a/mats/Mf-a6nt
+++ b/mats/Mf-a6nt
@@ -24,6 +24,8 @@ include Mf-base
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL=*
 
+export SCHEMEHEAPDIRS=../boot/%m
+
 foreign1.so: $(fsrc)
 	cmd.exe /c "vs.bat amd64 && cl /DWIN32 /DX86_64 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv957.lib $(fsrc)"
 

--- a/mats/Mf-i3nt
+++ b/mats/Mf-i3nt
@@ -24,6 +24,8 @@ include Mf-base
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL=*
 
+export SCHEMEHEAPDIRS=../boot/%m
+
 foreign1.so: $(fsrc)
 	cmd.exe /c "vs.bat x86 && cl /DWIN32 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv957.lib $(fsrc)"
 

--- a/mats/Mf-ta6nt
+++ b/mats/Mf-ta6nt
@@ -24,6 +24,8 @@ include Mf-base
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL=*
 
+export SCHEMEHEAPDIRS=../boot/%m
+
 foreign1.so: $(fsrc)
 	cmd.exe /c "vs.bat amd64 && cl /DWIN32 /DX86_64 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv957.lib $(fsrc)"
 

--- a/mats/Mf-ti3nt
+++ b/mats/Mf-ti3nt
@@ -24,6 +24,8 @@ include Mf-base
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL=*
 
+export SCHEMEHEAPDIRS=../boot/%m
+
 foreign1.so: $(fsrc)
 	cmd.exe /c "vs.bat x86 && cl /DWIN32 /Fe$@ /I${Include} /LD /MD /nologo ../bin/$m/csv957.lib $(fsrc)"
 


### PR DESCRIPTION
The absolute path for SCHEMEHEAPDIRS set in Mf-Base might be unix-style
on MSYS, which will not be understood by scheme. Setting it to a relative
path will work regardless of the environment used to build.

Tested with Cygwin and MSYS2.