### PR TITLE
Fix rational-valued? for numbers with an exceptional real part

### DIFF
--- a/LOG
+++ b/LOG
@@ -2259,3 +2259,5 @@
     BUILDING, c/vs.bat, wininstall/locate-vcredist.bat
 - make threaded foreign mats more robust
     mats/foreign.ms
+- fix rational-valued? for numbers with an exceptional real part
+    s/5_3.ss mats/5_1.ms

--- a/mats/5_1.ms
+++ b/mats/5_1.ms
@@ -726,6 +726,12 @@
     (not (rational-valued? +inf.0))
     (not (rational-valued? -inf.0))
     (not (rational-valued? +nan.0))
+    (not (rational-valued? +inf.0+0.0i))
+    (not (rational-valued? +inf.0-0.0i))
+    (not (rational-valued? -inf.0+0.0i))
+    (not (rational-valued? -inf.0-0.0i))
+    (not (rational-valued? +nan.0+0.0i))
+    (not (rational-valued? +nan.0-0.0i))
  )
 
 (mat integer?

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1950,6 +1950,14 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{\protect\scheme{rational-valued?} and exceptional flonums (9.5.8)}
+
+The \scheme{rational-value?} function returned incorrect results when called on
+a value with an inexact zero imaginary part and real part that is an exceptional
+floating point value (i.e., an infinity or NaN).  For example,
+\scheme{(rational-valued? +inf.0+0.0i)} incorrectly returned \scheme{#t}, but now
+returns \scheme{#f}.
+
 \subsection{Calls to foreign-callable procedures may cause the process to terminate with
 error 0xC0000409 STATUS\_STACK\_BUFFER\_OVERRUN on 64-bit Windows (9.5.8)}
 

--- a/s/5_3.ss
+++ b/s/5_3.ss
@@ -941,7 +941,9 @@
     (type-case x
       [(fixnum? bignum? ratnum?) #t]
       [(flonum?) (not (exceptional-flonum? x))]
-      [($inexactnum?) (fl= ($inexactnum-imag-part x) 0.0)]
+      [($inexactnum?)
+       (and (fl= ($inexactnum-imag-part x) 0.0)
+            (not (exceptional-flonum? ($inexactnum-real-part x))))]
       [else #f])))
 
 (set! real?


### PR DESCRIPTION
The result of

    (rational-valued? +inf.0+0.0i)

is `#t` but it should be `#f`.