### PR TITLE
consolidate $thread-check testing code

### DIFF
--- a/LOG
+++ b/LOG
@@ -2266,3 +2266,6 @@
   makes <=, =, and >= transitive as required by R6RS.  (< and > were
   already transitive, but the behavior is changed to match.)
     s/5_3.ss mats/5_3.ms
+- consolidate the $thread-check code in misc.ms and thread.ms, keeping
+  the thread.ms version of the code since it is more recent
+    mats/misc.ms mats/thread-check.ss mats/thread.ms

--- a/mats/misc.ms
+++ b/mats/misc.ms
@@ -1911,31 +1911,15 @@
     #t)
 
   (when-threaded
-    ; copied from thread.ms
-    (begin
-      (define $threads (foreign-procedure "(cs)threads" () scheme-object))
-      (define $nthreads 1)
-      (define $yield
-        (let ([t (make-time 'time-duration 1000 0)])
-          (lambda () (sleep t))))
-      (define $thread-check
-        (lambda ()
-          (let loop ([n 10] [nt (length ($threads))])
-            (cond
-              [(<= nt $nthreads)
-               (set! $nthreads nt)
-               (collect)]
-              [else
-                ($yield)
-                (let* ([ls ($threads)] [nnt (length ls)])
-                  (cond
-                    [(< nnt nt) (loop n nnt)]
-                    [(= n 0)
-                     (set! $nthreads nnt)
-                     (errorf #f "extra threads running ~s" ls)]
-                    [else (loop (- n 1) nnt)]))]))
-          #t))
-      ($thread-check)))
+    (let-syntax ([mats-dir-relative
+                  (lambda (x)
+                    (syntax-case x ()
+                      [(_ (include ?path))
+                       (string? (datum ?path))
+                       #`(include #,(format "~a/~a" *mats-dir* (datum ?path)))]))])
+      (mats-dir-relative
+        (include "../../mats/thread-check.ss")))
+    ($thread-check))
 
   (when-threaded
     ((lambda (x)

--- a/mats/thread-check.ss
+++ b/mats/thread-check.ss
@@ -1,0 +1,22 @@
+    (define $threads (foreign-procedure "(cs)threads" () scheme-object))
+    (define $nthreads 1)
+    (define $yield
+      (let ([t (make-time 'time-duration 1000000 0)])
+        (lambda () (sleep t))))
+    (define $thread-check
+      (lambda ()
+        (let loop ([n 100] [nt (length ($threads))])
+          (cond
+            [(<= nt $nthreads)
+             (set! $nthreads nt)
+             (collect)]
+            [else
+             ($yield)
+             (let* ([ls ($threads)] [nnt (length ls)])
+               (cond
+                 [(< nnt nt) (loop n nnt)]
+                 [(= n 0)
+                  (set! $nthreads nnt)
+                  (errorf #f "extra threads running ~s" ls)]
+                 [else (loop (- n 1) nnt)]))]))
+        #t))

--- a/mats/thread.ms
+++ b/mats/thread.ms
@@ -99,29 +99,15 @@
          (not (mutex? 'mutex))
          (not (thread-condition? 'condition))))
   (begin
-    (define $threads (foreign-procedure "(cs)threads" () scheme-object))
     (define $fib (lambda (x) (if (< x 2) 1 (+ ($fib (- x 1)) ($fib (- x 2))))))
-    (define $nthreads 1)
-    (define $yield
-      (let ([t (make-time 'time-duration 1000000 0)])
-        (lambda () (sleep t))))
-    (define $thread-check
-      (lambda ()
-        (let loop ([n 100] [nt (length ($threads))])
-          (cond
-            [(<= nt $nthreads)
-             (set! $nthreads nt)
-             (collect)]
-            [else
-             ($yield)
-             (let* ([ls ($threads)] [nnt (length ls)])
-               (cond
-                 [(< nnt nt) (loop n nnt)]
-                 [(= n 0)
-                  (set! $nthreads nnt)
-                  (errorf #f "extra threads running ~s" ls)]
-                 [else (loop (- n 1) nnt)]))]))
-        #t))
+    (let-syntax ([mats-dir-relative
+                  (lambda (x)
+                    (syntax-case x ()
+                      [(_ (include ?path))
+                       (string? (datum ?path))
+                       #`(include #,(format "~a/~a" *mats-dir* (datum ?path)))]))])
+      (mats-dir-relative
+        (include "../../mats/thread-check.ss")))
     (define $time-in-range?
       (lambda (start stop target)
         (let ([t (time-difference stop start)])


### PR DESCRIPTION
Consolidate the $thread-check code to bring the version in misc.ms up to date with the thread.ms changes from 0a6a1e14e7ecb9e39fa7a10a8584ed2fec24cbf4.

I noticed the code had gotten out of sync while investigating a spurious failure of $thread-check in misc.ms mat cost-center clause 45.