### PR TITLE
arm32le: only use cache sysconf constants if they are defined

### DIFF
--- a/LOG
+++ b/LOG
@@ -2304,3 +2304,5 @@
     csug/csug.stex bintar/Makefile rpm/Makefile pkg/Makefile
     wininstall/Makefile wininstall/a6nt.wxs wininstall/i3nt.wxs
     wininstall/ta6nt.wxs wininstall/ti3nt.wxs
+- fix arm32le compilation systems using musl libc
+    c/arm32le.c

--- a/c/arm32le.c
+++ b/c/arm32le.c
@@ -41,11 +41,13 @@ void S_doflush(uptr start, uptr end) {
 void S_machine_init(void) {
   int l1_dcache_line_size, l1_icache_line_size;
 
-  if ((l1_dcache_line_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE)) <= 0) {
+#ifdef _SC_LEVEL1_DCACHE_LINESIZE
+  if ((l1_dcache_line_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE)) <= 0)
+#endif
     l1_dcache_line_size = DEFAULT_L1_MAX_CACHE_LINE_SIZE;
-  }
-  if ((l1_icache_line_size = sysconf(_SC_LEVEL1_ICACHE_LINESIZE)) <= 0) {
+#ifdef _SC_LEVEL1_ICACHE_LINESIZE
+  if ((l1_icache_line_size = sysconf(_SC_LEVEL1_ICACHE_LINESIZE)) <= 0)
+#endif
     l1_icache_line_size = DEFAULT_L1_MAX_CACHE_LINE_SIZE;
-  }
   l1_max_cache_line_size = l1_dcache_line_size > l1_icache_line_size ? l1_dcache_line_size : l1_icache_line_size;
 }


### PR DESCRIPTION
This fixes compilation on musl libc which presently does not implement
these sysconf constants [\[0\]][0]. Please note though that this only fixes
compilation, there is still a separate run-time issue (see #622).

[0]: https://www.openwall.com/lists/musl/2017/07/24/1