### PR TITLE
add `make install-docs`

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -222,6 +222,11 @@ The make file supports several targets:
   installation.  If your system has a vim installation, then it might
   contain an rgb.txt in $VIMRUNTIME.
 
+'sudo make install-docs'
+  builds the documentation as with 'make docs' and installs it. If the installcsug and
+  installreleasenotes directories used with './configure' are writable by the current
+  user, then 'sudo' is not necessary.
+
 'make clean'
   removes binaries from the workarea.
 

--- a/LOG
+++ b/LOG
@@ -2306,3 +2306,6 @@
     wininstall/ta6nt.wxs wininstall/ti3nt.wxs
 - fix arm32le compilation systems using musl libc
     c/arm32le.c
+- added install-docs target for make and corresponding configuration
+  options: --installdoc, --installcsug, and --installreleasenotes
+    configure makefiles/Makefile.in

--- a/configure
+++ b/configure
@@ -34,6 +34,9 @@ installgroup=""
 installbin=""
 installlib=""
 installman=""
+installdoc=""
+installcsug=""
+installreleasenotes=""
 installschemename="scheme"
 installpetitename="petite"
 installscriptname="scheme-script"
@@ -189,6 +192,15 @@ while [ $# != 0 ] ; do
     --installman=*)
       installman=`echo $1 | sed -e 's/^--installman=//'`
       ;;
+    --installdoc=*)
+      installdoc=`echo $1 | sed -e 's/^--installdoc=//'`
+      ;;
+    --installcsug=*)
+      installcsug=`echo $1 | sed -e 's/^--installcsug=//'`
+      ;;
+    --installreleasenotes=*)
+      installreleasenotes=`echo $1 | sed -e 's/^--installreleasenotes=//'`
+      ;;
     --installowner=*)
       installowner=`echo $1 | sed -e 's/^--installowner=//'`
       ;;
@@ -334,6 +346,18 @@ if [ "$installman" = "" ] ; then
   installman=$installprefix/$installmansuffix
 fi
 
+if [ "$installdoc" = "" ] ; then
+  installdoc=$installprefix/share/doc
+fi
+
+if [ "$installcsug" = "" ] ; then
+  installcsug=$installdoc/csug9.5
+fi
+
+if [ "$installreleasenotes" = "" ] ; then
+  installreleasenotes=$installdoc/csv9
+fi
+
 if [ "$disablex11" = "no" ] ; then
   if [ $m = a6osx ] || [ $m = ta6osx ] ; then
     if [ ! -d /opt/X11/include/ ] ; then
@@ -360,6 +384,10 @@ if [ "$help" = "yes" ]; then
   echo "  --installbin=<pathname>           bin directory ($installbin)"
   echo "  --installlib=<pathname>           lib directory ($installlib)"
   echo "  --installman=<pathname>           manpage directory ($installman)"
+  echo "  --installdoc=<pathname>           documentation root ($installdoc)"
+  echo "  --installcsug=<pathname>          guide directory ($installcsug)"
+  # abbreviate "release notes" to fit default help in 80 cols:
+  echo "  --installreleasenotes=<pathname>  notes directory ($installreleasenotes)"
   echo "  --temproot=<pathname>             staging root ($temproot)"
   echo "  --installowner=<ownername>        install with owner ($installowner)"
   echo "  --installgroup=<groupname>        install with group ($installgroup)"
@@ -444,9 +472,11 @@ sed -e 's/$(m)/'$m'/g'\
   makefiles/Makefile.in > Makefile
 
 sed -e 's/$(m)/'$m'/g'\
+    -e "s;^installdir=.*\$;installdir=$installcsug;"\
     makefiles//Makefile-csug.in > csug/Makefile
 
 sed -e 's/$(m)/'$m'/g'\
+    -e "s;^installdir=.*\$;installdir=$installreleasenotes;"\
     makefiles//Makefile-release_notes.in > release_notes/Makefile
 
 cat makefiles/Makefile-workarea.in > $w/Makefile

--- a/makefiles/Makefile.in
+++ b/makefiles/Makefile.in
@@ -60,6 +60,11 @@ docs: build
 	(cd csug && $(MAKE) m=$(m))
 	(cd release_notes && $(MAKE) m=$(m))
 
+.PHONY: install-docs
+install-docs: docs
+	(cd csug && $(MAKE) install m=$(m))
+	(cd release_notes && $(MAKE) install m=$(m))
+
 .PHONY: bintar
 bintar:
 	(cd $(workarea) && $(MAKE) bintar)


### PR DESCRIPTION
The `configure` flags `--installdoc`, `--installcsug`, and `--installreleasenotes` control the installation location.

The commits https://github.com/racket/ChezScheme/commit/b75700b4a205a75d4c5f5128fbeb01a27eaaae6f (a.k.a. https://github.com/racket/racket/commit/a9dd06917cbdb3a14ac3572fb89bff061c9d6324) and https://github.com/racket/racket/commit/d897379ef64178347ba7af3f0314317433d00410 added this same interface to Racket's variant of Chez Scheme.

I have not changed `make install` to also install the documentation because it seems useful for `make install` to continue to work in environments without a TeX installation.