### PR TITLE
small repairs for old platforms

### DIFF
--- a/LOG
+++ b/LOG
@@ -2319,3 +2319,5 @@
     s/ppc32.ss
 - fix callable floating-point argument allocation on x86
     s/cpnanopass.ss
+- corrected signature of multibyte->string and string->multibyte
+    s/primdata.ss

--- a/LOG
+++ b/LOG
@@ -2317,4 +2317,5 @@
 - fix ppc32 conditional-branch code generation when displacement is
   exactly 32764
     s/ppc32.ss
-
+- fix callable floating-point argument allocation on x86
+    s/cpnanopass.ss

--- a/LOG
+++ b/LOG
@@ -2314,3 +2314,7 @@
   It now returns a negative number in this situation.
     cpnanopass.ss
     5_4.ms root-experr-* patch-*
+- fix ppc32 conditional-branch code generation when displacement is
+  exactly 32764
+    s/ppc32.ss
+

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1950,6 +1950,11 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Repair ppc32 code generation for a specific branch displacement (9.5.9)}
+
+Branch generation would go wrong if the displacement was exactly 32,764
+bytes.
+
 \subsection{\scheme{char-} returns negative results (9.6.0)}
 
 The character difference oprator returned a large positive integer in

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1950,6 +1950,16 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Repair callable floating-point argument allocation for x86 (9.5.9)}
+
+When a foreign callable receives a `double` or `float` argument, the
+allocation of space to box the number would try to save the
+floating-point return register in the (rare) case that allocation
+requires a new page of memory. Saving the return register harmless on
+most platforms, but on x86, a save and restore involves popping then
+pushing the x87 register stack, which is invalid if nothing was there
+at the start.
+
 \subsection{Repair ppc32 code generation for a specific branch displacement (9.5.9)}
 
 Branch generation would go wrong if the displacement was exactly 32,764

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -10641,7 +10641,7 @@
                    (Scheme->C type toC t)])))
             (define C->Scheme
               ; ASSUMPTIONS: ac0, ac1, and xp are not C argument registers
-              (lambda (type fromC lvalue)
+              (lambda (type fromC lvalue for-return?)
                 (define integer->ptr
                  ; ac0 holds low 32-bits, ac1 holds high 32 bits, if needed
                   (lambda (width lvalue)
@@ -10752,12 +10752,12 @@
                       ,(unsigned->ptr bits lvalue))]
                   [(fp-double-float)
                    (%seq
-                     (set! ,%xp ,(%constant-alloc type-flonum (constant size-flonum) #t))
+                     (set! ,%xp ,(%constant-alloc type-flonum (constant size-flonum) for-return?))
                      ,(fromC %xp)
                      (set! ,lvalue ,%xp))]
                   [(fp-single-float)
                    (%seq
-                     (set! ,%xp ,(%constant-alloc type-flonum (constant size-flonum) #t))
+                     (set! ,%xp ,(%constant-alloc type-flonum (constant size-flonum) for-return?))
                      ,(fromC %xp)
                      (set! ,lvalue ,%xp))]
                   [(fp-ftd ,ftd)
@@ -10798,7 +10798,7 @@
                                          ;; was instead installed in the first argument.
                                          `(seq (set! ,maybe-lvalue ,(%constant svoid)) ,e)]
                                         [else
-                                         `(seq ,(C->Scheme result-type c-res maybe-lvalue) ,e)])
+                                         `(seq ,(C->Scheme result-type c-res maybe-lvalue #t) ,e)])
                                       e))))])
                     (if new-frame?
                         (sorry! who "can't handle nontail foreign calls")
@@ -10847,7 +10847,7 @@
                               [(real-register? '%cp) `(set! ,cp-save ,%cp)]
                               [else `(nop)])
                             ; convert arguments
-                            ,(fold-left (lambda (e x arg-type c-arg) `(seq ,(C->Scheme arg-type c-arg x) ,e))
+                            ,(fold-left (lambda (e x arg-type c-arg) `(seq ,(C->Scheme arg-type c-arg x #f) ,e))
                                (set-locs fv* frame-x*
                                  (set-locs (map (lambda (reg) (in-context Lvalue (%mref ,%tc ,(reg-tc-disp reg)))) reg*) reg-x*
                                    `(set! ,%ac0 (immediate ,(length arg-type*)))))

--- a/s/ppc32.ss
+++ b/s/ppc32.ss
@@ -1393,9 +1393,10 @@
 
   (define conditional-branch-disp?
     (lambda (x)
-      (and (fixnum? x) 
-           (fx<= (- (expt 2 15)) x (- (expt 2 15) 1))
-           (not (fxlogtest x #b11)))))
+      (let ([x (+ x 4)])
+        (and (fixnum? x)
+             (fx<= (- (expt 2 15)) x (- (expt 2 15) 1))
+             (not (fxlogtest x #b11))))))
 
   (define asm-size
     (lambda (x)

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1471,7 +1471,7 @@
   (merge [sig [(procedure list list) -> (list)]] [flags true])
   (merge! [sig [(procedure list list) -> (list)]] [flags true])
   (mkdir [sig [(pathname) (pathname sub-uint) -> (void)]] [flags])
-  (multibyte->string [feature windows] [sig [(sub-uint bytevector) -> (string)]] [flags true discard])
+  (multibyte->string [feature windows] [sig [(sub-ptr bytevector) -> (string)]] [flags true discard])
   (mutable-box? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard])
   (mutable-string? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard])
   (mutable-fxvector? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard])
@@ -1652,7 +1652,7 @@
   (standard-output-port [sig [() (sub-symbol) (sub-symbol maybe-transcoder) -> (output-port)]] [flags true])
   (standard-error-port [sig [() (sub-symbol) (sub-symbol maybe-transcoder) -> (output-port)]] [flags true])
   (statistics [sig [() -> (sstats)]] [flags unrestricted alloc])
-  (string->multibyte [feature windows] [sig [(sub-uint string) -> (bytevector)]] [flags true discard])
+  (string->multibyte [feature windows] [sig [(sub-ptr string) -> (bytevector)]] [flags true discard])
   (string->number [sig [(string) (string sub-ufixnum) -> (maybe-number)]] [flags discard]) ; radix not restricted to 2, 4, 8, 16
   (string<=? [sig [(string string ...) -> (boolean)]] [flags mifoldable discard])        ; not restricted to 2+ arguments
   (string<? [sig [(string string ...) -> (boolean)]] [flags mifoldable discard])         ; not restricted to 2+ arguments


### PR DESCRIPTION
Three commits for small repairs backported from the Racket branch:

 * repair ppc32 code generation when a branch displacement is exactly 32,764 bytes
 * repair register handling — in a way that matters only for x86 — for a foreign callable float argument
 * repair too-narrow signatures for `multibyte->string` and `string->multibyte`

The commits don't include new tests. It must be possible to construct an expression that would try a 32,764-byte branch on ppc32, but it's not obvious and doesn't seem worth the trouble; there was such a branch generated by a Racket library at the time of the repair. For x86, existing tests could already fail and would sometimes fail in the Racket CI setup (but I don't know how to probe for x87 stack misuse more directly). For the signature changes, I think "primvars.ms" will use the new signature (but "primvars.ms" is ok with signatures that are too narrow); with the old signature, "windows.ms" tests could fail on Windows in the Racket branch due to the way cptypes uses the signature for optimization.