### PR TITLE
Fix error in documentation

### DIFF
--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -3312,11 +3312,11 @@ be unlocked by an equal number of calls to
 \scheme{Sunlock_object} or \scheme{unlock-object} before it is
 truly unlocked.
 
-The function \scheme{Sunlocked_objectp} can be used to determine
+The function \scheme{Slocked_objectp} can be used to determine
 if an object is locked.
 
 \begin{flushleft}
-\cfunction{int}{Sunlocked_objectp}{ptr \var{obj}}
+\cfunction{int}{Slocked_objectp}{ptr \var{obj}}
 \end{flushleft}
 
 When a foreign procedure call is made into Scheme, a return address


### PR DESCRIPTION
`unlocked_objectp` should be `locked_objectp`, as per [`s/mkheader.ss`](https://github.com/cisco/ChezScheme/blob/f19ae927a9011e033e4aea08eddad3241116d7d5/s/mkheader.ss#L348)

Error seems to go back to initial open source release.