### PR TITLE
Fix `Ssymbol_to_string` doc

### DIFF
--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -2991,7 +2991,7 @@ Scheme counterparts.
 \begin{flushleft}
 \cmacro{ptr}{Scar}{ptr \var{pair}}
 \cmacro{ptr}{Scdr}{ptr \var{pair}}
-\cmacro{ptr}{Ssymbol_to_string}{ptr \var{sym}}
+\cfunction{ptr}{Ssymbol_to_string}{ptr \var{sym}}
 \cmacro{ptr}{Sunbox}{ptr \var{box}}
 \end{flushleft}
 


### PR DESCRIPTION
`Ssymbol_to_string` is a function, not a macro.

If it'd be better for me to combine this, #647, and #648 into one PR, let me know and I'll do so. I've just been authoring these as I've been running through and writing some bindings for the Chez Scheme kernel and noticing errors.