### PR TITLE
Fix foreign docs in several places

### DIFF
--- a/LOG
+++ b/LOG
@@ -2336,5 +2336,6 @@
     c/foreign.c
 - Propagate immutable versions of "", #(), #vu8() and #vfx() in cp0.
     s/cp0.ss s/cpnanopass.ss
-- Fix several issues in foreign docs (section 4.8)
+- correct mislabeling of some functions as macros and vice versa in
+  docs + correct name of Slocked_objectp from Sunlocked_objectp
     csug/foreign.stex

--- a/LOG
+++ b/LOG
@@ -2336,3 +2336,5 @@
     c/foreign.c
 - Propagate immutable versions of "", #(), #vu8() and #vfx() in cp0.
     s/cp0.ss s/cpnanopass.ss
+- Fix several issues in foreign docs (section 4.8)
+    csug/foreign.stex

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -3365,7 +3365,7 @@ operation as its Scheme counterpart, i.e., the Scheme procedure
 \scheme{foreign-callable-entry-point}.
 
 \begin{flushleft}
-\cfunction{(void (*) (void))}{Sforeign_callable_entry_point}{ptr \var{code}}
+\cmacro{(void (*) (void))}{Sforeign_callable_entry_point}{ptr \var{code}}
 \end{flushleft}
 
 \noindent
@@ -3377,7 +3377,7 @@ is not saved across any calls back into Scheme.
 The inverse translation can be made via \scheme{Sforeign_callable_code_object}.
 
 \begin{flushleft}
-\cfunction{ptr}{Sforeign_callable_code_object}{(void (*addr)(void))}
+\cmacro{ptr}{Sforeign_callable_code_object}{(void (*addr)(void))}
 \end{flushleft}
 
 \parheader{Low-level support for calls into Scheme}

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -2991,7 +2991,7 @@ Scheme counterparts.
 \begin{flushleft}
 \cmacro{ptr}{Scar}{ptr \var{pair}}
 \cmacro{ptr}{Scdr}{ptr \var{pair}}
-\cmacro{ptr}{Ssymbol_to_string}{ptr \var{sym}}
+\cfunction{ptr}{Ssymbol_to_string}{ptr \var{sym}}
 \cmacro{ptr}{Sunbox}{ptr \var{box}}
 \end{flushleft}
 

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -3312,11 +3312,11 @@ be unlocked by an equal number of calls to
 \scheme{Sunlock_object} or \scheme{unlock-object} before it is
 truly unlocked.
 
-The function \scheme{Sunlocked_objectp} can be used to determine
+The function \scheme{Slocked_objectp} can be used to determine
 if an object is locked.
 
 \begin{flushleft}
-\cfunction{int}{Sunlocked_objectp}{ptr \var{obj}}
+\cfunction{int}{Slocked_objectp}{ptr \var{obj}}
 \end{flushleft}
 
 When a foreign procedure call is made into Scheme, a return address


### PR DESCRIPTION
Consolidation of #647, #648, and #649 + a `LOG` entry.

 - `Slocked_objectp` is now named correctly, as opposed to the previous incorrect `Sunlocked_objectp`.
 - Correctly marked `Sforeign_callable_{entry_point,code_object}` as macros, rather than functions.
 - Correctly marked `Ssymbol_to_string` as a function, rather than a macro.