### PR TITLE
Fix configure arm64 error

### DIFF
--- a/configure
+++ b/configure
@@ -133,6 +133,11 @@ case "${CONFIG_UNAME}" in
       m64=a6osx
       tm32=ti3osx
       tm64=ta6osx
+    else
+      echo "arm64 is not supported"
+      echo "try racket's fork https://github.com/racket/ChezScheme/"
+      m64=arm64osx
+      tm64=tarm64osx
     fi
     installprefix=/usr/local
     installmansuffix=share/man
@@ -311,7 +316,7 @@ while [ $# != 0 ] ; do
 done
 
 if [ "$bits" = "" ] ; then
-  if uname -a | egrep 'amd64|x86_64' > /dev/null 2>&1 ; then
+  if uname -a | egrep 'amd64|x86_64|arm64' > /dev/null 2>&1 ; then
     bits=64
   else
     bits=32


### PR DESCRIPTION
On arm64 (M1/M2 MacOS) ./configure throws nonfatal errors

./configure: line 338: [: =: unary operator expected
./configure: line 338: [: =: unary operator expected

because $m is not defined. This patch handles arm64, advising user that arm64 is not supported.