### PR TITLE
--installprefix requires an equal sign

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -89,7 +89,7 @@ if successful, creates several files and directories:
 './configure' recognizes various options for controlling the type
 of build and the installation location.  For example, '--threads'
 requests a build with support for native threads, '--32' requests
-a 32-bit build, and '--installprefix <pathname>' specifies the
+a 32-bit build, and '--installprefix=<pathname>' specifies the
 installation root.  './configure --help' prints the supported
 options.
 


### PR DESCRIPTION
If a space is used as the doc instructed, `configure` gives error "option '--installprefix' unrecognized or missing an argument"