### PR TITLE
repair for overflow checking and `raw` form

### DIFF
--- a/LOG
+++ b/LOG
@@ -2370,3 +2370,6 @@
 - fix gensym->unique-string to leave symbol unchanged on failure
     c/externs.h c/intern.c mats/5_7.ms s/5_7.ss s/prims.ss boot/*
     mats/root-experr-compile-0-f-f-f mats/root-experr-compile-2-f-f-f
+- fix repair to invalid live-pointer mask, where a pass did not handle the
+  new raw-data form correctly
+    mats/fx.ms s/cpnanopass.ss

--- a/mats/fx.ms
+++ b/mats/fx.ms
@@ -562,6 +562,16 @@
    (test-cp0-expansion eqv? '(fx*) 1)
    (test-cp0-expansion eqv? '(fx* 3) 3)
    (test-cp0-expansion eqv? '(fx* 3 4 5) 60)
+
+   ;; regression test for stack overflow checking and `raw` wrapper
+   (equal? 0
+           (call/cc
+            (lambda (esc)
+              (let loop ([i 100000])
+                (if (fx= i 0)
+                    (esc 0)
+                    (fx* i (loop (fx- i 1))))))))
+
  )
 
 (mat r6rs:fx*

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -9403,6 +9403,7 @@
            (values
              `(if ,e0 ,(wrap-oc oc1 (wrap-tc tc1 e1)) ,(wrap-oc oc2 (wrap-tc tc2 e2)))
              oc tc))]
+        [(raw ,[e #f -> e oc tc]) (values `(raw ,e) oc tc)]
         [(seq ,[e0 #f -> e0 oc0 tc0] ,[e1 oc1 tc1])
          (values `(seq ,e0 ,e1) (combine-seq oc0 oc1) (combine-seq tc0 tc1))])
       (CaseLambdaClause : CaseLambdaClause (ir force-overflow?) -> CaseLambdaClause ()


### PR DESCRIPTION
In 102b2c1082, the auto-generated case in `np-place-overflow-and-trap` for `raw` was not the correct treatment of the form.