### PR TITLE
follow xdg spec for history file on non-Windows

### DIFF
--- a/LOG
+++ b/LOG
@@ -2373,3 +2373,7 @@
 - fix repair to invalid live-pointer mask, where a pass did not handle the
   new raw-data form correctly
     mats/fx.ms s/cpnanopass.ss
+- change the default expeditor history file on non-Windows systems to
+  "$XDG_STATE_HOME/chezscheme/history" and document the existing Windows
+  default, "%APPDATA%\Chez Scheme\History"
+    scheme.1.in s/expeditor.ss csug/csug.bib csug/use.stex

--- a/csug/csug.bib
+++ b/csug/csug.bib
@@ -566,3 +566,16 @@ year = 2008}
    url = {https://doi.org/10.1145/263700.263733},
    year = {1997}
 }
+
+@techreport{xdg-base-directory,
+author = {Waldo Bastian and
+          Allison Karlitskaya and
+          Lennart Poettering and
+          Johannes L\"{o}thberg},
+title = {{XDG Base Directory Specification}, version 0.8},
+type = {{Cross-Desktop Group} specification},
+institution = {Freedesktop.org (X.Org Foundation)},
+url = {https://specifications.freedesktop.org/basedir-spec/0.8/},
+month = may,
+year = 2021
+}

--- a/csug/use.stex
+++ b/csug/use.stex
@@ -345,12 +345,34 @@ The expression editor does not run if the TERM environment variable is not
 set (on Unix-based systems), if the standard input or output files have
 been redirected, or if the \scheme{--eedisable} command-line option
 (Section~\ref{SECTUSECOMMANDLINE}) has been used.
-The history is saved across sessions, by default, in the file
-``.chezscheme\_history'' in the user's home directory.
+By default, the history is saved across sessions.
 The \scheme{--eehistory} command-line option
-(Section~\ref{SECTUSECOMMANDLINE}) can be used to specify a different
-location for the history file or to disable the saving and restoring of
-the history file.
+(Section~\ref{SECTUSECOMMANDLINE}) can be used to
+disable the saving and restoring of the history file or to specify an
+alternate location for the history file.
+The default location depends on the operating system:
+\begin{itemize}
+\item
+On Windows, the default file is
+``\scheme{%APPDATA%\Chez Scheme\History}'', where the value of
+\scheme{%APPDATA%} is typically
+``\scheme{C:\Users\\var{username}\AppData\Roaming}''.
+If the \scheme{%APPDATA%} environment variable is not set, the file
+``\scheme{%HOME%\.chezscheme_history}'' is used instead.
+If the \scheme{%HOME%} environment variable is also not set, the file
+``\scheme{.chezscheme_history}'' in the current directory is used.
+
+\item
+On other systems, the default file is
+``\scheme{$XDG_STATE_HOME/chezscheme/history}'', where the default
+value of \scheme{$XDG_STATE_HOME}, per the XDG Base Directory
+Specification~\cite{xdg-base-directory}, is
+``\scheme{$HOME/.local/state}''.
+For compatibility with older versions of Chez Scheme, if the file
+``\scheme{$XDG_STATE_HOME/chezscheme/history}'' does not exist, but
+the file ``\scheme{~/.chezscheme_history}'' does exist, the existing
+file is used instead of creating a new one.
+\end{itemize}
 
 Keys for nearly all printing characters (letters, digits, and special
 characters) are ``self inserting'' by default.

--- a/scheme.1.in
+++ b/scheme.1.in
@@ -195,7 +195,7 @@ The expression editor does not run if the TERM environment variable is
 not set, if the standard input or output files have been redirected, or
 if the --eedisable command-line option has been used.
 The history is saved across sessions, by default, in the file
-\*(lq$HOME/.chezscheme_history\*(rq.
+\*(lq$XDG_STATE_HOME/chezscheme/history\*(rq.
 The --eehistory command-line option
 can be used to specify a different
 location for the history file or to disable the saving and restoring of


### PR DESCRIPTION
Change the default location for the expeditor history file to `$XDG_STATE_HOME/chezscheme/history` on non-Windows systems, but fall back to `~/.chezscheme_history` when it already exists. Also, document the existing locations used on Windows (by default, `%APPDATA%\Chez Scheme\History`).