### PR TITLE
Replace naive complex division by Algorithm 116

### DIFF
--- a/LOG
+++ b/LOG
@@ -2373,3 +2373,5 @@
 - fix repair to invalid live-pointer mask, where a pass did not handle the
   new raw-data form correctly
     mats/fx.ms s/cpnanopass.ss
+- fix cfl/ produces unwanted nan if denominator contains +/-infinity
+    s/library.ss

--- a/s/library.ss
+++ b/s/library.ss
@@ -204,7 +204,7 @@
           (fl- ($inexactnum-imag-part x) ($inexactnum-imag-part y)))]))
 
 (define-library-entry (cfl/ x y)
-   ;; spurious overflows, underflows, and division by zero
+   ;; Robert L. Smith, Algorithm 116
    (cond
       [(flonum? y)
        ;; a+bi/c => a/c + (b/c)i
@@ -214,17 +214,34 @@
               (fl/ ($inexactnum-real-part x) y)
               (fl/ ($inexactnum-imag-part x) y)))]
       [(flonum? x)
-       ;; a / c+di => c(a/(cc+dd)) + (-d(a/cc+dd))i
        (let ([c ($inexactnum-real-part y)] [d ($inexactnum-imag-part y)])
-          (let ([t (fl/ x (fl+ (fl* c c) (fl* d d)))])
-             (fl-make-rectangular (fl* c t) (fl- (fl* d t)))))]
+         (if (fl> (flabs c) (flabs d))
+             (let* ([r (fl/ d c)]
+                    [den (fl+ c (fl* r d))])
+               (fl-make-rectangular
+                (fl/ a den)
+                (fl/ (fl- (fl* a r)) den)))
+             (let* ([r (fl/ c d)]
+                    [den (fl+ d (fl* r c))])
+               (fl-make-rectangular
+                (fl/ (fl* a r) den)
+                (fl/ (fl- a) den)))))]
       [else
-       ;; a+bi / c+di => (ac+bd)/(cc+dd) + ((bc-ad)/(cc+dd))i
+       ;; a+bi / c+di => (a+b(d/c))/(c+d(d/c)) + ((b-a(d/c))/(c+d(d/c)))i  if |c| >  |d|
+       ;; a+bi / c+di => (b+a(c/d))/(d+c(c/d)) + ((a-b(c/d))/(d+c(c/d)))i  if |c| <= |d|
        (let ([a ($inexactnum-real-part x)] [b ($inexactnum-imag-part x)]
              [c ($inexactnum-real-part y)] [d ($inexactnum-imag-part y)])
-          (let ([t (fl+ (fl* c c) (fl* d d))])
-             (fl-make-rectangular (fl/ (fl+ (fl* a c) (fl* b d)) t)
-                                  (fl/ (fl- (fl* b c) (fl* a d)) t))))]))
+         (if (fl> (flabs c) (flabs d))
+             (let* ([r (fl/ d c)]
+                    [den (fl+ c (fl* r d))])
+               (fl-make-rectangular
+                (fl/ (fl+ a (fl* b r)) den)
+                (fl/ (fl- b (fl* a r)) den)))
+             (let* ([r (fl/ c d)]
+                    [den (fl+ d (fl* r c))])
+               (fl-make-rectangular
+                (fl/ (fl+ (fl* a r) b) den)
+                (fl/ (fl- (fl* b r) a) den)))))]))
 
 (let ()
   (define char-oops


### PR DESCRIPTION
Using Robert L. Smith's "Algorithm 116: Complex division", which fixes nan produced by original naive division method and potential float overflows.

fix #709