### PR TITLE
repair collector handling of ephemerons

### DIFF
--- a/LOG
+++ b/LOG
@@ -2398,6 +2398,9 @@
 - reduce allocation and copying for certain cases in bytevector->string
     mats/io.ms release_notes/release_notes.stex s/io.ss
 - update zlib to version 1.3
-- repair collector handling of weak pointers when the max target generation
+- repair collector handling of weak pairs when the max target generation
   is greater than the minimum target generation
+    c/gc.c mats/4.ms
+- repair collector handling of ephemeron pairs that refer to objects in
+  younger generations
     c/gc.c mats/4.ms

--- a/mats/4.ms
+++ b/mats/4.ms
@@ -3965,6 +3965,19 @@
                    (eq? (car e) key2))))))))
 
    ;; ----------------------------------------
+   ;; Check mutation two generations back and interaction with collection
+   (or (equal? (current-eval) interpret)
+       (equal? (with-interrupts-disabled
+                (let ([pr (ephemeron-cons 1 2)])
+                  (collect 0)
+                  (collect 1) ; puts `pr` in gen 2
+                  (let ([tl (list 1 2 3)])
+                    (set-car! pr tl) ; gen 2 reference to gen 0
+                    (collect 1 1 2)
+                    pr)))
+               '(#!bwp . #!bwp)))
+
+   ;; ----------------------------------------
    ;; Check fasl:
    (let ([s (gensym)])
      (define-values (o get) (open-bytevector-output-port))

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -1966,6 +1966,11 @@ The size of these string and bytevector buffers was previously hardcoded at 1024
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Garbage collector incorrectly handles emphemerons (9.6.0)}
+
+A bug where the garbage collector sometimes incorrectly handles epehemeron pairs has
+been fixed.
+
 \subsection{Garbage collector incorrectly handles mutated weak pairs (9.6.0)}
 
 A bug where the garbage collector sometimes incorrectly handles mutated weak pairs has


### PR DESCRIPTION
When an ephemeron pair refers to an object in younger generation, and when a collection would move that object to a generation that's less the maximum target generation, the collector could sometimes mishandle the ephemeron pair by trying to register it multiple times for later handling.