### PR TITLE
Optimize _ pattern in syntax-case clauses

### DIFF
--- a/LOG
+++ b/LOG
@@ -2455,3 +2455,5 @@
     boot/*/scheme.h c/externs.h c/number.c c/scheme.c csug/foreign.stex
     mats/foreign1.c mats/foreign.ms release_notes/release_notes.stex
     s/mkheader.ss
+- optimize simple _ patterns in syntax-case
+    s/syntax.ss

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -6423,12 +6423,16 @@
            (let ([y (gen-var 'tmp)])
              (build-let no-source
                (list y)
-               (list (if (eq? p 'any)
-                         (build-primcall no-source 3 'list
-                           (build-lexical-reference no-source x))
-                         (build-primcall no-source 3 '$syntax-dispatch
-                           (build-lexical-reference no-source x)
-                           (build-data no-source p))))
+               (list (cond
+                       [(eq? p 'any)
+                        (build-primcall no-source 3 'list
+                                        (build-lexical-reference no-source x))]
+                       [(eq? p '_)
+                        (build-data no-source '())]
+                       [else
+                        (build-primcall no-source 3 '$syntax-dispatch
+                                        (build-lexical-reference no-source x)
+                                        (build-data no-source p))]))
                (let-syntax ([y (identifier-syntax
                                  (build-lexical-reference no-source y))])
                  (build-conditional no-source


### PR DESCRIPTION
Plain `_` patterns in `syntax-case` occurs fairly frequently in code (more than 80 occurrences in Chez Scheme itself), and these patterns never fail. There are used like `else` clauses for `syntax-case`.

An easy optimization is to avoid calling `$syntax-dispatch` for such patterns and directly embed the `()` return value that would result for such a call. A similar optimization already existed for patterns that consists of a single identifier.

With that optimization, `cp0` can easily optimize out the last call to `syntax-error` that is never reached.

Before:
```
> (expand/optimize '(syntax-case x () (_ 'ok)))
(let ([tmp x])
  (let ([tmp (#3%$syntax-dispatch tmp '_)])
    (if tmp 'ok (#3%syntax-error tmp))))
```

After:
```
(expand/optimize '(syntax-case x () (_ 'ok)))
(begin x 'ok)
```

----
Note: there is something fishy with the GitHub workflows, and one random job would fail. It happened on the main in my fork, as well as with my branch.
