### PR TITLE
repair tests for cmg=1

### DIFF
--- a/mats/4.ms
+++ b/mats/4.ms
@@ -4821,7 +4821,8 @@
                      (bwp-object? (car x))))))
    ;; check interaction of weak pairs, generations, and specific target generations for collection
    (with-interrupts-disabled
-    (parameterize ([#%$enable-check-heap #t])
+    (parameterize ([#%$enable-check-heap #t]
+                   [collect-maximum-generation (max (collect-maximum-generation) 2)])
       (let ([key "key"])
         (let ([e (weak-cons key #f)])
           (collect 0 1 1)
@@ -5010,7 +5011,8 @@
    ;; Check interaction of mutation and incremental generation promotion
 
    (with-interrupts-disabled
-    (parameterize ([#%$enable-check-heap #t])
+    (parameterize ([#%$enable-check-heap #t]
+                   [collect-maximum-generation (max (collect-maximum-generation) 2)])
       (let ([key "key"])
         (let ([e (ephemeron-cons key #f)])
           (collect 0 1 1)


### PR DESCRIPTION
In attempting to improve some tests, commit a4654e4ee lost two adjustments to `collect-maximum-generation` to ensure that tests work when the parameter is set to 1 (as in some modes that are tried by `make test-more`).