### PR TITLE
restore simpler Windows CI

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -2,8 +2,7 @@
 set -e -o pipefail
 export ZUO_JOBS="$(getconf _NPROCESSORS_ONLN)"
 if test "$TOOLCHAIN" = vs ; then
-    # cmd.exe /c "build.bat $TARGET_MACHINE"
-    echo assuming built previously
+    MSYS_NO_PATHCONV=1 cmd.exe /c "build.bat $TARGET_MACHINE"
 else
     if test -n "$CONFIGURE_ARGS" ; then
         ./configure $CONFIGURE_ARGS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,21 +75,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install chezscheme
-      - name: Build Chez Scheme with Visual Studio
-        if: ${{ matrix.config.toolchain == 'vs' }}
-        shell: cmd
-        run: build.bat ${{ matrix.config.machine }}
       - name: Build Chez Scheme
         run: .github/workflows/build.sh
       - name: Run tests
-        if: ${{ matrix.config.toolchain != 'vs' }}
         timeout-minutes: 60
         run: .github/workflows/test.sh
-      - name: Run tests with Visual Studio
-        if: ${{ matrix.config.toolchain == 'vs' }}
-        timeout-minutes: 60
-        shell: cmd
-        run: build.bat ${{ matrix.config.machine }} /test-some
       - name: Archive workspace
         if: always()
         run: tar -c -h -z -f $TARGET_MACHINE$TOOLCHAIN$VARIANT.tgz $TARGET_MACHINE

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -4,7 +4,7 @@ if test "$TEST_TARGET" = ""; then
     TEST_TARGET=test-some
 fi
 if test "$TOOLCHAIN" = vs ; then
-    cmd.exe /c "build.bat $TARGET_MACHINE /$TEST_TARGET"
+    MSYS_NO_PATHCONV=1 cmd.exe /c "build.bat $TARGET_MACHINE /$TEST_TARGET"
 else
     make $TEST_TARGET
 fi


### PR DESCRIPTION
Mostly reverts 01b5bb60cc, but also ~~changes "/c" to "//c"~~ uses `MSYS_NO_PATHCONV=1` --- which seems to be the right repair to the original problem based on the way Windows `bash` variants treat arguments that start with `/`.