### PR TITLE
repair pb loading for big-endian architectures

### DIFF
--- a/c/fasl.c
+++ b/c/fasl.c
@@ -2159,9 +2159,10 @@ void S_swap_dounderflow_header_endian(ptr co)
   /* The `dounderflow` library entry starts with a header, so
      it does not have a `pb_adr` instruction before. We need
      to finish swapping the header's `ptr`-sized values, but
-     the mv-return address is already linked, so the only
-     thing to fix turns out to be the first `ptr`. */
-  uint32_t *code = (uint32_t *)&CODEIT(co, 0);
+     the mv-return address is already linked, and the live mask
+     and frame size are 0, so the only thing to fix turns out
+     to be the toplink `uptr`. */
+  uint32_t *code = (uint32_t *)&RPHEADERTOPLINK(TO_PTR(&CODEIT(co, 0)));
   uint32_t a = code[0];
   uint32_t b = code[1];
   code[0] = b;

--- a/configure
+++ b/configure
@@ -144,8 +144,8 @@ case "${CONFIG_UNAME}" in
       m64=arm64osx
       tm64=tarm64osx
     elif uname -m | egrep 'Power' > /dev/null 2>&1 ; then
-      m64=ppc32osx
-      tm64=tppc32osx
+      m32=ppc32osx
+      tm32=tppc32osx
       pbendian=b
       default_warning_flags=""
     fi


### PR DESCRIPTION
Commit 360d5ef952 missed an adjustment for big-endian machines — partly due to the bad way that a swap was implemented, where it did not use a suitable macro to find the right offset.

Also, fix `configure` for detecting `ppc32osx`.