### PR TITLE
add $hashtable-cells that skips immutable check

### DIFF
--- a/mats/hash.ms
+++ b/mats/hash.ms
@@ -307,6 +307,7 @@
      (same-entries? (hashtable-entries ht) keys vals)
      (or (not (hashtable-mutable? ht))
          (same-elements? (hashtable-cells ht) (vector-map cons keys vals)))
+     (same-elements? (#%$hashtable-cells ht) (vector-map cons keys vals))
 
      (same-elements? (r6rs:hashtable-keys ht) keys)
      (same-entries? (r6rs:hashtable-entries ht) keys vals)
@@ -328,6 +329,7 @@
      (same-entries? (hashtable-entries ht 0) '#() '#())
      (or (not (hashtable-mutable? ht))
          (same-elements? (hashtable-cells ht 0) '#()))
+     (same-elements? (#%$hashtable-cells ht 0) '#())
 
      (or
       (< (hashtable-size ht) 2)
@@ -365,7 +367,11 @@
                (let ([got-cells (hashtable-cells ht 2)])
                  (ormap (lambda (keys vals)
                           (same-elements? got-cells (vector-map cons keys vals)))
-                        keyss valss))))))))))
+                        keyss valss)))
+           (let ([got-cells (#%$hashtable-cells ht 2)])
+             (ormap (lambda (keys vals)
+                      (same-elements? got-cells (vector-map cons keys vals)))
+                    keyss valss)))))))))
 
 (mat hashtable-arguments
  ; make-eq-hashtable

--- a/s/newhash.ss
+++ b/s/newhash.ss
@@ -26,7 +26,7 @@ Documentation notes:
   pairs, and then uses a weak or ephemeron eq hashtable to map the key
   to its value; use the size of the eq hashtable as the generic hashtable's
   size
-- an eqv hashtabble pairs an eq hashtable and an generic hashtable
+- an eqv hashtable pairs an eq hashtable and an generic hashtable
 |#
 
 #|
@@ -94,7 +94,7 @@ Documentation notes:
 ;;; eqv-hashtable operators
 (define make-weak-eqv-hashtable)         ; [k], k >= 0
   
-;;; unsafe eq-hashtable operators
+;;; unsafe hashtable operators
 (define $make-eq-hashtable)              ; fxminlen subtype, fxminlen = 2^n, n >= 0
 (define $eq-hashtable-keys)              ; eq-hashtable
 (define $eq-hashtable-values)            ; eq-hashtable
@@ -102,6 +102,7 @@ Documentation notes:
 (define $eq-hashtable-cells)             ; eq-hashtable
 (define $eq-hashtable-copy)              ; eq-hashtable [mutableflag]
 (define $eq-hashtable-clear!)            ; eq-hashtable [fxminlen]
+(define $hashtable-cells)                ; hashtable [fxminlen]
 
 ;;; inspection
 (define $hashtable-veclen)
@@ -1062,7 +1063,7 @@ Documentation notes:
           [(generic) ($gen-hashtable-entries h (most-positive-fixnum))]
           [else ($ht-hashtable-entries h (most-positive-fixnum))])))
 
-    (set-who! hashtable-cells
+    (set-who! $hashtable-cells
       (hashtable-content-dispatch who
                                   $eq-hashtable-cells
                                   $eqv-hashtable-cells

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -2196,6 +2196,7 @@
   ($get-timer [flags single-valued])
   ($guard [flags])
   ($hand-coded [flags single-valued])
+  ($hashtable-cells [sig [(hashtable) -> (vector)] [(hashtable uint) -> (vector)]] [flags alloc])
   ($hashtable-report [flags true])
   ($hashtable-size->minlen [flags single-valued])
   ($hashtable-veclen [flags discard])


### PR DESCRIPTION
Provide a way to work around the 10.x breaking change in `hashtable-cells`.