### PR TITLE
Make (load-shared-object #f) portable

### DIFF
--- a/c/externs.h
+++ b/c/externs.h
@@ -445,6 +445,7 @@ extern ptr *S_get_call_arena(ptr tc);
 /* windows.c */
 extern INT S_getpagesize(void);
 extern ptr S_LastErrorString(void);
+extern HMODULE *S_enum_process_modules(void);
 extern void *S_ntdlopen(const char *path);
 extern void *S_ntdlsym(void *h, const char *s);
 extern ptr S_ntdlerror(void);

--- a/c/foreign.c
+++ b/c/foreign.c
@@ -66,9 +66,6 @@ static ptr bvstring(const char *s);
 
 #ifdef LOAD_SHARED_OBJECT
 static void load_shared_object(const char *path);
-#ifdef WIN32
-HMODULE *base_modules;
-#endif /* WIN32 */
 #endif /* LOAD_SHARED_OBJECT */
 
 #ifdef HPUX
@@ -135,9 +132,15 @@ static ptr lookup_dynamic(const char *s, ptr tbl) {
 
 #ifdef WIN32
         if (!handle) {
-            for (HMODULE *m = base_modules; *m; ++m) {
-                value = dlsym(*m, s);
-                if (value != NULL) return addr_to_ptr(value);
+            HMODULE *modules = S_enum_process_modules();
+            if (modules) {
+                for (HMODULE *m = modules; *m; ++m) {
+                    value = dlsym(*m, s);
+                    if (value != NULL) break;
+                }
+                free(modules);
+                if (value != NULL)
+                    return addr_to_ptr(value);
             }
         } else
 #endif /* WIN32 */
@@ -349,9 +352,6 @@ void S_foreign_init(void) {
     S_protect(&S_foreign_dynamic);
     S_foreign_dynamic = Snil;
     Sforeign_symbol("(cs)load_shared_object", (void *)load_shared_object);
-#ifdef WIN32
-    base_modules = S_enum_process_modules();
-#endif /* WIN32 */
 #endif /* LOAD_SHARED_OBJECT */
 
     Sforeign_symbol("(cs)lookup_foreign_entry", (void *)lookup_foreign_entry);

--- a/c/windows.c
+++ b/c/windows.c
@@ -18,6 +18,7 @@
 
 #include "system.h"
 #include <objbase.h>
+#include <psapi.h>
 #include <io.h>
 #include <sys/stat.h>
 
@@ -47,6 +48,17 @@ void *S_ntdlopen(const char *path) {
   void *r = (void *)LoadLibraryW(pathw);
   free(pathw);
   return r;
+}
+
+HMODULE *S_enum_process_modules(void) {
+
+    enum { MAX_MODULES = 256 };
+
+    static HMODULE modules[MAX_MODULES + 1] = { NULL };
+    DWORD req_num_bytes;
+    EnumProcessModules(GetCurrentProcess(), modules, MAX_MODULES*sizeof(HMODULE), &req_num_bytes);
+
+    return modules;
 }
 
 void *S_ntdlsym(void *h, const char *s) {

--- a/c/windows.c
+++ b/c/windows.c
@@ -51,12 +51,31 @@ void *S_ntdlopen(const char *path) {
 }
 
 HMODULE *S_enum_process_modules(void) {
-
-    enum { MAX_MODULES = 256 };
-
-    static HMODULE modules[MAX_MODULES + 1] = { NULL };
+    DWORD cur_num_bytes = 1024;
     DWORD req_num_bytes;
-    EnumProcessModules(GetCurrentProcess(), modules, MAX_MODULES*sizeof(HMODULE), &req_num_bytes);
+    HMODULE *modules = malloc(cur_num_bytes);
+
+    if (!modules)
+        return NULL;
+
+    for (;;) {
+        if (!EnumProcessModules(GetCurrentProcess(), modules, cur_num_bytes, &req_num_bytes))
+            return NULL;
+        req_num_bytes += sizeof *modules; // for sentinel NULL value
+        if (req_num_bytes <= cur_num_bytes)
+            break;
+        HMODULE *new_mod = realloc(modules, req_num_bytes);
+        if (!new_mod) {
+            free(modules);
+            return NULL;
+        }
+
+        modules = new_mod;
+        cur_num_bytes = req_num_bytes;
+    }
+
+    const size_t numel = req_num_bytes/sizeof *modules;
+    modules[numel - 1] = NULL;
 
     return modules;
 }

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -2670,8 +2670,9 @@ via one of the other methods described in this section.
 \endentryheader
 
 \noindent
-\var{path} must be a string.
-\scheme{load-shared-object} loads the shared object named by \var{path}.
+\var{path} must be a string or \scheme{#f}.
+If \var{path} is a string, \scheme{load-shared-object} loads the shared object
+named by \var{path}.
 Shared objects may be system libraries or files created from ordinary
 C programs.
 All external symbols in the shared object, along with external symbols
@@ -2685,6 +2686,22 @@ If \var{path} does not begin with a ``.'' or ``/'', the shared
 object is searched for in a default set of directories determined
 by the system.
 
+If \var{path} is \scheme{#f}, external symbols in the executable itself (if
+any), as well as those found in dependent shared objects, are also made
+available as foreign entries.
+Usually, executables do not export symbols, but can be instructed to do so with
+proper compilation flags.
+One may thus create an executable based on {\ChezScheme}, and have Scheme code
+access exported symbols from it and also from any shared object dynamically
+linked to it.
+
+Because {\ChezScheme} is dynamically linked to the operating system's
+C library, all C functions are also accessible after evaluation of
+\scheme{(load-shared-object #f)}.
+This provides a simple way to gain access to standard C functions (such as
+\var{memcpy} or \var{getenv}), which may be very convenient for Scheme programs
+intended to be portable across different systems.
+
 On most Unix systems, \scheme{load-shared-object} is based on the
 system routine \scheme{dlopen}.
 %Under AIX, \scheme{load-shared-object} is based on the system routine
@@ -2697,10 +2714,13 @@ and loader for precise rules for locating and building shared objects.
 
 \scheme{load-shared-object} can be used to access built-in C library
 functions, such as \scheme{getenv}.
-The name of the shared object varies from one system to another.
+As stated above, it is easier to simply evaluate
+\scheme{(load-shared-object #f)}, because the name of the shared object varies
+from one system to another.
 % On Sun Sparc systems running Solaris 2.X or higher
 % running Digital Unix 2.X or higher, and SGI systems running IRIX 5.X
 % or higher
+
 On Linux systems:
 
 \schemedisplay

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -2695,12 +2695,16 @@ One may thus create an executable based on {\ChezScheme}, and have Scheme code
 access exported symbols from it and also from any shared object dynamically
 linked to it.
 
-Because {\ChezScheme} is dynamically linked to the operating system's
-C library, all C functions are also accessible after evaluation of
-\scheme{(load-shared-object #f)}.
+Because {\ChezScheme} is usually dynamically linked to the operating system's C
+library, all built-in C library functions are also accessible after evaluation
+of \scheme{(load-shared-object #f)}.
 This provides a simple way to gain access to standard C functions (such as
 \var{memcpy} or \var{getenv}), which may be very convenient for Scheme programs
 intended to be portable across different systems.
+If {\ChezScheme} is statically linked however, the standard C functions may only
+be accessible in this manner if they are present in the executable and
+exported, otherwise the shared object containing the C library must be
+explicitly named; see below for examples for some platforms.
 
 On most Unix systems, \scheme{load-shared-object} is based on the
 system routine \scheme{dlopen}.
@@ -2714,9 +2718,7 @@ and loader for precise rules for locating and building shared objects.
 
 \scheme{load-shared-object} can be used to access built-in C library
 functions, such as \scheme{getenv}.
-As stated above, it is easier to simply evaluate
-\scheme{(load-shared-object #f)}, because the name of the shared object varies
-from one system to another.
+The name of the shared object varies from one system to another.
 % On Sun Sparc systems running Solaris 2.X or higher
 % running Digital Unix 2.X or higher, and SGI systems running IRIX 5.X
 % or higher

--- a/mats/foreign.ms
+++ b/mats/foreign.ms
@@ -294,6 +294,18 @@
     )
    ])
 
+(mat load-shared-object-f
+  (equal?
+    (with-input-from-string
+      (separate-eval
+        '(begin
+           (printf "(~S " (foreign-entry? "memcpy"))
+           (load-shared-object #f)
+           (printf "~S)~%" (foreign-entry? "memcpy"))
+           (void)))
+      read)
+    '(#f #t)))
+
 (mat foreign-entry?
    (foreign-entry? "id")
    (foreign-entry? "idid")


### PR DESCRIPTION
_Am I late to the Chez Scheme 10 party?_

This is an old PR that's now reworked. Basically, an non-documented feature of `load-shared-object` is that it accepts `#f`. On UNIX it does something useful, but on Windows it just makes an invalid memory reference. 

The behavior on UNIX systems is to make the exported symbols of the executable as well as all shared objects linked to it available as foreign entries (what essentially `dlopen(NULL, ...)` does). It's very useful to get standard C library functions in a portable way; moreover, when creating a custom executable based on Chez Scheme, all dynamic libraries linked to the executable are readily available with `(load-shared-object #f)` to have access to the linked foreign entries. It helps decoupling the shared objects from their paths.