### PR TITLE
improve configure and build when using MSYS2

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -341,7 +341,7 @@ WINDOWS VIA COMMAND PROMPT
 To build on Windows with MSYS2 and MinGW gcc or Clang, follow the same
 instructions as for Unix above, but the result will be a native
 Windows build. Cygwin as a compilation target is not currently
-support.
+supported.
 
 To build on Windows with Microsoft Visual Studio, use
 

--- a/c/types.h
+++ b/c/types.h
@@ -520,7 +520,7 @@ typedef struct thread_gc {
 
 #define main_sweeper_index maximum_parallel_collect_threads
 
-#if defined(__MINGW32__) && !defined(HAND_CODED_SETJMP_SIZE)
+#if defined(__MINGW32__) && !defined(HAND_CODED_SETJMP_SIZE) && !defined(__aarch64__)
 /* With MinGW on 64-bit Windows, setjmp/longjmp is not reliable. Using
    __builtin_setjmp/__builtin_longjmp is reliable, but
    __builtin_longjmp requires 1 as its second argument. So, allocate
@@ -539,8 +539,14 @@ typedef struct thread_gc {
 /* assuming malloc will give us required alignment */
 # define CREATEJMPBUF() malloc(sizeof(jmp_buf))
 # define FREEJMPBUF(jb) free(jb)
-# define SETJMP(jb) _setjmp(jb)
-# define LONGJMP(jb,n) _longjmp(jb, n)
+# if defined(__MINGW32__) && defined(__aarch64__)
+   /* no _-prefixed variants */
+#  define SETJMP(jb) setjmp(jb)
+#  define LONGJMP(jb,n) longjmp(jb, n)
+#else
+#  define SETJMP(jb) _setjmp(jb)
+#  define LONGJMP(jb,n) _longjmp(jb, n)
+# endif
 #endif
 
 #define DOUNDERFLOW\

--- a/c/version.h
+++ b/c/version.h
@@ -196,7 +196,7 @@ typedef int tputsputcchar;
 typedef char *memcpy_t;
 struct timespec;
 #ifdef __MINGW32__
-# if defined(__aarch64__)
+# if defined(__aarch64__) && !defined(PORTABLE_BYTECODE)
 #  define HAND_CODED_SETJMP_SIZE 32
 # endif
 #else

--- a/configure
+++ b/configure
@@ -63,6 +63,7 @@ installreleasenotes=""
 installschemename="scheme"
 installpetitename="petite"
 installscriptname="scheme-script"
+unamebits=""
 relativeBootFiles=yes
 cflagsset=no
 disablex11=no
@@ -95,13 +96,7 @@ preloadBootFiles=
 alwaysUseBootFile=
 skipSubmoduleUpdate=
 
-# On WSL, set OS to "Windows_NT" (as already set in MSYS2) to create a
-# Windows build instead of a Linux (on Windows) build:
-if [ "$OS" = "Windows_NT" ] ; then
-    CONFIG_UNAME="CYGWIN_NT-"
-else
-    CONFIG_UNAME=`uname`
-fi
+CONFIG_UNAME=`uname`
 
 # using `uname`, infer OS-based defaults
 case "${CONFIG_UNAME}" in
@@ -168,15 +163,32 @@ case "${CONFIG_UNAME}" in
       gzipmanpages=no
     fi
     ;;
-  CYGWIN_NT-*)
-    if uname -m | egrep 'i386|i686|amd64|athlon|x86_64' > /dev/null 2>&1 ; then
-      m32=i3nt
-      m64=a6nt
-      tm32=ti3nt
-      tm64=ta6nt
-      installprefix=/usr/local
-      installmansuffix=share/man
-    fi
+  MINGW*)
+    # MSYS2 (but not $MSYSTEM as "MSYS", because Cygwin is not currently supported)
+    case "$MSYSTEM" in
+        *ARM64*)
+            m64=arm64nt
+            tm64=tarm64nt
+            ;;
+        *)
+            m32=i3nt
+            m64=a6nt
+            tm32=ti3nt
+            tm64=ta6nt
+            ;;
+    esac
+    # `uname -m` will report the way that `uname` is compiled, but we want
+    # to infer bits based on "$MSYSTEM", so override `uname -m` for bits
+    case "$MSYSTEM" in
+        *32)
+            unamebits=32
+            ;;
+        *)
+            unamebits=64
+            ;;
+    esac
+    installprefix=/usr/local
+    installmansuffix=share/man
     ;;
 esac
 
@@ -199,7 +211,7 @@ if [ "$unixsuffix" != "" ] ; then
         else
             pbendian=b
         fi
-    elif uname -m | egrep 'armv|aarch64|evbarm' > /dev/null 2>&1 ; then
+    elif uname -m | egrep 'armv|aarch64|arm64|evbarm' > /dev/null 2>&1 ; then
         m32=arm32${unixsuffix}
         m64=arm64${unixsuffix}
         tm32=tarm32${unixsuffix}
@@ -448,7 +460,9 @@ esac
 
 if [ "$bits" = "" ] ; then
   # infer default bits; this will be irrelevant if a machine is specified
-  if uname -m | egrep 'amd64|x86_64|aarch64|arm64|ppc64|powerpc64|riscv64|loongarch64' > /dev/null 2>&1 ; then
+  if [ "$unamebits" != "" ] ; then
+    bits="$unamebits"
+  elif uname -m | egrep 'amd64|x86_64|aarch64|arm64|ppc64|powerpc64|riscv64|loongarch64' > /dev/null 2>&1 ; then
     bits=64
   # NetBSD `uname -m` produces "evbarm" for AArch64
   elif uname -p | egrep 'aarch64' > /dev/null 2>&1 ; then


### PR DESCRIPTION
Update `configure` to infer a suitable machine based on "$MSYSTEM", and clear out some misleading WSL/Cygwin names and comments. Also, adjust the setjmp/longjmp configuration to work for pb in a CLANGARM64 environment.