### PR TITLE
unbreak `system` in a thread that has interrupts disabled

### DIFF
--- a/c/prim5.c
+++ b/c/prim5.c
@@ -711,9 +711,9 @@ static void s_showalloc(IBOOL show_dump, const char *outfn) {
 
 static ptr s_system(const char *s) {
   INT status;
-  char *s_arg;
 #ifdef PTHREADS
   ptr tc = get_thread_context();
+  char *s_arg = NULL;
 #endif
 
 #ifdef PTHREADS
@@ -725,11 +725,11 @@ static ptr s_system(const char *s) {
       S_error("system", "malloc failed");
     memcpy(s_arg, s, len);
     deactivate_thread(tc);
-  }
-#else
-  s_arg = (char *)s;
+    s = s_arg;
+  } else
+    s_arg = NULL;
 #endif
-  status = SYSTEM(s_arg);
+  status = SYSTEM(s);
 #ifdef PTHREADS
   if (DISABLECOUNT(tc) == FIX(0)) {
     reactivate_thread(tc);

--- a/mats/unix.ms
+++ b/mats/unix.ms
@@ -708,6 +708,11 @@
 (unless (or (windows?)
             (not (threaded?)))
   (mat thread-system
+
+    ;; make sure `system` works when interrupts are disabled
+    (with-interrupts-disabled
+      (eqv? 0 (system "echo hi")))
+
     ;; check that when a thread is deactivated during `system`,
     ;; the command that it's running isn't GCed
     (let* ([count 50]


### PR DESCRIPTION
Fixes a mistake in d7cc2cf2e5. This mistake was noticed by some C compilers, but I missed the warnings.