### PR TITLE
improve some tests that have been unreliable

### DIFF
--- a/mats/misc.ms
+++ b/mats/misc.ms
@@ -1160,7 +1160,13 @@
             (pause-until (lambda () (eq? 'done (unbox ready))))
             (pause-until (lambda () (= 1 (#%$top-level-value '$active-threads))))
             ;; Get thread's size, which shouldn't include bstr
-            (let ([post-sizes (compute-size-increments (list th-code th))])
+            (let ([post-sizes (compute-size-increments (list th-code
+                                                             th
+                                                             ;; don't count parameters towards te thread's
+                                                             ;; size; in particluar, the `$tt-fat` parameter
+                                                             ;; from a "thread.ms" test can have random symbols,
+                                                             ;; some of which may be bound to large values
+                                                             (#%$tc-field 'parameters (#%$tc))))])
               (printf "SIZES ~s\n" (list pre-sizes N post-sizes))
               (mutex-release m)
               ;; Wait for thread to exit
@@ -2672,7 +2678,10 @@
 
   ((lambda (x)
      (and (time<? (make-time 'time-duration 0 0) x)
-          (or (time<? x (make-time 'time-duration 0 20))
+          ;; on a modern machine, we expect a time on the
+          ;; order of 1s, but allow a lof ot variation or
+          ;; a slow machine with up to 50s:
+          (or (time<? x (make-time 'time-duration 0 50))
               (#%$enable-check-heap))))
    (begin
      ($cc-fib 30)


### PR DESCRIPTION
A `compute-size-increments` test has been a long-time problem. It turns out that it was failing randomly due to a random list of symbols stashed in a thread parameter by an earlier test; sometimes, one of those symbols can reach a lot of data. The solution here is to not count data reachable from thread parameters.

A `cost-center-time` test has been failing on very slow machines. As a timing test, it's inherently unreliable, but turning up the limit should make failures rare enough without making the test useless.