### PR TITLE
remove time-t-bits from machine definition

### DIFF
--- a/boot/pb/equates.h
+++ b/boot/pb/equates.h
@@ -1189,7 +1189,6 @@ typedef uint64_t U64;
 #define time_duration 0x2
 #define time_monotonic 0x3
 #define time_process 0x0
-#define time_t_bits 0x40
 #define time_thread 0x1
 #define time_utc 0x4
 #define timer_interrupt_index 0x2

--- a/c/scheme.c
+++ b/c/scheme.c
@@ -219,9 +219,9 @@ static void idiot_checks(void) {
               (long)sizeof(ptrdiff_t), ptrdiff_t_bits);
     oops = 1;
   }
-  if (sizeof(time_t) * 8 != time_t_bits) {
-    fprintf(stderr, "sizeof(time_t) * 8 [%ld] != time_t_bits [%d]\n",
-              (long)sizeof(time_t), time_t_bits);
+  if (sizeof(time_t) * 8 > 64) {
+    fprintf(stderr, "sizeof(time_t) [%ld] * 8 > 64\n",
+              (long)sizeof(time_t));
     oops = 1;
   }
 #endif

--- a/c/stats.c
+++ b/c/stats.c
@@ -42,11 +42,7 @@ static long adjust_time_zone(ptr dtvec, struct tm *tmxp, ptr given_tzoff);
 
 /********  unique-id  ********/
 
-#if (time_t_bits == 32)
-#define S_integer_time_t(x) Sinteger32((iptr)(x))
-#elif (time_t_bits == 64)
 #define S_integer_time_t(x) Sinteger64(x)
-#endif
 
 #ifdef WIN32
 

--- a/s/default.def
+++ b/s/default.def
@@ -32,7 +32,6 @@
                                                    8
                                                    4))
 (define-constant-default special-initial-field-alignment? #f)
-(define-constant-default time-t-bits (constant ptr-bits))
 (define-constant-default segment-table-levels (if (= 64 (constant ptr-bits))
                                                   3
                                                   1))

--- a/s/machine.zuo
+++ b/s/machine.zuo
@@ -12,21 +12,6 @@
     [(string=? arch "la64") "loongarch64"]
     [else arch]))
 
-(define (arch+os->time_t-bits arch os)
-  (cond
-    [(string=? os "nb")
-     ;; NetBSD 6.0 and later:
-     64]
-    [(string=? os "ob")
-     ;; OpenBSD 5.5 and later:
-     64]
-    [else
-     (cond
-       [(string=? arch "i3") 32]
-       [(string=? arch "ppc32") 32]
-       [(string=? arch "arm32") 32]
-       [else 64])]))
-
 ;; Get or synthesize a "machine.def" file and supporting files,
 ;; returns
 ;;    (list (cons dep-name build) dep-input-name ...)
@@ -63,7 +48,6 @@
      (define m.def (~a m ".def"))
      (define arch.def (~a arch ".def"))
      (define os.def (~a os ".def"))
-     (define time_t-bits (arch+os->time_t-bits arch os))
      (define src (at-source m.def))
      (cons (if (file-exists? src)
                (cons m.def
@@ -73,8 +57,7 @@
                  (cons src
                        (lambda (dest token)
                          (fill-template (at-source src) dest
-                                        (hash 'M m 'March arch
-                                              'Mtimet time_t-bits))))))
+                                        (hash 'M m 'March arch))))))
            (append
             (list "default.def"
                   arch.def)

--- a/s/tunix.def
+++ b/s/tunix.def
@@ -3,6 +3,5 @@
 
 (define-constant machine-type (constant machine-type-$(M)))
 (features iconv expeditor pthreads)
-(define-constant time-t-bits $(Mtimet))
 (include "$(March).def")
 (include "default.def")

--- a/s/unix.def
+++ b/s/unix.def
@@ -3,6 +3,5 @@
 
 (define-constant machine-type (constant machine-type-$(M)))
 (features iconv expeditor)
-(define-constant time-t-bits $(Mtimet))
 (include "$(March).def")
 (include "default.def")


### PR DESCRIPTION
Trying to pick `time-t-bits` is a problem, particularly for i3le, since some 32-bit Linux variants now use a 64-bit `time_t`. Fortunately, the only use of `time-t-bits` is in the kernel to select between `Sinteger64` and `Sinteger32`, and just using `Sinteger64` is safe.