### PR TITLE
Add log header to assembly output

### DIFF
--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -8344,6 +8344,7 @@
              (let ([ptrace* (map CaseLambdaExpr le* func*)])
                (for-each resolve-funcrel! funcrel*)
                (when aop
+                 (fprintf aop "output of np-generate-code (assembly):\n")
                  (for-each (lambda (ptrace) (ptrace aop)) ptrace*)
                  (flush-output-port aop))
                (local-label-func l)))])


### PR DESCRIPTION
This adds a header before the assembly output from `np-generate-code`, which aids in processing this output with further tooling.