### PR TITLE
Syntax quoting

### DIFF
--- a/csug/syntax.stex
+++ b/csug/syntax.stex
@@ -335,15 +335,12 @@ For example:
 \endentryheader
 
 A \scheme{quote-syntax} expression is like a \scheme{quote}
-expression except that contextual information associated with
+expression, except that contextual information associated with
 the datum is retained.
 
 Unlike \scheme{syntax}, \scheme{quote-syntax} does not substitute
 pattern variables bound by \scheme{with-syntax} or
 \scheme{syntax-case}.
-
-(This form is identical to the Revised$^4$ Report
-\scheme{syntax}.)
 
 \schemedisplay
 (let-syntax ([m (lambda (stx)

--- a/csug/syntax.stex
+++ b/csug/syntax.stex
@@ -1,11 +1,11 @@
 % Copyright 2005-2017 Cisco Systems, Inc.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
-% 
+%
 % http://www.apache.org/licenses/LICENSE-2.0
-% 
+%
 % Unless required by applicable law or agreed to in writing, software
 % distributed under the License is distributed on an "AS IS" BASIS,
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -326,6 +326,32 @@ For example:
 
 \scheme{datum->syntax-object} is identical to the Revised$^6$ Report
 \scheme{datum->syntax}.
+
+%----------------------------------------------------------------------------
+\entryheader
+\formdef{quote-syntax}{\categorysyntax}{(quote-syntax \var{datum})}
+\returns a syntax object
+\listlibraries
+\endentryheader
+
+A \scheme{quote-syntax} expression is like a \scheme{quote}
+expression except that contextual information associated with
+the datum is retained.
+
+Unlike \scheme{syntax}, \scheme{quote-syntax} does not substitute
+pattern variables bound by \scheme{with-syntax} or
+\scheme{syntax-case}.
+
+(This form is identical to the Revised$^4$ Report
+\scheme{syntax}.)
+
+\schemedisplay
+(let-syntax ([m (lambda (stx)
+                  (syntax-case stx ()
+                    [(_ x)
+                     #`(list 'x '#,(quote-syntax x))]))])
+  (m y)) ;=> (y x)
+\endschemedisplay
 
 %----------------------------------------------------------------------------
 \entryheader
@@ -1667,7 +1693,7 @@ procedure:
 
 \scheme{get-datum/annotations} is like \scheme{get-datum} but instead of returning
 a plain datum, it returns an annotation encapsulating a datum (possibly with nested
-annotations), a source object, and the plain (stripped) datum.  
+annotations), a source object, and the plain (stripped) datum.
 It also returns a second value, the position of the first character beyond the
 object in the file.
 Character positions are accepted and returned by

--- a/mats/8.ms
+++ b/mats/8.ms
@@ -1,12 +1,12 @@
 ;;; 8.ms
 ;;; Copyright 1984-2017 Cisco Systems, Inc.
-;;; 
+;;;
 ;;; Licensed under the Apache License, Version 2.0 (the "License");
 ;;; you may not use this file except in compliance with the License.
 ;;; You may obtain a copy of the License at
-;;; 
+;;;
 ;;; http://www.apache.org/licenses/LICENSE-2.0
-;;; 
+;;;
 ;;; Unless required by applicable law or agreed to in writing, software
 ;;; distributed under the License is distributed on an "AS IS" BASIS,
 ;;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -215,7 +215,7 @@
 
   (begin
     (define $a 'aaa)
-    (define $x 'xxx) 
+    (define $x 'xxx)
     (define-syntax $introduce-module
       (identifier-syntax
         (begin (module $a ($x) (define $x 73))
@@ -564,7 +564,7 @@
     #t)
   (equal? (gp$f) '())
   (equal? (gp$f (1 2 3 4 5) (6 7 8)) '(1 2 3 4 6 7 5 8))
-  (error? 
+  (error?
     (define-syntax gp$g
       (syntax-rules ()
         [(_ x ... y ...) '(x ... y ...)])))
@@ -943,7 +943,7 @@
  ; [
   (error? ($do-one "'(a b (c d])")) ; )
 
-  (error? ($do-one '(let () 
+  (error? ($do-one '(let ()
                       (define-syntax a
                         (lambda (x)
                           (syntax-case x ()
@@ -981,7 +981,7 @@
           (library ($selib1) (export (rename (a $selib1-a)))
             (import (rnrs))
             (define x 0)
-            (define-syntax a 
+            (define-syntax a
               (syntax-rules ()
                 [(_ n) (begin (set! x (+ x n)) x)])))
           (import ($selib1))
@@ -993,7 +993,7 @@
           (library ($selib1) (export (rename (a $selib1-a)))
             (import (rnrs))
             (define x 0)
-            (define-syntax a 
+            (define-syntax a
               (syntax-rules ()
                 [(_) (begin (set! x (+ x 1)) x)])))
           (import ($selib1))
@@ -1178,7 +1178,7 @@
  ; [
   (error? ($do-one "'(a b (c d])")) ; )
 
-  (error? ($do-one '(let () 
+  (error? ($do-one '(let ()
                       (define-syntax a
                         (lambda (x)
                           (syntax-case x ()
@@ -1218,7 +1218,7 @@
           (library ($selib1) (export (rename (a $selib1-a)))
             (import (rnrs))
             (define x 0)
-            (define-syntax a 
+            (define-syntax a
               (syntax-rules ()
                 [(_ n) (begin (set! x (+ x n)) x)])))
           (import ($selib1))
@@ -1230,7 +1230,7 @@
           (library ($selib1) (export (rename (a $selib1-a)))
             (import (rnrs))
             (define x 0)
-            (define-syntax a 
+            (define-syntax a
               (syntax-rules ()
                 [(_) (begin (set! x (+ x 1)) x)])))
           (import ($selib1))
@@ -1449,7 +1449,7 @@
     (define-syntax defconst
       (syntax-rules ()
         ((_ $x e)
-         (anonymous-module (($x t)) 
+         (anonymous-module (($x t))
            (define-syntax $x (identifier-syntax t))
            (define t e)))))
     (defconst $a 3)
@@ -1510,7 +1510,7 @@
     (define-syntax defconst
       (syntax-rules ()
         ((_ $x e)
-         (module (($x t)) 
+         (module (($x t))
            (define-syntax $x (identifier-syntax t))
            (define t e)))))
     (defconst $a 3)
@@ -2594,7 +2594,7 @@
                          (call/cc (lambda (continue) b1 b2 ...))
                          e2
                          (f))))))])))
-      (define ls-in) 
+      (define ls-in)
       (define ls-out)
       (for ((begin (set! ls-in '(a b c d e f g h i j)) (set! ls-out '()))
             (not (null? ls-in))
@@ -2632,7 +2632,7 @@
     (alias 3 x))
   (eq? (let ((x 2)) (alias y x) y) 2)
   (equal?
-    (let ((x "x"))          
+    (let ((x "x"))
       (define-syntax fool
         (let ()
           (alias y x)
@@ -4410,7 +4410,7 @@
       (let* ([ss.out (with-output-to-string (lambda () (load "testfile.ss")))]
              [cf.out (with-output-to-string (lambda () (compile-file "testfile.ss")))]
              [so.out (with-output-to-string (lambda () (load "testfile.so")))])
-        (let ([actual 
+        (let ([actual
                (list
                  ss.out
                  (substring cf.out
@@ -4536,7 +4536,7 @@
   ($foofrah
     '(begin
        (eval-when (compile load eval)
-         (module const (get put) 
+         (module const (get put)
            (define ht (make-eq-hashtable))
            (define get (lambda (name) (hashtable-ref ht name 0)))
            (define put (lambda (name value) (hashtable-set! ht name value)))))
@@ -4554,7 +4554,7 @@
   ($foofrah
     '(begin
        (eval-when (compile load eval)
-         (module const (get put) 
+         (module const (get put)
            (define ht (make-eq-hashtable))
            (define get (lambda (name) (hashtable-ref ht name 0)))
            (define put (lambda (name value) (hashtable-set! ht name value)))))
@@ -4574,7 +4574,7 @@
   ($foofrah
     '(begin
        (eval-when (compile load eval)
-         (module const (get put) 
+         (module const (get put)
            (define ht (make-eq-hashtable))
            (define get (lambda (name) (hashtable-ref ht name 0)))
            (define put (lambda (name value) (hashtable-set! ht name value)))))
@@ -4593,7 +4593,7 @@
   ($foofrah
     '(begin
        (eval-when (compile eval)
-         (module const (get put) 
+         (module const (get put)
            (define ht (make-eq-hashtable))
            (define get (lambda (name) (hashtable-ref ht name 0)))
            (define put (lambda (name value) (hashtable-set! ht name value)))))
@@ -4615,7 +4615,7 @@
          (identifier-syntax
            (begin
              (eval-when (compile eval)
-               (module const (get put) 
+               (module const (get put)
                  (define ht (make-eq-hashtable))
                  (define get (lambda (name) (hashtable-ref ht name 0)))
                  (define put (lambda (name value) (hashtable-set! ht name value)))))
@@ -4635,7 +4635,7 @@
   (begin
     (with-output-to-file "testfile-lib-c.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(library (testfile-lib-c)
              (export y)
              (import (chezscheme) (testfile-lib-a))
@@ -4644,7 +4644,7 @@
       'replace)
     (with-output-to-file "testfile-test-ac.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(begin
              (library (testfile-lib-a)
                (export x)
@@ -4667,7 +4667,7 @@
   (begin
     (with-output-to-file "testfile.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(let-syntax ([a (lambda (x) 0)])
              (define-syntax $foo (lambda (x) #'cons)))))
       'replace)
@@ -4678,7 +4678,7 @@
   (begin
     (with-output-to-file "testfile.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(begin
              (define-syntax $foo-a (lambda (x) 0))
              (define-syntax $foo (lambda (x) #'cons)))))
@@ -4702,7 +4702,7 @@
   (begin
     (with-output-to-file "testfile-tlb-a1.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(library (testfile-tlb-a1)
              (export tlb-a1-rats)
              (import (rnrs))
@@ -4710,7 +4710,7 @@
       'replace)
     (with-output-to-file "testfile-tlb-a2.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(define-syntax tlb-a2-foo
              (let ()
                (import (testfile-tlb-a1))
@@ -4718,7 +4718,7 @@
       'replace)
     (with-output-to-file "testfile-tlb-a3.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(let-syntax ([silly (lambda (x)
                                  (import (testfile-tlb-a1))
                                  (syntax-case x ()
@@ -4727,7 +4727,7 @@
       'replace)
     (with-output-to-file "testfile-tlb-a4.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(module (tlb-a4-pie)
              (import (testfile-tlb-a1))
              (define-syntax tlb-a4-pie
@@ -4735,13 +4735,13 @@
       'replace)
     (with-output-to-file "testfile-tlb-a5.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(meta define tlb-a5-spam
              (let () (import (testfile-tlb-a1)) #'(cons tlb-a1-rats 5)))))
       'replace)
     (with-output-to-file "testfile-tlb-a6a.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(library (testfile-tlb-a6a)
              (export tlb-a6-fop)
              (import (rnrs) (testfile-tlb-a1))
@@ -4749,7 +4749,7 @@
       'replace)
     (with-output-to-file "testfile-tlb-a6b.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(library (testfile-tlb-a6b)
              (export tlb-a6-alpha)
              (import (rnrs) (testfile-tlb-a6a))
@@ -4762,17 +4762,17 @@
       'replace)
     (with-output-to-file "testfile-tlb-a7.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(define-property spam spam (let () (import (testfile-tlb-a1)) #'(cons tlb-a1-rats 7)))))
       'replace)
     (with-output-to-file "testfile-tlb-a8.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(define tlb-a8-spam (let () (import (testfile-tlb-a1)) #'(cons tlb-a1-rats 8)))))
       'replace)
     (with-output-to-file "testfile-tlb-a9.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(let ()
              (import (testfile-tlb-a1))
              (set! tlb-a9-spam #'(cons tlb-a1-rats 9)))))
@@ -4828,7 +4828,7 @@
   (begin
     (with-output-to-file "testfile-tlb-bQ.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(library (testfile-tlb-bQ)
              (export tlb-bq)
              (import (rnrs))
@@ -4836,7 +4836,7 @@
       'replace)
     (with-output-to-file "testfile-tlb-bA.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(library (testfile-tlb-bA)
              (export tlb-bset-a! tlb-bget-a)
              (import (rnrs))
@@ -5407,7 +5407,7 @@
       ans)
     '(35 54 48))
   (begin
-    (module (mat-meta-zeta) 
+    (module (mat-meta-zeta)
       (meta module frobrat (boz) (define boz 3))
       (define-syntax rot (lambda (x) (import frobrat) boz))
       (define mat-meta-zeta rot))
@@ -5510,7 +5510,7 @@
       (define-syntax y (lambda (z) x))
       (define $meta-z y))
     (equal? $meta-z "jolly"))
-  
+
  ; local tests
   (error? ;=> out-of-context or unbound error
     (let ()
@@ -5549,7 +5549,7 @@
           `(,#'quote (,p ,b))))
       a)
     '(3 4))
-  
+
   (begin
     (define $mm-p "p")
     (define $mm-q "q")
@@ -5584,7 +5584,7 @@
       (c put 7 p)
       (list (c get 1) (c get 2) (c get 7)))
     '("q!" "r!" "p!"))
-  
+
  ; assuming internal-defines-as-letrec* defaults to #t
   (internal-defines-as-letrec*)
  ; following tests assume it's set to #f
@@ -5681,7 +5681,7 @@
         (set! hobbits (cons 'bilbo hobbits)))
       (set! hobbits (cons 'pippin hobbits)))
     (equal? hobbits '(pippin bilbo frodo lobelia merry)))
-  
+
  ; assuming internal-defines-as-letrec* true
   (internal-defines-as-letrec*)
   (begin
@@ -5756,7 +5756,7 @@
     (!y (+ (?y) 1))
     (x values)
     (eq? (?y) 1))
-  
+
  ; test for proper evaluation of meta defines and inits at compile-file time,
  ; visit time, revisit time, and load time
   (begin
@@ -6147,12 +6147,12 @@
         (pretty-print
           '(library (testfile-mctv0) (export get-ctv get-property) (import (chezscheme))
              (define-syntax get-ctv
-               (lambda (x)  
+               (lambda (x)
                  (lambda (r)
                    (syntax-case x ()
                      [(_ q) #`'#,(datum->syntax #'* (r #'q))]))))
              (define-syntax get-property
-               (lambda (x)  
+               (lambda (x)
                  (lambda (r)
                    (syntax-case x ()
                      [(_ q prop) #`'#,(datum->syntax #'* (r #'q #'prop))])))))))
@@ -6391,7 +6391,7 @@
   (begin
     (library (dp get-property) (export get-property) (import (scheme))
       (define-syntax get-property
-        (lambda (x)  
+        (lambda (x)
           (lambda (r)
             (syntax-case x ()
               [(_ q prop) #`'#,(datum->syntax #'* (r #'q #'prop))])))))
@@ -6407,7 +6407,7 @@
     '(spamgle . #f))
   (equal?
     (let ()
-      (import scheme) 
+      (import scheme)
       (cons (get-property cons frotz) (get-property cons fratz)))
     (if (free-identifier=? #'cons (let () (import scheme) #'cons))
         '(spamgle . #f)
@@ -6432,12 +6432,12 @@
     '(#f . #f))
   (equal?
     (let ()
-      (import scheme) 
+      (import scheme)
       (cons (get-property cons frotz) (get-property cons fratz)))
     '(#f . #f))
   (equal?
     (let ()
-      (import scheme) 
+      (import scheme)
       (define-property list type "procedure")
       (list (get-property list type) (get-property car type)))
     '("procedure" #f))
@@ -6554,11 +6554,11 @@
         (get-property x rats)
         x))
     (equal?
-      (get-output-string dp-out) 
+      (get-output-string dp-out)
       "\"x-spam\" \"x-frob\" #f 444\n"))
   (equal?
     (let ()
-      (import dp-m1) 
+      (import dp-m1)
       (list
         (get-property x spam)
         (get-property x frob)
@@ -6577,13 +6577,13 @@
         (get-property dp-out rats)))
     (and
       (equal?
-        (get-output-string dp-out) 
+        (get-output-string dp-out)
         "\"dp-out-spam\" \"dp-out-frob\" #f\n")
       (not (get-property dp-out spam))
       (not (get-property dp-out frob))))
   (equal?
     (let ()
-      (import dp-m1) 
+      (import dp-m1)
       (list
         (get-property x spam)
         (get-property x frob)
@@ -7358,7 +7358,7 @@
       'replace)
     (with-output-to-file "testfile-C.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(library (testfile-C)
              (export)
              (import (scheme) (testfile-A) (testfile-B))
@@ -7366,7 +7366,7 @@
       'replace)
     (for-each separate-compile '(A B C))
     #t)
-  (equal? 
+  (equal?
     (let ()
       (import (testfile-C))
       (list $testfile-A-x (get-property $testfile-A-x $testfile-A-prop-id)))
@@ -8496,7 +8496,7 @@
       'replace)
     (with-output-to-file "testfile-a3-9.ss"
       (lambda ()
-        (pretty-print 
+        (pretty-print
           '(let ()
              (import (scheme) (testfile-a3-8))
              (printf "inside testfile-a3-9\n"))))
@@ -8885,7 +8885,7 @@
            (define x #f)
            (error #f "failed to load library (invoke-fail)"))
          (guard (e [else
-                     (guard (e2 [else 
+                     (guard (e2 [else
                                   (display-condition e) (newline)
                                   (display-condition e2) (newline)])
                        (eval 'x (environment '(chezscheme) '(invoke-fail))))])
@@ -8902,7 +8902,7 @@
            (define x #f)
            (define y (eval '(if x 5 10) (environment '(chezscheme) '(invoke-cyclic)))))
          (guard (e [else
-                     (guard (e2 [else 
+                     (guard (e2 [else
                                   (display-condition e) (newline)
                                   (display-condition e2) (newline)])
                        (eval 'x (environment '(chezscheme) '(invoke-cyclic))))])
@@ -10072,13 +10072,13 @@
   (file-exists? "testdir/cil1.so")
   (file-exists? "testdir/cil2.so")
   (equal? $cil '(cil1 cil2))
-  (equal? (let () (import (testdir cil2)) (get-y)) '((57388321) . 57388321)) 
+  (equal? (let () (import (testdir cil2)) (get-y)) '((57388321) . 57388321))
   (equal? (let () (import (testdir cil2)) (f 772) (get-y)) 772)
   (eq?
     (parameterize ([compile-imported-libraries #t])
       (load-program "testdir/cil"))
     (void))
-  (equal? (let () (import (testdir cil2)) (get-y)) '((57388321) . 57388321)) 
+  (equal? (let () (import (testdir cil2)) (get-y)) '((57388321) . 57388321))
   (equal? $cil '(cil1 cil2))
   (begin
     (rm-rf "testdir")
@@ -10121,13 +10121,13 @@
   (file-exists? "testdir/cil3.so")
   (file-exists? "testdir/cil4.so")
   (equal? $cil '(cil3 cil4))
-  (equal? (let () (import (testdir cil4)) (get-y)) '((57388321) . 57388321)) 
+  (equal? (let () (import (testdir cil4)) (get-y)) '((57388321) . 57388321))
   (equal? (let () (import (testdir cil4)) (f 772) (get-y)) 772)
   (eq?
     (parameterize ([compile-imported-libraries #t])
       (load-program "testdir/cil"))
     (void))
-  (equal? (let () (import (testdir cil4)) (get-y)) '((57388321) . 57388321)) 
+  (equal? (let () (import (testdir cil4)) (get-y)) '((57388321) . 57388321))
   (equal? $cil '(cil3 cil4))
   (begin
     (rm-rf "testdir")
@@ -10173,7 +10173,7 @@
   (file-exists? "objdir/testdir/cil5.foo")
   (file-exists? "objdir/testdir/cil6.bar")
   (equal? $cil '(cil5 cil6))
-  (equal? (let () (import (testdir cil6)) (get-y)) '((57388321) . 57388321)) 
+  (equal? (let () (import (testdir cil6)) (get-y)) '((57388321) . 57388321))
   (equal? (let () (import (testdir cil6)) (f 772) (get-y)) 772)
   (eq?
     (parameterize ([compile-imported-libraries #t]
@@ -10181,7 +10181,7 @@
                    [library-extensions '((".sls" . ".bar") (".ss" . ".foo"))])
       (load-program "testdir/cil"))
     (void))
-  (equal? (let () (import (testdir cil6)) (get-y)) '((57388321) . 57388321)) 
+  (equal? (let () (import (testdir cil6)) (get-y)) '((57388321) . 57388321))
   (equal? $cil '(cil5 cil6))
   (begin
     (rm-rf "testdir")
@@ -10228,7 +10228,7 @@
       (load-program "testdir/cil"))
     (void))
   (equal? $cil '(cil8 cil7))
-  (equal? (let () (import (testdir cil8)) (get-y)) '((57388321) . 57388321)) 
+  (equal? (let () (import (testdir cil8)) (get-y)) '((57388321) . 57388321))
   (begin
     (rm-rf "testdir")
     #t)
@@ -10274,7 +10274,7 @@
       (load-program "testdir/cil"))
     (void))
   (equal? $cil '(cil10 cil9))
-  (equal? (let () (import (testdir cil10)) (get-y)) '((57388321) . 57388321)) 
+  (equal? (let () (import (testdir cil10)) (get-y)) '((57388321) . 57388321))
   (begin
     (rm-rf "testdir")
     #t)
@@ -10326,7 +10326,7 @@
     (parameterize ([compile-imported-libraries #t])
       (load-program "testdir/cil.so"))
     (void))
-  (equal? (let () (import (testdir cil12)) (get-y)) '((57388321) . 57388321)) 
+  (equal? (let () (import (testdir cil12)) (get-y)) '((57388321) . 57388321))
   (equal? $cil '())
   (begin
     (rm-rf "testdir")
@@ -10862,7 +10862,7 @@
     (begin
       (with-output-to-file "testfile-tlp3.ss"
         (lambda ()
-          (pretty-print 
+          (pretty-print
             '(library (testfile-tlp3)
                (export t1-x)
                (import (chezscheme))
@@ -10899,7 +10899,7 @@
       (define dep8)
       (with-output-to-file "testfile-tlp6.ss"
         (lambda ()
-          (pretty-print 
+          (pretty-print
             '(library (testfile-tlp6)
                (export t1-x)
                (import (chezscheme))
@@ -10934,7 +10934,7 @@
       (define dep8)
       (with-output-to-file "testfile-tlp9.ss"
         (lambda ()
-          (pretty-print 
+          (pretty-print
             '(library (testfile-tlp9)
                (export t1-x)
                (import (chezscheme))
@@ -11837,7 +11837,7 @@
                                      (make-string (* 2 (file-buffer-size)) #\a)
                                      "\""
                                      "\nend"))
-    
+
     (define input-port-with-lines (open-string-input-port input-string-with-lines))
     (define sfd-with-lines
       (let ((op (open-output-file "testfile.ss" 'replace)))
@@ -12025,5 +12025,20 @@
                  (with ([(z1 z2) 'y1])
                     '(z2 z1)))])
           #t)
-   (equal? (foo (a b) (c d) (e f)) '(b a))
- )
+   (equal? (foo (a b) (c d) (e f)) '(b a)))
+
+(mat quote-syntax
+   (equal? (syntax->datum (quote-syntax (a b c))) '(a b c))
+   (equal? (syntax->datum (quote-syntax ...)) '...)
+   (bound-identifier=? (quote-syntax ...) (syntax (... ...)))
+   (free-identifier=? (quote-syntax ...) (syntax (... ...)))
+   (equal? (with-syntax ([x #'y]) (syntax->datum (quote-syntax x))) 'x)
+   (let-syntax ([m (lambda (stx)
+                     (syntax-case stx ()
+                       [(_ x) #'(and (equal? (syntax->datum (quote-syntax x)) '+)
+                                     (free-identifier=? (syntax x) #'-))]))])
+     (with-syntax ([+ #'-]) (m +)))
+   (error? ; invalid syntax
+     (quote-syntax))
+   (error? ; invalid syntax
+     (quote-syntax a b)))

--- a/mats/root-experr-compile-0-f-f-f
+++ b/mats/root-experr-compile-0-f-f-f
@@ -9373,6 +9373,8 @@ enum.mo:Expected error in mat enumeration: "make-record-type: cannot extend seal
 8.mo:Expected error in mat extend-syntax: "extend-syntax: invalid context for ... in (foo x . ...)".
 8.mo:Expected error in mat extend-syntax: "extend-syntax: invalid context for ... in (foo (...))".
 8.mo:Expected error in mat extend-syntax: "extend-syntax: duplicate pattern variable name x in (foo x x)".
+8.mo:Expected error in mat quote-syntax: "invalid syntax (quote-syntax)".
+8.mo:Expected error in mat quote-syntax: "invalid syntax (quote-syntax a b)".
 fx.mo:Expected error in mat fx=: "fx=: (a) is not a fixnum".
 fx.mo:Expected error in mat fx=: "fx=: <int> is not a fixnum".
 fx.mo:Expected error in mat fx=: "fx=: <-int> is not a fixnum".

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -102,7 +102,7 @@ A version number listed in parentheses in the header for a change
 indicates the first minor release or internal prerelease to support
 the change.
 
-More information on {\ChezScheme} and {\PetiteChezScheme} can 
+More information on {\ChezScheme} and {\PetiteChezScheme} can
 \scheme{be} found at \hyperlink{http://www.scheme.com/}{http://www.scheme.com},
 and extensive documentation is available in
 \TSPL{4}{th} (available directly from MIT Press or from online and local retailers)
@@ -776,6 +776,13 @@ When searching for boot files, the two-character escape sequence
 Scheme is configured to use this facility to find boot files relative
 to the executable, even when installed.
 
+\subsection{Syntax quoting (9.9.9)}
+
+The new \scheme{quote-syntax} form is like the R$^6$RS \scheme{syntax}
+form except that pattern variables are not substituted.  It can be
+useful for macro transformers that need to embed syntax objects based
+on the input in the output.
+
 \subsection{New conversions from Scheme to C signed and unsigned integers (9.6.4)}
 
 The following new functions
@@ -1354,7 +1361,7 @@ leaves all imported libraries visible.
 \subsection{24-, 40-, 48-, and 56-bit bit-field containers (9.3.3)}
 
 The total size of the fields within an ftype \scheme{bits} can now be
-24, 40, 48, or 56 (as well as 8, 16, 32, and 64). 
+24, 40, 48, or 56 (as well as 8, 16, 32, and 64).
 
 \subsection{Object-counting for static-generation collections (9.3.3)}
 
@@ -2379,7 +2386,7 @@ the registers.
 
 \subsection{24-, 40-, 48-, and 56-bit integer values (8.9.3)}
 
-Support for storing and extracting 24-, 40-, 48-, and 56-bit integers 
+Support for storing and extracting 24-, 40-, 48-, and 56-bit integers
 to and from records, bytevectors, and foreign types (ftypes) has been
 added.
 For records and ftypes, this is accomplished by declaring a field
@@ -3084,7 +3091,7 @@ A bug in the source optimizer that caused pariah forms to be ignored
 has been fixed.
 [This bug dated back to at least Version 9.3.1.]
 
-\subsection{Invalid memory references involving complex numbers (9.5)} 
+\subsection{Invalid memory references involving complex numbers (9.5)}
 
 A bug on 64-bit platforms that occasionally caused invalid memory
 references when operating on inexact complex numbers or the imaginary parts
@@ -3348,7 +3355,7 @@ a large number of libraries.
 
 \scheme{profile-release-counters} is now generation-friendly, meaning
 it does not incur any overhead for code objects in generations that
-have not been collected since the last call to\scheme{profile-release-counters}. 
+have not been collected since the last call to\scheme{profile-release-counters}.
 Also, it no longer allocates memory when counters are released.
 
 \subsection{Reduced cost for obtaining profile counts (9.5.4)}

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1,12 +1,12 @@
 ;;; primdata.ss
 ;;; Copyright 1984-2017 Cisco Systems, Inc.
-;;; 
+;;;
 ;;; Licensed under the Apache License, Version 2.0 (the "License");
 ;;; you may not use this file except in compliance with the License.
 ;;; You may obtain a copy of the License at
-;;; 
+;;;
 ;;; http://www.apache.org/licenses/LICENSE-2.0
-;;; 
+;;;
 ;;; Unless required by applicable law or agreed to in writing, software
 ;;; distributed under the License is distributed on an "AS IS" BASIS,
 ;;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -1107,6 +1107,7 @@
   (predicate [flags])
   (prefix [flags])
   (profile [flags])
+  (quote-syntax [flags])
   (rec [flags])
   (rename [flags])
   (record-case [flags])

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -1,12 +1,12 @@
 ;;; syntax.ss
 ;;; Copyright 1984-2017 Cisco Systems, Inc.
-;;; 
+;;;
 ;;; Licensed under the Apache License, Version 2.0 (the "License");
 ;;; you may not use this file except in compliance with the License.
 ;;; You may obtain a copy of the License at
-;;; 
+;;;
 ;;; http://www.apache.org/licenses/LICENSE-2.0
-;;; 
+;;;
 ;;; Unless required by applicable law or agreed to in writing, software
 ;;; distributed under the License is distributed on an "AS IS" BASIS,
 ;;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -4940,7 +4940,7 @@
                     ($oops who "loading ~a did not define library ~s" obj-path path))]))))
       (define do-load-library-src-or-obj
         (lambda (src-path obj-path)
-          (define (load-source) 
+          (define (load-source)
             (with-message "object file is out-of-date"
               (with-message (format "loading source file ~s" src-path)
                 (do-load-library src-path 'load))))
@@ -5172,7 +5172,7 @@
                     (eq? x 'exists))
           ($oops who "~s is not a timestamp mode" x))
         x)))
-  
+
   (set! expand-omit-library-invocations
     ($make-thread-parameter #f
       (lambda (v) (and v #t))))
@@ -5214,7 +5214,7 @@
                 (let loop ([rlpinfo* '()])
                   (let ([x (fasl-read ip situation)])
                     (if (or (library-info? x) (program-info? x))
-                        (loop (cons x rlpinfo*)) 
+                        (loop (cons x rlpinfo*))
                         (begin (close-port ip) (reverse rlpinfo*))))))))))
       (unless (memq situation '(load visit revisit)) ($oops who "invalid situation ~s; should be one of load, visit, or revisit" situation))
       (let-values ([(libdirs* fn*) (parse-inputs input*)])
@@ -5511,7 +5511,7 @@
                     (for-each (lambda (req) (import-library (libreq-uid req))) (libdesc-import-req* desc))
                     (p)))]))]
           [else ($oops #f "library ~:s is not defined" uid)])))
-  
+
     ; invoking or visiting a possibly unloaded library occurs in two separate steps:
     ;   1. load library and all dependencies first, recompiling or reloading if requested and required
     ;   2. invoke or visit the library and dependencies
@@ -5892,7 +5892,7 @@
                        [else (put-global-definition-hook s b)])))])
              ; add system bindings to other modules as appropriate
               (cond
-                [(any-set? (prim-mask (or keyword system-keyword)) m)
+               [(any-set? (prim-mask (or keyword system-keyword)) m)
                  (let ([id (make-resolved-id s (wrap-marks top-wrap) s)])
                    (cond
                      [(any-set? (prim-mask keyword) m)
@@ -6024,6 +6024,12 @@
    (lambda (e r w ae)
       (syntax-case e ()
          ((_ e) (build-data ae (strip (syntax e) w)))
+         (_ (syntax-error (source-wrap e w ae))))))
+
+(global-extend 'core 'quote-syntax
+   (lambda (e r w ae)
+      (syntax-case e ()
+         ((_ e) (build-data no-source (source-wrap (syntax e) w ae)))
          (_ (syntax-error (source-wrap e w ae))))))
 
 (global-extend 'core 'syntax


### PR DESCRIPTION
This contribution adds the `quote-syntax` form to the language. This form, which can also be found in Racket and Guile, is like `syntax` but does not substitute pattern variables.  (In fact, `quote-syntax` is like the `syntax` form from the R<sup>4</sup>RS appendix.)

The `quote-syntax` can be helpful for macro writers when the quoted datum's contents are not controlled by the macro and unwanted capture of pattern variables has to be avoided.