### PR TITLE
Use GNU89 for kernel C

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
             os: ubuntu-22.04
           - machine: ta6le
             os: ubuntu-22.04
+            configure: CFLAGS+=-std=gnu89
           - machine: ta6le
             os: ubuntu-22.04
             variant: reboot
@@ -44,6 +45,7 @@ jobs:
           - machine: ta6nt
             os: windows-2022
             toolchain: gcc
+            configure: CFLAGS+=-std=gnu89
     runs-on: ${{ matrix.config.os }}
     env:
       TARGET_MACHINE: ${{ matrix.config.machine }}

--- a/c/foreign.c
+++ b/c/foreign.c
@@ -134,7 +134,8 @@ static ptr lookup_dynamic(const char *s, ptr tbl) {
         if (!handle) {
             HMODULE *modules = S_enum_process_modules();
             if (modules) {
-                for (HMODULE *m = modules; *m; ++m) {
+                HMODULE *m;
+                for (m = modules; *m; ++m) {
                     value = dlsym(*m, s);
                     if (value != NULL) break;
                 }

--- a/c/self-exe.c
+++ b/c/self-exe.c
@@ -73,7 +73,8 @@ static char *wide_to_utf8(const wchar_t *arg) {
 
 static char *get_process_executable_path(const char *exec_file) {
   wchar_t *path = NULL;
-  for (DWORD n = 0, sz = 256;; sz *= 2) {
+  DWORD n, sz;
+  for (n = 0, sz = 256;; sz *= 2) {
     path = (wchar_t *)malloc(sz * sizeof(wchar_t));
     if (path == NULL) {
       return NULL;
@@ -153,7 +154,8 @@ static char *get_self_path_platform() {
      sysctl may not return the desired path if there are multiple hardlinks
      to the file. */
 #if __FreeBSD_version >= 1300057
-  for (size_t bufsize = 256;; bufsize *= 2) {
+  size_t bufsize;
+  for (bufsize = 256;; bufsize *= 2) {
     char *buf = (char *)malloc(bufsize);
     if (buf == NULL) {
       return NULL;
@@ -174,7 +176,8 @@ static char *get_self_path_platform() {
   while (*p++ != 0)
     ;
   /* Iterate through auxiliary vectors for AT_EXECPATH. */
-  for (Elf_Auxinfo *aux = (Elf_Auxinfo *)p; aux->a_type != AT_NULL; aux++) {
+  Elf_Auxinfo *aux;
+  for (aux = (Elf_Auxinfo *)p; aux->a_type != AT_NULL; aux++) {
     if (aux->a_type == AT_EXECPATH) {
       return copy_string((char *)aux->a_un.a_ptr);
     }
@@ -238,7 +241,8 @@ static char *get_self_path_generic(const char *exec_file) {
   if (s == NULL) {
     return NULL;
   }
-  for (char *p = s + strspn(s, ":"); *p != '\0'; p += strspn(p, ":")) {
+  char *p;
+  for (p = s + strspn(s, ":"); *p != '\0'; p += strspn(p, ":")) {
     char *t = p;
     p += strcspn(p, ":");
     if (*p != '\0') {


### PR DESCRIPTION
C99/GNU99 is obviously well established and a sensible choice of standard for a C code base. Still, in some environments where it remains useful to compile Chez Scheme, the default `gcc` mode is GNU89.
    
Since C isn't the main development language for Chez Scheme, since it's easy to stick to GNU89, and since that usefully reduces build friction, this commit makes the few changes needs to get back to GNU89. GitHub CI is configured to use `-std=gnu89` for two builds to help maintain the choice.
    
GNU89 is a little more flexible than C89 (ANSI C), because it allows declarations in the middle of a block, but it does not allow variables defined in the parentheses after `for`. We also rely on GNU extensions for inlining declarations.

The CI configuration here relies on #781, so this PR is a candidate for merging after that one.