### PR TITLE
Update debug.stex to fix link to "How to Debug Chez Scheme Programs".

### DIFF
--- a/csug/debug.stex
+++ b/csug/debug.stex
@@ -1058,7 +1058,7 @@ returns the symbol \scheme{box}.
 returns an inspector object containing the contents of the box.
 
 \instype{TLC}
-Box inspector objects contain {\ChezScheme} boxes.
+TLC inspector objects contain {\ChezScheme} transport link cells.
 
 \insmsg{tlc}{\scheme{'type}}
 returns the symbol \scheme{tlc}.

--- a/csug/debug.stex
+++ b/csug/debug.stex
@@ -26,7 +26,7 @@ the tutorial ``How to Debug Chez Scheme Programs.''
 HTML and PDF versions
 % of the tutorial
 are available at
-\hyperlink{http://www.cs.indiana.edu/chezscheme/debug/}{http://www.cs.indiana.edu/chezscheme/debug/}.
+\hyperlink{https://scheme.com/debug/debug.html}{https://scheme.com/debug/debug.html}.
 
 
 \section{Tracing\label{SECTDEBUGTRACING}}


### PR DESCRIPTION
Updated broken URL to point to the Scheme.com copy of Kent Dybvig's "How to Debug Chez Scheme Programs".

Also, I think I found a copy/paste error in the file:

```
Box inspector objects. Box inspector objects contain Chez Scheme boxes.
...
TLC inspector objects. Box inspector objects contain Chez Scheme boxes.
```

I suspect the description of TLC inspector objects is a copy/paste error from the description of Box inspector objects.  I'm not sure what an accurate and useful description of a `TLC inspector object` is, though.  If anyone knows, please fix!  :)