### PR TITLE
doc: pseudo-random-generator-next! can't return 0.0

### DIFF
--- a/csug/numeric.stex
+++ b/csug/numeric.stex
@@ -1506,8 +1506,8 @@ Checks whether \var{val} is a pseudo-random generator state.
 provided, it must be a positive, exact integer.
 
 Steps a pseudo-random generator to produce a number. The result is an
-inexact number between \scheme{0.0} (inclusive) and \scheme{1.0}
-(exclusive) if \var{below-int} is not provided. If \scheme{below-int} is
+inexact number between \scheme{0.0} and \scheme{1.0}
+(both exclusive) if \var{below-int} is not provided. If \scheme{below-int} is
 provided, the result is an exact integer between \scheme{0} (inclusive)
 and \scheme{below-int} (exclusive).
 


### PR DESCRIPTION
According to the code of `S_random_state_next_double` at https://github.com/cisco/ChezScheme/blob/1f5adec2c18712c89eb1692458fcf5d6514bff42/c/random.c#L108-L109 (which is invoked by `pseudo-random-generator-next!`), the value is in the range (inclusively) 1 / (m1 + 1) to m1 / (m1 + 1). Therefore, 0.0 cannot be the result.