### PR TITLE
adjustment and workaround for macOS iconv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
             os: macos-12
           - machine: ta6osx
             os: macos-12
+          - machine: arm64osx
+            os: macos-14
+          - machine: tarm64osx
+            os: macos-14
           - machine: i3le
             os: ubuntu-22.04
           - machine: ti3le

--- a/c/version.h
+++ b/c/version.h
@@ -328,6 +328,8 @@ typedef int tputsputcchar;
 #define NSECCTIME(sb) (sb).st_ctimespec.tv_nsec
 #define NSECMTIME(sb) (sb).st_mtimespec.tv_nsec
 #define ICONV_INBUF_TYPE char **
+/* workaround issue in macOS 14.2.1 iconv: */
+#define DISTRUST_ICONV_PROGRESS
 #endif
 
 #if defined(__QNX__)

--- a/mats/io.ms
+++ b/mats/io.ms
@@ -1012,7 +1012,9 @@
                 '()
                 (if (fx= i #xD800)
                     (f #xE000)
-                    (cons i (f (fx+ i 1)))))))
+                    (if (fx= i #xFEFF) ; avoid BOM, which an encoder is arguably justified in dropping
+                        (f (fx+ i 1))
+                        (cons i (f (fx+ i 1))))))))
         (define ls2
           (let f ([n 1000000])
             (if (fx= n 0)
@@ -1021,7 +1023,9 @@
                   (let ([n (random (- #x110000 (- #xE000 #xD800)))])
                     (if (<= #xD800 n #xDFFF)
                         (+ n (- #xE000 #xD800))
-                        n))
+                        (if (fx= n #xFEFF) ; avoid BOM
+                            #xFEFE
+                            n)))
                   (f (fx- n 1))))))
         (define s (apply string (map integer->char (append ls1 ls2))))
         #;(define s (apply string (map integer->char ls1)))


### PR DESCRIPTION
Intended to address #797.

History note: the iconv library in macOS 14.0 was especially broken. By 14.2.1, it has been mostly fixed, but I think the Chez Scheme test suite uncovers a remaining problem. That problem persists in 14.3.1. 

The two different failing cases have different reasons:

* The test at line 1004 fails because iconv encodes a BOM to UTF-8 as 0 bytes. That's arguably correct behavior (a BOM encoding isn't supposed to appear in UTF-8), and the test suite can accommodate it by just avoiding a BOM.

* The test at line 710 fails due to behavior that seems to be a lingering bug in iconv, where the library incorrectly reports too little decoding success (by not advancing the output pointer) than it should when failing to convert a lambda character to a Chinese encoding. The commit here works around that by not trusting the pointer advances when an a specific error is reported. Unless I have it wrong, the change is ok for a working iconv, too, in part due to the way the workaround is specific to an `E2BIG` result.

I'm not sure the bug-workaround change is a good idea. Workarounds for OS bugs are sometimes necessary, but it's usually easier to get a sense of the bug's extent so that a workaround feels worthwhile. This workaround is fairly specific to a random corner of a library, and I can't help thinking there are likely other random corners with bugs. Still, I lean toward having the workaround, for now. An alternative is to disable the failing test on macOS.