### PR TITLE
Repairs and improvements for building with external dependencies

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -149,7 +149,8 @@ information on the supported options.
 The generated makefile mostly just ensures that a `zuo` executable is
 built in a `bin` directory, and then it defers the actual build work
 to `zuo`, which uses the "main.zuo" file. If you have `zuo` installed,
-you can use `zuo` directly instead of `make`. In general, instead of
+you can use `zuo` directly instead of `make`: in that case, you may
+wish to use `./configure ZUO=<zuo>`. In general, instead of
 the command `make X` to build target `X` as described below, you can
 use `zuo . X` (or `bin/zuo . X` after `bin/zuo` is built).
 
@@ -333,7 +334,7 @@ The makefile supports several targets:
  * `make clean`
 
    Removes all built elements from the workarea, and then removes
-   `bin/zuo`.
+   `bin/zuo` (unless configured with `ZUO=<zuo>`).
 
 
 WINDOWS VIA COMMAND PROMPT

--- a/build.zuo
+++ b/build.zuo
@@ -224,10 +224,15 @@
            token))
 
   (define stexlib
-    (let ((found (assoc "STEXLIB" (hash-ref (runtime-env) 'env))))
-      (if found
-          (cdr found)
-          (at-source "stex"))))
+    (let ([configured (hash-ref config 'STEXLIB "")]
+          [env (assoc "STEXLIB" (hash-ref (runtime-env) 'env))])
+      (cond
+        [(not (equal? "" configured))
+         configured]
+        [env
+         (cdr env)]
+        [else
+         (at-source "stex")])))
   (define stex-sources
     (source-tree stexlib))
 

--- a/configure
+++ b/configure
@@ -103,6 +103,7 @@ moreBootFiles=
 preloadBootFiles=
 alwaysUseBootFile=
 skipSubmoduleUpdate=
+zuoExternal=
 
 CONFIG_UNAME=`uname`
 
@@ -446,6 +447,9 @@ while [ $# != 0 ] ; do
     LZ4=*)
       LZ4Lib=`echo $1 | sed -e 's/^LZ4=//'`
       ;;
+    ZUO=*)
+      zuoExternal=`echo $1 | sed -e 's/^ZUO=//'`
+      ;;
     *)
       echo "option '$1' unrecognized or missing an argument; try $0 --help"
       exit 1
@@ -672,6 +676,7 @@ if [ "$help" = "yes" ]; then
   echo "  STRIP=<strip>                     executable stripper"
   echo "  ZLIB=<lib>                        link to <lib> instead of own zlib"
   echo "  LZ4=<lib>                         link to <lib> instead of own LZ4"
+  echo "  ZUO=<zuo>                         build with <zuo> instead of own Zuo"
   echo ""
   echo "Available machine types: $machs"
   echo ""
@@ -889,8 +894,17 @@ submod_instructions () {
     exit 1
 }
 
-if [ ! -f "$srcdir"/zuo/configure ] ; then
-    submod_instructions 'Source in "zuo" is missing'
+if [ "${zuoExternal}" = "" ] ; then
+    if [ ! -f "$srcdir"/zuo/configure ] ; then
+        submod_instructions 'Source in "zuo" is missing'
+    fi
+    ZUO="bin/zuo"
+    RM_ZUO="rm -f bin/zuo"
+    ZUO_TARGET="bin/zuo"
+else
+    ZUO="${zuoExternal}"
+    RM_ZUO="@echo 'Not cleaning external ${zuoExternal}'"
+    ZUO_TARGET="DoNotBuildZuo"
 fi
 
 if [ ! -f "$srcdir"/nanopass/nanopass.ss ] ; then
@@ -1129,6 +1143,10 @@ enablelibffi=$libffi
 preloadBootFiles=$preloadBootFiles
 alwaysUseBootFile=$alwaysUseBootFile
 relativeBootFiles=$relativeBootFiles
+
+ZUO=$ZUO
+RM_ZUO=$RM_ZUO
+ZUO_TARGET=$ZUO_TARGET
 
 InstallBin=$installbin
 InstallLib=$installlib

--- a/configure
+++ b/configure
@@ -93,6 +93,7 @@ default_warning_flags="-Wpointer-arith -Wall -Wextra -Wno-implicit-fallthrough"
 CFLAGS_ADD=
 zlibLib=
 LZ4Lib=
+STEXLIB=
 Kernel=KernelLib
 buildKernelOnly=no
 enableFrompb=yes
@@ -447,6 +448,9 @@ while [ $# != 0 ] ; do
     LZ4=*)
       LZ4Lib=`echo $1 | sed -e 's/^LZ4=//'`
       ;;
+    STEXLIB=*)
+      STEXLIB=`echo $1 | sed -e 's/^STEXLIB=//'`
+      ;;
     ZUO=*)
       zuoExternal=`echo $1 | sed -e 's/^ZUO=//'`
       ;;
@@ -676,6 +680,7 @@ if [ "$help" = "yes" ]; then
   echo "  STRIP=<strip>                     executable stripper"
   echo "  ZLIB=<lib>                        link to <lib> instead of own zlib"
   echo "  LZ4=<lib>                         link to <lib> instead of own LZ4"
+  echo "  STEXLIB=<stex>                    build docs with <stex> instead of own stex"
   echo "  ZUO=<zuo>                         build with <zuo> instead of own Zuo"
   echo ""
   echo "Available machine types: $machs"
@@ -923,8 +928,10 @@ if [ "${LZ4Lib}" = "" ] ; then
     fi
 fi
 
-if [ ! -f "$srcdir"/stex/Mf-stex ] ; then
-    submod_instructions 'Source in "stex" is missing'
+if [ "${STEXLIB}" = "" ] ; then
+    if [ ! -f "$srcdir"/stex/Mf-stex ] ; then
+        submod_instructions 'Source in "stex" is missing'
+    fi
 fi
 
 # more compile and link flags for c/Mf-unix and mats/Mf-unix
@@ -1133,6 +1140,7 @@ cursesLib=$cursesLib
 ncursesLib=$ncursesLib
 zlibLib=$zlibLib
 LZ4Lib=$LZ4Lib
+STEXLIB=$STEXLIB
 warningFlags=$warningFlags
 Kernel=$Kernel
 installscriptname=$installscriptname

--- a/configure
+++ b/configure
@@ -897,13 +897,13 @@ if [ ! -f "$srcdir"/nanopass/nanopass.ss ] ; then
     submod_instructions 'Source in "nanopass" is missing'
 fi
 
-if [ "${zlibDep}" != "" ] ; then
+if [ "${zlibLib}" = "" ] ; then
     if [ ! -f "$srcdir"/zlib/configure ] ; then
         submod_instructions 'Source in "zlib" is missing'
     fi
 fi
 
-if [ "${LZ4Dep}" != "" ] ; then
+if [ "${LZ4Lib}" = "" ] ; then
     if [ ! -f "$srcdir"/lz4/lib/Makefile ] ; then
         submod_instructions 'Source in "lz4" is missing'
     fi
@@ -1083,7 +1083,7 @@ cp "$srcdir"/makefiles/buildmain.zuo main.zuo
 # Some idea, but in the workarea, so it refers to "workarea.zuo" here:
 cp "$srcdir"/makefiles/workmain.zuo $w/main.zuo
 
-# The content of "$w/Makefile" records configuration decisions,
+# The content of "$w/Mf-config" records configuration decisions,
 # and the Zuo build script takes it from there
 cat > $w/Mf-config << END
 srcdir=$srcdir

--- a/makefiles/Makefile.in
+++ b/makefiles/Makefile.in
@@ -3,8 +3,6 @@ workarea=$(w)
 
 include $(workarea)/Mf-config
 
-ZUO=bin/zuo
-
 .PHONY: build
 build: $(ZUO)
 	+ $(ZUO) $(workarea) MAKE="$(MAKE)"
@@ -144,9 +142,9 @@ pkg: $(ZUO)
 .PHONY: clean
 clean: $(ZUO)
 	+ $(ZUO) $(workarea) clean MAKE="$(MAKE)"
-	rm -f bin/zuo
+	$(RM_ZUO)
 
 # Using `+` here means that $(ZUO) gets built even if `-n`/`--dry-run` is provided to `make`
-$(ZUO): $(srcdir)/zuo/zuo.c
+$(ZUO_TARGET): $(srcdir)/zuo/zuo.c
 	+ mkdir -p bin
 	+ $(CC_FOR_BUILD) -DZUO_LIB_PATH='"'"../zuo/lib"'"' -o $(ZUO) $(srcdir)/zuo/zuo.c


### PR DESCRIPTION
This patch series repairs and improves support for configuring Chez Scheme to use external copies of some dependencies normally included as submodules. Overall, these changes let Chez Scheme be built in ways that already worked to build older versions of Chez Scheme and the copy of Chez Scheme distributed with Racket (because the configure script in the Racket sources tried less hard to make sure the dependencies were really present).

 1. The first patch fixes the checks for the `zlib` and `lz4` submodules, which are currently noops, to actually perform checks unless configured with `ZLIB=<zlib>` or `LZ4=<lz4>`, respectively.
 2. The second patch adds an analogous `ZUO=<zuo>` argument. Rather than simply skip the submodule check and require the user then to build with `make ZUO=zuo` (or to use Zuo directly), this patch records the configuration choice in `Mf-config` and slightly adjusts `Makefile.in` to adapt more gracefully to this mode.
 3. The final patch similarly adds an `STEXLIB=<stex>` argument to `configure` and updates `build.zuo` as I had considered in https://github.com/racket/racket/pull/4203#issuecomment-1107692530 after https://github.com/racket/racket/commit/d897379ef64178347ba7af3f0314317433d00410:
    > The only way to use an installed Stex up to this point has been running `make STEXLIB=` with GNU Make or some other `make` that will propagate it as needed. I have only adjusted the Zuo script to recognize an `STEXLIB` passed that way: I haven't tried to support setting `STEXLIB` via `configure` or other mechanisms. There would be some uniformity in doing so, but it wouldn't be useful for Guix packaging unless it were also supported upstream, since we try to share as much as possible between the package definitions for the two Chez Schemes.

In fact, with these changes cherry-picked as downstream patches, my draft update of the [Guix package](https://packages.guix.gnu.org/packages/chez-scheme) to Chez Scheme 10 is able to share its *entire* build recipe exactly with our [`chez-scheme-for-racket`](https://packages.guix.gnu.org/packages/chez-scheme-for-racket) package (which we used for the architectures newly supported in version 10 and will continue to use for bootstrapping).