### PR TITLE
constrain signal delivery to Scheme to the main thread

### DIFF
--- a/c/globals.h
+++ b/c/globals.h
@@ -49,6 +49,7 @@ EXTERN int S_num_preserve_ownership_threads;
 # ifdef IMPLICIT_ATOMIC_AS_EXPLICIT
 EXTERN s_thread_mutex_t S_implicit_mutex;
 # endif
+EXTERN s_thread_t S_main_thread_id;
 #endif
 
 /* segment.c */

--- a/c/schsig.c
+++ b/c/schsig.c
@@ -666,6 +666,16 @@ ptr S_dequeue_scheme_signals(ptr tc) {
 static void forward_signal_to_scheme(INT sig) {
   ptr tc = get_thread_context();
 
+#ifdef PTHREADS
+  /* deliver signals to the main thread, only; depending
+     on the threads that are running, `tc` might even be NULL */
+  if (tc != TO_PTR(&S_G.thread_context)) {
+    pthread_kill(S_main_thread_id, sig);
+    RESET_SIGNAL
+    return;
+  }
+#endif
+
   if (enqueue_scheme_signal(tc, sig)) {
     SIGNALINTERRUPTPENDING(tc) = Strue;
     SOMETHINGPENDING(tc) = Strue;

--- a/c/thread.c
+++ b/c/thread.c
@@ -40,6 +40,7 @@ void S_thread_init(void) {
     s_thread_cond_init(&S_terminated_cond);
     S_alloc_mutex.owner = 0;
     S_alloc_mutex.count = 0;
+    S_main_thread_id = s_thread_self();
 
 # ifdef IMPLICIT_ATOMIC_AS_EXPLICIT
     s_thread_mutex_init(&S_implicit_mutex);

--- a/csug/system.stex
+++ b/csug/system.stex
@@ -547,6 +547,8 @@ After a signal handler for a given signal has been registered, receipt
 of the specified signal results in a call to the handler.
 The handler is passed the signal number, allowing the same handler to
 be used for different signals while differentiating among them.
+In a threaded version of the system, signals are always delivered to
+the main thread.
 
 Signals handled in this fashion are treated like keyboard interrupts in
 that the handler is not called immediately when the signal is delivered


### PR DESCRIPTION
This change is an attempt to address #809.

My guess here is that the test crashes when signal 14 is delivered to a thread that is not a Scheme thread. In particular, if a GC has happened previously while multiple threads were running, then GC worker threads may be waiting around. They haven't masked signals, and the thread-local variable for a thread context will be NULL in those worker threads.

In that scenario, I don't think the signal would get delivered to a non-main thread on macOS, because `sigprocmask` and the automatic masking of signals during delivery is process-wide there. On Linux, however, the signal mask is thread-specific. That difference would explain why I see the crash rarely and (in retrospect, as far as I can remember) only when trying out different Linux systems and not when working in my main macOS development environment.

Before this change, I can force a crash by ensuring that GC threads have been created, disabling signals in the main thread in Linux, and then having a handled signal delivered to the Scheme process. So, maybe the test was sometimes crashing when the main thread happens to have signals blocked in the main thread when signal 14 is delivered to the process. That particular problem could not have happened before parallelism was added to the GC, and so maybe it would never have happened in the test before. In practice, there are often extra threads running in a process, and that's why this patch adjusts the signal handler to redirect to the main thread instead of setting the signal mask in GC worker threads.