### PR TITLE
add configuration for s390x (and related) to `c/version.h`

### DIFF
--- a/c/version.h
+++ b/c/version.h
@@ -48,6 +48,11 @@
 # define FLUSHCACHE
 #endif
 
+#if defined(__s390__) || defined(__s390x__) || defined(__zarch__)
+# define PORTABLE_BYTECODE_BIGENDIAN
+# define BIG_ENDIAN_IEEE_DOUBLE
+#endif
+
 #ifdef PORTABLE_BYTECODE
 # undef FLUSHCACHE
 # ifdef PORTABLE_BYTECODE_BIGENDIAN


### PR DESCRIPTION
This configuration enables pb mode to run on s390x.

See also to racket/racket#4951.