### PR TITLE
avoid wrong assembly code for threaded mode on ARMv5 and earlier

### DIFF
--- a/c/atomic.h
+++ b/c/atomic.h
@@ -89,7 +89,7 @@ FORCEINLINE int CAS_STORE_RELEASE(volatile void *addr, void *old_val, void *new_
                         : "cc", "memory", "x12", "x7");
   return ret;
 }
-#elif defined(__arm__)
+#elif defined(__arm__) && ((arm_isa_version >= 6) || (__ARM_ARCH >= 6))
 FORCEINLINE int S_cas_any_fence(int load_acquire, volatile void *addr, void *old_val, void *new_val) {
   int ret;
   if (load_acquire)


### PR DESCRIPTION
This change makes a `tpb32l` build work for ARM before ARMv6 — including the `armel` Debian build, as opposed to `armhf`.

The main obstacle to supporting older Arm processors directly is that the "arm32.ss" backend currently uses hardware-supported floating point instructions via the VFP extension, which means ARMv6 and later. A software floating-point mode could be added (or restored, since it looks like there may have been one at some point?), but my guess is that there isn't any demand at the moment. Meanwhile, this simple change at least lets `tpb32l` build. 

See also racket/racket#4955.