### PR TITLE
repair GC for reference bytevector whose length isn't a multiple of a word

### DIFF
--- a/boot/pb/gc-ocd.inc
+++ b/boot/pb/gc-ocd.inc
@@ -131,9 +131,26 @@ static IGEN copy(thread_gc *tgc, ptr p, seginfo *si, ptr *dest)
                   {
                     uptr len = Sbytevector_reference_length(p);
                     memcpy_aligned(&BVIT(new_p, 0), &BVIT(p, 0), ptr_bytes * len);
-                    if ((len & 1) == 0)
                     {
-                      INITBVREFIT(new_p, len) = FIX(0);
+                      uptr extra = (Sbytevector_length(p)) - (len * ptr_bytes);
+                      if (extra == 0)
+                      {
+                        if ((len & 1) == 0)
+                        {
+                          INITBVREFIT(new_p, len) = FIX(0);
+                        }
+                      }
+                      else
+                      {
+                        INITBVREFIT(new_p, len) = INITBVREFIT(p, len);
+                        {
+                          uptr xlen = len + 1;
+                          if ((xlen & 1) == 0)
+                          {
+                            INITBVREFIT(new_p, xlen) = FIX(0);
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/boot/pb/gc-oce.inc
+++ b/boot/pb/gc-oce.inc
@@ -206,9 +206,26 @@ static IGEN copy(thread_gc *tgc, ptr p, seginfo *si, ptr *dest)
                   {
                     uptr len = Sbytevector_reference_length(p);
                     memcpy_aligned(&BVIT(new_p, 0), &BVIT(p, 0), ptr_bytes * len);
-                    if ((len & 1) == 0)
                     {
-                      INITBVREFIT(new_p, len) = FIX(0);
+                      uptr extra = (Sbytevector_length(p)) - (len * ptr_bytes);
+                      if (extra == 0)
+                      {
+                        if ((len & 1) == 0)
+                        {
+                          INITBVREFIT(new_p, len) = FIX(0);
+                        }
+                      }
+                      else
+                      {
+                        INITBVREFIT(new_p, len) = INITBVREFIT(p, len);
+                        {
+                          uptr xlen = len + 1;
+                          if ((xlen & 1) == 0)
+                          {
+                            INITBVREFIT(new_p, xlen) = FIX(0);
+                          }
+                        }
+                      }
                     }
                     S_G.countof[tg][countof_bytevector] += 1;
                     S_G.bytesof[tg][countof_bytevector] += p_sz;

--- a/boot/pb/gc-par.inc
+++ b/boot/pb/gc-par.inc
@@ -131,9 +131,26 @@ static IGEN copy(thread_gc *tgc, ptr p, seginfo *si, ptr *dest)
                   {
                     uptr len = Sbytevector_reference_length(p);
                     memcpy_aligned(&BVIT(new_p, 0), &BVIT(p, 0), ptr_bytes * len);
-                    if ((len & 1) == 0)
                     {
-                      INITBVREFIT(new_p, len) = FIX(0);
+                      uptr extra = (Sbytevector_length(p)) - (len * ptr_bytes);
+                      if (extra == 0)
+                      {
+                        if ((len & 1) == 0)
+                        {
+                          INITBVREFIT(new_p, len) = FIX(0);
+                        }
+                      }
+                      else
+                      {
+                        INITBVREFIT(new_p, len) = INITBVREFIT(p, len);
+                        {
+                          uptr xlen = len + 1;
+                          if ((xlen & 1) == 0)
+                          {
+                            INITBVREFIT(new_p, xlen) = FIX(0);
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/mats/foreign.ms
+++ b/mats/foreign.ms
@@ -3709,6 +3709,18 @@
   (equal? #false (bytevector-reference*-ref (make-reference-bytevector (foreign-sizeof 'ptr)) 0))
   (equal? (void) (bytevector-reference-set! (make-reference-bytevector (foreign-sizeof 'ptr)) 0 #false))
 
+  ;; ensure that a GC correctly handles extra bytes that don't fit into a word:
+  (let ([make (lambda ()
+                (let ([bv (make-reference-bytevector (- (foreign-sizeof 'ptr) 1))]
+                      [bv2 (make-reference-bytevector (+ (foreign-sizeof 'ptr) 1))])
+                  (bytevector-u8-set! bv 0 72)
+                  (bytevector-u8-set! bv2 (foreign-sizeof 'ptr) 73)
+                  (list bv bv2)))])
+    (let ([pre (make)])
+      (collect-rendezvous)
+      (equal? pre
+              (make))))
+
   (not (reference-bytevector? #vu8(1 2 3)))
   (not (reference-bytevector? 7))
   (begin

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2726,6 +2726,15 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Bounds checking and collection for some reference-bytevector lengths (10.1.0)}
+
+When a reference bytevector's length is smaller than the machine's
+word size, then bounds checking was incorrect in
+\scheme{bytevector-reference-ref}, \scheme{bytevector-reference*-ref},
+and \scheme{bytevector-reference-set!}. In addition, the garbage
+collector would fail to preserve the last few bytes of a reference
+bytevector whose length is not a multiple of the word size.
+
 \subsection{\scheme{library-exports} for library that is not yet imported (10.0.0)}
 
 When visiting or loading a separately compiled library,


### PR DESCRIPTION
A reference bytevector is intended to be used as a multiple of a word size, but there's no explicit constraint, and so it should work with any length. When the length is not a multiple of the word size, then in a copying step, extra bytes at the end of the bytevector were missed.

The bug was exposed on a 32-bit platform by tests added as part of #821.
