### PR TITLE
configure: Fix flags handling for pb little-endian targets

### DIFF
--- a/configure
+++ b/configure
@@ -728,7 +728,7 @@ fi
 
 # Infer flags needed for threads:
 case "${flagsm}" in
-  t*le|t*gnu|t*fb|t*ob|t*nb)
+  t*le|*l|t*gnu|t*fb|t*ob|t*nb)
       threadFlags="-D_REENTRANT -pthread"
       threadLibs="-lpthread"
       ;;
@@ -840,7 +840,7 @@ fi
 # Add automatic linking flags, unless suppressed by --disable-auto-flags
 if [ "$addflags" = "yes" ] ; then
   case "${flagsm}" in
-    *le|*gnu)
+    *le|*l|*gnu)
         LDFLAGS="${LDFLAGS} -rdynamic"
         ;;
     *fb|*nb)
@@ -854,7 +854,7 @@ if [ "$addflags" = "yes" ] ; then
   esac
 
   case "${flagsm}" in
-    *le|*gnu)
+    *le|*l|*gnu)
         LIBS="${LIBS} -lm -ldl ${ncursesLib} -lrt"
         ;;
     *fb|*ob)
@@ -950,7 +950,7 @@ exeSuffix=
 
 # compile flags for c/Mf-unix and mats/Mf-unix
 case "${flagsmuni}" in
-    *le|*gnu)
+    *le|*l|*gnu)
         mdcflags="-fPIC -shared"
         ;;
     *fb|*ob)
@@ -984,7 +984,7 @@ case "${flagsmuni}" in
     i3le)
         mdldflags="-melf_i386"
         ;;
-    *le|*gnu)
+    *le|*l|*gnu)
         ;;
     i3nb)
         mdldflags="-m elf_i386"


### PR DESCRIPTION
While upgrading the Alpine Linux ChezScheme package to 0.10.0, I encountered a weird build failure on ppc64le (`--machine=tpb64l`) were it fails to link against ncurses:

```
gcc -Os -fstack-clash-protection -Wformat -Werror=format-security -o tpb64l/bin/tpb64l/scheme tpb64l/boot/tpb64l/main.o tpb64l/boot/tpb64l/libkernel.a -Wl,--as-needed,-O1,--sort-common -Wl,-z,pack-relative-relocs -L/lib -lz -llz4
/usr/lib/gcc/powerpc64le-alpine-linux-musl/13.2.1/../../../../powerpc64le-alpine-linux-musl/bin/ld: tpb64l/boot/tpb64l/libkernel.a(expeditor.o): in function `s_ee_carriage_return':
expeditor.c:(.text+0xcc): undefined reference to `tputs'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/13.2.1/../../../../powerpc64le-alpine-linux-musl/bin/ld: tpb64l/boot/tpb64l/libkernel.a(expeditor.o): in function `s_ee_bell':
expeditor.c:(.text+0x124): undefined reference to `tputs'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/13.2.1/../../../../powerpc64le-alpine-linux-musl/bin/ld: tpb64l/boot/tpb64l/libkernel.a(expeditor.o): in function `s_ee_scroll_reverse':
expeditor.c:(.text+0x198): undefined reference to `tputs'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/13.2.1/../../../../powerpc64le-alpine-linux-musl/bin/ld: expeditor.c:(.text+0x1b4): undefined reference to `tputs'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/13.2.1/../../../../powerpc64le-alpine-linux-musl/bin/ld: tpb64l/boot/tpb64l/libkernel.a(expeditor.o): in function `s_ee_clear_screen':
expeditor.c:(.text+0x200): undefined reference to `tputs'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/13.2.1/../../../../powerpc64le-alpine-linux-musl/bin/ld: tpb64l/boot/tpb64l/libkernel.a(expeditor.o):expeditor.c:(.text+0x258): more undefined references to `tputs' follow
/usr/lib/gcc/powerpc64le-alpine-linux-musl/13.2.1/../../../../powerpc64le-alpine-linux-musl/bin/ld: tpb64l/boot/tpb64l/libkernel.a(expeditor.o): in function `s_ee_init_term':
expeditor.c:(.text+0x1980): undefined reference to `setupterm'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/13.2.1/../../../../powerpc64le-alpine-linux-musl/bin/ld: tpb64l/boot/tpb64l/libkernel.a(expeditor.o):(.toc+0x0): undefined reference to `cur_term'
collect2: error: ld returned 1 exit status
```
Further debugging revealed that this is due to the fact that the `configure` script does not add `-lncurses` to the linker flags if the machine type does not end in `*le`. Since 0.10.0 introduced little-endian targets (such as `tpb64l`) which do not end in `*le` I guess the `configure` script needs to be adjusted accordingly?

This patch fixes the described build failure on Alpine Linux.