### PR TITLE
restore `(debug-level 2)` behavior, but reduce its guarantees

### DIFF
--- a/csug/system.stex
+++ b/csug/system.stex
@@ -2724,10 +2724,13 @@ It is used to tell the compiler how important the preservation of
 debugging information is, with 0 being least important and 3 being
 most important.
 The default value is 1.
-As of Version~9.0, it is used solely to determine whether an
-error-causing call encountered in nontail position is treated as
-if it were in tail position (thus causing the caller's frame not
-to appear in a stack backtrace); this occurs at debug levels below~2.
+
+As of Version~9.0, the value of \scheme{debug-level} is used by the
+system only to discourage optimizations that affect the continuation
+as revealed by the inspector. The reduced optimization is intended to
+produce more informative stack backtraces at the point when an
+exception is raised, and the reduction applies when the debug level is
+2 or 3.
 
 %----------------------------------------------------------------------------
 \entryheader

--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -206,6 +206,10 @@
   (cptypes-equivalent-expansion?
     '(lambda () (box (let ([x (error 'who "msg")]) (cons x (random)))))
     '(lambda () (error 'who "msg")))
+  (parameterize ([debug-level 2])
+    (cptypes-equivalent-expansion?
+     '(lambda () (box (let ([x (error 'who "msg")]) (cons x (random)))))
+     '(lambda () (#%$value (error 'who "msg")))))
   (cptypes-equivalent-expansion?
     '(lambda (x) (vector-set! (box 5) 0 0) 1)
     '(lambda (x) (vector-set! (box 5) 0 0) 2))
@@ -1565,6 +1569,25 @@
   (cptypes-equivalent-expansion?
    '(lambda (x) (error 'x "no") (add1 x))
    '(lambda (x) (error 'x "no")))
+  (parameterize ([debug-level 2])
+    (cptypes-equivalent-expansion?
+     '(lambda (x) (error 'x "no") (add1 x))
+     '(lambda (x) (error 'x "no") (void))))
+  (parameterize ([debug-level 2])
+    (not
+     (cptypes-equivalent-expansion?
+      '(lambda (x) (error 'x "no") (add1 x))
+      '(lambda (x) (error 'x "no")))))
+  (parameterize ([debug-level 2])
+    (not
+     (cptypes-equivalent-expansion?
+      '(lambda (x) (rationalize "no") (add1 x))
+      '(lambda (x) (rationalize "no")))))
+  (parameterize ([debug-level 2])
+    (not
+     (cptypes-equivalent-expansion?
+      '(lambda (x) (+ 1 "no") (add1 x))
+      '(lambda (x) (+ 1 "no")))))
   (cptypes-equivalent-expansion?
    '(lambda (f) (f (error 'x "no") f))
    '(lambda (f) (error 'x "no")))
@@ -1574,6 +1597,11 @@
   (cptypes-equivalent-expansion?
    '(lambda (x) (if (error 'x "no") (add1 x) (sub1 x)))
    '(lambda (x) (error 'x "no")))
+  (parameterize ([debug-level 2])
+    (not
+     (cptypes-equivalent-expansion?
+      '(lambda (x) (if (error 'x "no") (add1 x) (sub1 x)))
+      '(lambda (x) (error 'x "no")))))
   (cptypes-equivalent-expansion?
    '(lambda (x) (+ (error 'x "no") x))
    '(lambda (x) (error 'x "no")))
@@ -1595,9 +1623,30 @@
   (cptypes-equivalent-expansion?
    '(let ([x #f]) (case-lambda [() x] [(y) (set! x (error 'x "no"))]))
    '(let ([x #f]) (case-lambda [() x] [(y) (error 'x "no")])))
+  (parameterize ([debug-level 2])
+    (cptypes-equivalent-expansion?
+     '(let ([x #f]) (case-lambda [() x] [(y) (set! x (error 'x "no"))]))
+     '(let ([x #f]) (case-lambda [() x] [(y) (error 'x "no") (void)]))))
+  (parameterize ([debug-level 2])
+    (not
+     (cptypes-equivalent-expansion?
+      '(let ([x #f]) (case-lambda [() x] [(y) (set! x (error 'x "no"))]))
+      '(let ([x #f]) (case-lambda [() x] [(y) (error 'x "no")])))))
+
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (if x (x) (error 'x "no")))
+   '(lambda (x) (if x (void) (error 'x "no")) (x)))
+  (parameterize ([debug-level 2])
+    (not
+     (cptypes-equivalent-expansion?
+      '(lambda (x) (if x (x) (error 'x "no")))
+      '(lambda (x) (if x (void) (error 'x "no")) (x)))))
 
   (cptypes-equivalent-expansion?
    '(lambda (x) (+ (#%$call-setting-continuation-attachment 'a (lambda () (error 'x "no ~s" a))) 1))
+   '(lambda (x) (#%$value (#%$call-setting-continuation-attachment 'a (lambda () (error 'x "no ~s" a))))))
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (if (#%$call-setting-continuation-attachment 'a (lambda () (error 'x "no ~s" a))) 1))
    '(lambda (x) (#%$value (#%$call-setting-continuation-attachment 'a (lambda () (error 'x "no ~s" a))))))
   (not
    (cptypes-equivalent-expansion?
@@ -1617,6 +1666,10 @@
    (cptypes-equivalent-expansion?
     '(lambda (x) (+ (#%$call-consuming-continuation-attachment 'a (lambda (a) (error 'x "no ~s" a))) 1))
     '(lambda (x) (#%$call-consuming-continuation-attachment 'a (lambda (a) (error 'x "no ~s" a))))))
+  (parameterize ([optimize-level 2])
+    (cptypes-equivalent-expansion?
+     '(lambda (p) (car p) (vector-ref p 0) (oops))
+     '(lambda (p) (car p) (vector-ref p 0))))
 )
 
 (mat cptypes-boxes

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2726,6 +2726,28 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Optimization and \scheme{debug-level} $\geq$ 2 (10.1.0)}
+
+Setting \scheme{debug-level} to 2 or higher did not prevent an
+error-causing call in nontail position to stay nontail when
+\scheme{enable-type-recovery} is \scheme{#t} (the default value).
+Furthermore, a tail error-causing call could be made non-tail by
+optimizations that aim to expose non-error paths. Those behaviors
+moved further from the documented behavior of \scheme{debug-level}
+than Chez Scheme version 9.x---but version 9.x was also not consistent
+with the documentation due to cp0 conversions such as replacing
+\scheme{(let ([x \var{expr}]) x)} with just \var{expr}.
+
+Instead of guaranteeing any specific behavior, a \scheme{debug-level}
+value of 2 or higher is now defined to merely \emph{discourage}
+optimizations that affect the continuation structure as revealed by the
+inspector, where the goal is to produce more informative stack
+backtraces at the point where an exception is raised. The
+implementation produces results that are more in line with Chez Scheme
+9.x. Meanwhile, continuation marks support predictable and
+well-defined reflection on continuations in a way that is compatible
+with compiler optimizations.
+
 \subsection{Random number generation for large exact integers (10.1.0)}
 
 Given an exact integer greater than 4294967087,


### PR DESCRIPTION
When `debug-level` is 2 or more, optimization is supposed to refrain from moving a call to an error function into tail position of the enclosing function. (That's a stronger guarantee than the usual one of not moving an expression into tail position if there's potentially a way to detect the movement through continuation marks.) An earlier commit 6a73b9edc7 strengthened movement of error calls in a way that did not preserve this `(debug-level 2)` constraint, so this commit primarily adjusts those changes. Also, the earlier commit 19af32e2d allowed the compiler to move an error call out of tail position, and that transformation is now suppressed when `debug-level` is 2 or more.

These changes are meant to help with debugging, but they're not enough to implement the previously specified behavior of `debug-level`. It turns out that Chez Scheme v9.x didn't implement the specified behavior, either, because it would convert `(let ([x (error ...)]) x)` to just `(error ...)`, for example. The old specification seems too strong, and so part of the revision here is to change the specificaton to be encouraging a particular interaction of errors and continuaton-inspection results, but not guaranteeing it. Meanwhile, when well-defined reflection on continuations is needed, continuation marks provide that functionality.