### PR TITLE
Allow building against cosmopolitan libc

### DIFF
--- a/c/expeditor.c
+++ b/c/expeditor.c
@@ -677,7 +677,7 @@ static void s_ee_set_color(int color_id, IBOOL background) {
 # include <unistd.h>
 # include <time.h>
 #endif
-#if !defined(__GLIBC__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__linux__) && !defined(__EMSCRIPTEN__) && !defined(NO_USELOCALE)
+#if !defined(__GLIBC__) && !defined(__COSMOPOLITAN__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__linux__) && !defined(__EMSCRIPTEN__) && !defined(NO_USELOCALE)
 # include <xlocale.h>
 #endif
 

--- a/c/prim5.c
+++ b/c/prim5.c
@@ -749,8 +749,8 @@ static ptr s_system(const char *s) {
 #ifdef WIN32
   return Sinteger(status);
 #else
-  if WIFEXITED(status) return Sinteger(WEXITSTATUS(status));
-  if WIFSIGNALED(status) return Sinteger(-WTERMSIG(status));
+  if (WIFEXITED(status)) return Sinteger(WEXITSTATUS(status));
+  if (WIFSIGNALED(status)) return Sinteger(-WTERMSIG(status));
   S_error("system", "cannot determine subprocess exit status");
   return 0 /* not reached */;
 #endif /* WIN32 */

--- a/c/version.h
+++ b/c/version.h
@@ -86,9 +86,13 @@ FORCEINLINE void store_unaligned_uptr(uptr *addr, uptr val) {
 /*****************************************/
 /* Operating systems                     */
 
-#if defined(__linux__) || defined(__GNU__) /* Hurd */
+#if defined(__linux__) || defined(__COSMOPOLITAN__) || defined(__GNU__) /* Hurd */
 #define NOBLOCK O_NONBLOCK
-#define LOAD_SHARED_OBJECT
+/* cosmo dylib support is experimental, disable when using cosmo libc
+   https://github.com/jart/cosmopolitan/blob/3.3.10/libc/dlopen/dlopen.c#L801 */
+#ifndef __COSMOPOLITAN__
+# define LOAD_SHARED_OBJECT
+#endif
 #define USE_MMAP
 #define MMAP_HEAP
 #define IEEE_DOUBLE


### PR DESCRIPTION
~~Accompanies the same changes in the racket repo https://github.com/racket/racket/pull/5004~~

This was originally a patch just to get racket to build on cosmopolitan libc, which unfortunately would require more heavy lifting in the main distribution to work. I took what I had there and made it so that at least Chez will work more or less as advertised, a single binary that can hit many common operating systems on amd64 and aarch64, with no installation required.

See the cosmopolitan project page for more information https://github.com/jart/cosmopolitan 