### PR TITLE
small error-message consistency improvement for bit indices

### DIFF
--- a/mats/patch-compile-0-t-f-f
+++ b/mats/patch-compile-0-t-f-f
@@ -1320,7 +1320,7 @@
 ! 5_3.mo:Expected error in mat logbit?: "incorrect argument count in call (logbit?)".
 ! 5_3.mo:Expected error in mat logbit?: "incorrect argument count in call (logbit? 1)".
 ! 5_3.mo:Expected error in mat logbit?: "incorrect argument count in call (logbit? 1 2 3)".
-  5_3.mo:Expected error in mat logbit?: "logbit?: 3.4 is not an exact integer".
+  5_3.mo:Expected error in mat logbit?: "logbit?: invalid bit index 3.4".
   5_3.mo:Expected error in mat logbit?: "logbit?: "3" is not an exact integer".
   5_3.mo:Expected error in mat logbit?: "logbit?: invalid bit index -1".
 ! 5_3.mo:Expected error in mat bitwise-bit-set?: "incorrect argument count in call (bitwise-bit-set?)".
@@ -1328,19 +1328,19 @@
 ! 5_3.mo:Expected error in mat bitwise-bit-set?: "incorrect argument count in call (bitwise-bit-set? 3 4 5)".
   5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: 3.0 is not an exact integer".
   5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: "hi" is not an exact integer".
-  5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: 4/3 is not an exact integer".
-  5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: a is not an exact integer".
+  5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: invalid bit index 4/3".
+  5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: invalid bit index a".
   5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: invalid bit index -3".
 ! 5_3.mo:Expected error in mat logbit0: "incorrect argument count in call (logbit0)".
 ! 5_3.mo:Expected error in mat logbit0: "incorrect argument count in call (logbit0 1)".
 ! 5_3.mo:Expected error in mat logbit0: "incorrect argument count in call (logbit0 1 2 3)".
-  5_3.mo:Expected error in mat logbit0: "logbit0: 3.4 is not an exact integer".
+  5_3.mo:Expected error in mat logbit0: "logbit0: invalid bit index 3.4".
   5_3.mo:Expected error in mat logbit0: "logbit0: "3" is not an exact integer".
   5_3.mo:Expected error in mat logbit0: "logbit0: invalid bit index -1".
 ! 5_3.mo:Expected error in mat logbit1: "incorrect argument count in call (logbit1)".
 ! 5_3.mo:Expected error in mat logbit1: "incorrect argument count in call (logbit1 1)".
 ! 5_3.mo:Expected error in mat logbit1: "incorrect argument count in call (logbit1 1 2 3)".
-  5_3.mo:Expected error in mat logbit1: "logbit1: 3.4 is not an exact integer".
+  5_3.mo:Expected error in mat logbit1: "logbit1: invalid bit index 3.4".
   5_3.mo:Expected error in mat logbit1: "logbit1: "3" is not an exact integer".
   5_3.mo:Expected error in mat logbit1: "logbit1: invalid bit index -1".
 ! 5_3.mo:Expected error in mat bitwise-copy-bit: "incorrect argument count in call (bitwise-copy-bit)".
@@ -1348,8 +1348,8 @@
 ! 5_3.mo:Expected error in mat bitwise-copy-bit: "incorrect argument count in call (bitwise-copy-bit 1 2)".
 ! 5_3.mo:Expected error in mat bitwise-copy-bit: "incorrect argument count in call (bitwise-copy-bit 1 2 0 4)".
   5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: 3.4 is not an exact integer".
-  5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: a is not a nonnegative exact integer".
-  5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: -2 is not a nonnegative exact integer".
+  5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: invalid bit index a".
+  5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: invalid bit index -2".
   5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: bit argument 2 is not 0 or 1".
   5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: bit argument -1 is not 0 or 1".
   5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: bit argument a is not 0 or 1".

--- a/mats/root-experr-compile-0-f-f-f
+++ b/mats/root-experr-compile-0-f-f-f
@@ -1772,7 +1772,7 @@ primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input
 5_3.mo:Expected error in mat logbit?: "incorrect argument count in call (logbit?)".
 5_3.mo:Expected error in mat logbit?: "incorrect argument count in call (logbit? 1)".
 5_3.mo:Expected error in mat logbit?: "incorrect argument count in call (logbit? 1 2 3)".
-5_3.mo:Expected error in mat logbit?: "logbit?: 3.4 is not an exact integer".
+5_3.mo:Expected error in mat logbit?: "logbit?: invalid bit index 3.4".
 5_3.mo:Expected error in mat logbit?: "logbit?: "3" is not an exact integer".
 5_3.mo:Expected error in mat logbit?: "logbit?: invalid bit index -1".
 5_3.mo:Expected error in mat bitwise-bit-set?: "incorrect argument count in call (bitwise-bit-set?)".
@@ -1780,19 +1780,19 @@ primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input
 5_3.mo:Expected error in mat bitwise-bit-set?: "incorrect argument count in call (bitwise-bit-set? 3 4 5)".
 5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: 3.0 is not an exact integer".
 5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: "hi" is not an exact integer".
-5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: 4/3 is not an exact integer".
-5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: a is not an exact integer".
+5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: invalid bit index 4/3".
+5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: invalid bit index a".
 5_3.mo:Expected error in mat bitwise-bit-set?: "bitwise-bit-set?: invalid bit index -3".
 5_3.mo:Expected error in mat logbit0: "incorrect argument count in call (logbit0)".
 5_3.mo:Expected error in mat logbit0: "incorrect argument count in call (logbit0 1)".
 5_3.mo:Expected error in mat logbit0: "incorrect argument count in call (logbit0 1 2 3)".
-5_3.mo:Expected error in mat logbit0: "logbit0: 3.4 is not an exact integer".
+5_3.mo:Expected error in mat logbit0: "logbit0: invalid bit index 3.4".
 5_3.mo:Expected error in mat logbit0: "logbit0: "3" is not an exact integer".
 5_3.mo:Expected error in mat logbit0: "logbit0: invalid bit index -1".
 5_3.mo:Expected error in mat logbit1: "incorrect argument count in call (logbit1)".
 5_3.mo:Expected error in mat logbit1: "incorrect argument count in call (logbit1 1)".
 5_3.mo:Expected error in mat logbit1: "incorrect argument count in call (logbit1 1 2 3)".
-5_3.mo:Expected error in mat logbit1: "logbit1: 3.4 is not an exact integer".
+5_3.mo:Expected error in mat logbit1: "logbit1: invalid bit index 3.4".
 5_3.mo:Expected error in mat logbit1: "logbit1: "3" is not an exact integer".
 5_3.mo:Expected error in mat logbit1: "logbit1: invalid bit index -1".
 5_3.mo:Expected error in mat bitwise-copy-bit: "incorrect argument count in call (bitwise-copy-bit)".
@@ -1800,8 +1800,8 @@ primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input
 5_3.mo:Expected error in mat bitwise-copy-bit: "incorrect argument count in call (bitwise-copy-bit 1 2)".
 5_3.mo:Expected error in mat bitwise-copy-bit: "incorrect argument count in call (bitwise-copy-bit 1 2 0 4)".
 5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: 3.4 is not an exact integer".
-5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: a is not a nonnegative exact integer".
-5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: -2 is not a nonnegative exact integer".
+5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: invalid bit index a".
+5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: invalid bit index -2".
 5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: bit argument 2 is not 0 or 1".
 5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: bit argument -1 is not 0 or 1".
 5_3.mo:Expected error in mat bitwise-copy-bit: "bitwise-copy-bit: bit argument a is not 0 or 1".

--- a/s/5_3.ss
+++ b/s/5_3.ss
@@ -2976,7 +2976,7 @@
       ($oops who "~s is not an exact integer" x))
     (unless (or (and (fixnum? y) (fxnonnegative? y))
                 (and (bignum? y) ($bigpositive? y)))
-      ($oops who "~s is not a nonnegative exact integer" y))
+      ($oops who "invalid bit index ~s" y))
     (cond
       [(eq? b 0) (logbit0 y x)]
       [(eq? b 1) (logbit1 y x)]

--- a/s/library.ss
+++ b/s/library.ss
@@ -865,6 +865,9 @@
   (define exactintoops2
     (lambda (who x y)
       (exactintoops1 who (if (or (fixnum? x) (bignum? x)) y x))))
+  (define invalidindexoops
+    (lambda (who k)
+      ($oops who "invalid bit index ~s" k)))
 
   (define-library-entry (logand x y)
     (if (if (fixnum? x)
@@ -939,27 +942,27 @@
          (cond
            [(fixnum? k)
             (if (fx< k 0)
-                ($oops who "invalid bit index ~s" k)
+                (invalidindexoops who k)
                ; this case left to us by cp1in logbit? handler
                 (fx< n 0))]
            [(bignum? k)
             (if (< k 0)
-                ($oops who "invalid bit index ~s" k)
+                (invalidindexoops who k)
                ; this case left to us by cp1in logbit? handler
                 (fx< n 0))]
-           [else (exactintoops1 who k)])]
+           [else (invalidindexoops who k)])]
         [(bignum? n)
          (cond
            [(fixnum? k)
             (if (fx< k 0)
-                ($oops who "invalid bit index ~s" k)
+                (invalidindexoops who k)
                 ($logbit? k n))]
            [(bignum? k)
             (if (< k 0)
-                ($oops who "invalid bit index ~s" k)
+                (invalidindexoops who k)
                ; $logbit? requires k to be a fixnum
                 (fxlogtest (ash n (- k)) 1))]
-           [else (exactintoops1 who k)])]
+           [else (invalidindexoops who k)])]
         [else (exactintoops1 who n)]))
     (define-library-entry (logbit? k n) (do-logbit? 'logbit? k n))
     (define-library-entry (bitwise-bit-set? n k) (do-logbit? 'bitwise-bit-set? k n)))
@@ -969,14 +972,14 @@
         (cond
           [(fixnum? k)
            (if (fx< k 0)
-               ($oops 'logbit0 "invalid bit index ~s" k)
+               (invalidindexoops 'logbit0 k)
                ($logbit0 k n))]
           [(bignum? k)
            (if (< k 0)
-               ($oops 'logbit0 "invalid bit index ~s" k)
+               (invalidindexoops 'logbit0 k)
               ; $logbit0 requires k to be a fixnum
                ($logand n ($lognot (ash 1 k))))]
-          [else (exactintoops1 'logbit0 k)])
+          [else (invalidindexoops 'logbit0 k)])
         (exactintoops1 'logbit0 n)))
 
   (define-library-entry (logbit1 k n)
@@ -984,14 +987,14 @@
         (cond
           [(fixnum? k)
            (if (fx< k 0)
-               ($oops 'logbit1 "invalid bit index ~s" k)
+               (invalidindexoops 'logbit1 k)
                ($logbit1 k n))]
           [(bignum? k)
            (if (< k 0)
-               ($oops 'logbit1 "invalid bit index ~s" k)
+               (invalidindexoops 'logbit1 k)
               ; $logbit1 requires k to be a fixnum
                ($logor n (ash 1 k)))]
-          [else (exactintoops1 'logbit1 k)])
+          [else (invalidindexoops 'logbit1 k)])
         (exactintoops1 'logbit1 n)))
 
   (define-library-entry (logtest x y)


### PR DESCRIPTION
Functions like `vector-ref`, `string-ref`, `substring`, and `bitwise-bit-field` report a non-exact-integer index as a "bad index" error. But `bitwise-bit-set?`, `logbit?`, `logbit0`, and `logbit1` said "not an exact integer", instead, while reporting "bad index" for a negative exact integer; `bitwise-copy-bit` said "not a nonnegative exact integer". This commit changes the error message for those last five functions to always say "bad index".

Fixnum variants of the operations can still say "not a fixnum" or "invalid bit index", depending on whether the index is a negative fixnum. That seems justified on the grounds that fixnum operations add an extra constraint on their arguments. Another possible direction is to change the error messages to consistently "not a nonnegative exact integer" and "not a nonnegative fixnum", since (unlike other index cases), the index validity is independent of the indexed value. After trying out both, sticking with "invalid bit index" seems clearest and the most in the spirit of the current error messages.