### PR TITLE
fix missing `wcwidth` declaration on GNU Hurd

### DIFF
--- a/c/expeditor.c
+++ b/c/expeditor.c
@@ -681,7 +681,7 @@ static void s_ee_set_color(int color_id, IBOOL background) {
 # include <xlocale.h>
 #endif
 
-#if defined(__linux__) && !defined(_XOPEN_SOURCE)
+#if (defined(__gnu_hurd__) || defined(__linux__)) && !defined(_XOPEN_SOURCE)
 extern int wcwidth(wchar_t);
 #endif
 


### PR DESCRIPTION
Building on Debian GNU/Hurd i386 fails because of an implicit declaration of `wcwidth`. This commit makes GNU/Hurd use the same declaration that is used on GNU/Linux.