### PR TITLE
fix bytecode endianness handling on s390x, m68k and hppa

### DIFF
--- a/c/version.h
+++ b/c/version.h
@@ -44,7 +44,7 @@
 /*****************************************/
 /* Architectures                         */
 
-#if defined(__powerpc__) || defined(__POWERPC__) || defined(__sparc__)
+#if defined(__powerpc__) || defined(__POWERPC__) || defined(__sparc__) || defined(__s390x__) || defined(__m68k__) || defined(__hppa__)
 # if !(defined(__LITTLE_ENDIAN__) || defined(_LITTLE_ENDIAN))
 #  define PORTABLE_BYTECODE_BIGENDIAN
 #  define BIG_ENDIAN_IEEE_DOUBLE


### PR DESCRIPTION
Building on the s390x, m68k and hppa architectures using bytecode does not work. The build fails with `illegal pb instruction` or `invalid memory reference` while running bytecode. This commit fixes that by amending an architecture list that lists big endian architectures.