### PR TITLE
fix the whatis lines in scheme.1.in

### DIFF
--- a/scheme.1.in
+++ b/scheme.1.in
@@ -5,9 +5,9 @@
 .ds ]W 
 .TH SCHEME 1 "Chez Scheme Version 10.0.0 February 2024"
 .SH NAME
-\fIChez Scheme\fP
+{InstallSchemeName} - Chez Scheme
 .br
-\fIPetite Chez Scheme\fP
+{InstallPetiteName} - Petite Chez Scheme
 .SH SYNOPSIS
 \fB{InstallSchemeName}\fP [ \fIoptions\fP ] \fIfile\fP ...
 .br


### PR DESCRIPTION
Manpages have a standard format for the line that is used by the `whatis` command and lintian was complaining that Chez's pages did not use the right format. This commit fixes those lines.