### PR TITLE
improve support for lists in cptypes

### DIFF
--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -234,18 +234,6 @@
   (cptypes/once-equivalent-expansion?
     '(lambda (x) (when (fixnum? x) (zero? x) 7))
     '(lambda (x) (when (fixnum? x) 7)))
-  (cptypes-equivalent-expansion?
-    '(lambda (x f) (when (list-assuming-immutable? x) (f x) (list-assuming-immutable? x)))
-    '(lambda (x f) (when (list-assuming-immutable? x) (f x) #t)))
-  (not (cptypes-equivalent-expansion?
-         '(lambda (x f) (when (list? x) (f x) (unless (list? x) 1)))
-         '(lambda (x f) (when (list? x) (f x) (unless (list? x) 2)))))
-  (cptypes-equivalent-expansion?
-    '(lambda (f) (define x '(1 2 3)) (f x) (list-assuming-immutable? x))
-    '(lambda (f) (define x '(1 2 3)) (f x) #t))
-  (cptypes-equivalent-expansion?
-    '(lambda () (define x '(1 2 3)) (pair? x))
-    '(lambda () (define x '(1 2 3)) #t))
 )
 
 (mat cptypes-type-if
@@ -666,7 +654,6 @@
   (test-chain* '(record? #3%$record?))
   (test-chain* '((lambda (x) (eq? x car)) procedure?))
   (test-chain* '(record-type-descriptor? #3%$record?))
-  (test-chain* '(null? list-assuming-immutable? list? (lambda (x) (or (null? x) (pair? x)))))
   (test-disjoint '(pair? box? #3%$record? number?
                    vector? string? bytevector? fxvector? symbol?
                    char? boolean? null? (lambda (x) (eq? x (void)))
@@ -680,11 +667,6 @@
   (test-disjoint '(integer? ratnum?))
   (test-disjoint '((lambda (x) (eq? x 'banana)) (lambda (x) (eq? x 'apple))))
   (test-disjoint* '(list? record? vector?))
-  (not (test-disjoint* '(list? null?)))
-  (not (test-disjoint* '(list? pair?)))
-  (not (test-disjoint* '(list-assuming-immutable? null?)))
-  (not (test-disjoint* '(list-assuming-immutable? pair?)))
-  (not (test-disjoint* '(list-assuming-immutable? list?)))
 )
 
 ; use a gensym to make expansions equivalent
@@ -812,18 +794,56 @@
 )
 
 (mat cptypes-lists
+  (test-chain '(null? list-assuming-immutable? (lambda (x) (or (null? x) (pair? x)))))
+  (test-chain* '(null? list? (lambda (x) (or (null? x) (pair? x)))))
   (cptypes-equivalent-expansion?
-    '(lambda (x) (when (list-assuming-immutable? x) (list? (cdr x))))
+    '(lambda (x f) (when (list-assuming-immutable? x) (f) (list-assuming-immutable? x)))
+    '(lambda (x f) (when (list-assuming-immutable? x) (f) #t)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x f) (unless (list-assuming-immutable? x) (f) (list-assuming-immutable? x)))
+    '(lambda (x f) (unless (list-assuming-immutable? x) (f) #f)))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x f) (when (list? x) (f) (list? x)))
+         '(lambda (x f) (when (list? x) (f) #t))))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x f) (unless (list? x) (f) (list? x)))
+         '(lambda (x f) (unless (list? x) (f) #f))))
+  (test-disjoint '(null? pair?))
+  (not (test-disjoint* '(list? null?)))
+  (not (test-disjoint* '(list? pair?)))
+  (not (test-disjoint* '(list-assuming-immutable? null?)))
+  (not (test-disjoint* '(list-assuming-immutable? pair?)))
+  (not (test-disjoint* '(list-assuming-immutable? list?)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (list-assuming-immutable? x) (list-assuming-immutable? (cdr x))))
     '(lambda (x) (when (list-assuming-immutable? x) (cdr x) #t)))
   (cptypes-equivalent-expansion?
-    '(lambda (x) (when (and (list-assuming-immutable? x) (pair? x)) (list? (cdr x))))
+    '(lambda (x) (when (and (list-assuming-immutable? x) (pair? x)) (list-assuming-immutable? (cdr x))))
     '(lambda (x) (when (and (list-assuming-immutable? x) (pair? x)) #t)))
   (cptypes-equivalent-expansion?
-    '(lambda (x) (when (list-assuming-immutable? x) (list? (cdr (error 'e "")))))
+    '(lambda (x) (when (list-assuming-immutable? x) (list-assuming-immutable? (cdr (error 'e "")))))
     '(lambda (x) (when (list-assuming-immutable? x) (error 'e ""))))
   (cptypes-equivalent-expansion?
-    '(lambda (x) (when (vector? x) (list? (#2%cdr x)) 1))
+    '(lambda (x) (when (vector? x) (list-assuming-immutable? (#2%cdr x)) 1))
     '(lambda (x) (when (vector? x) (#2%cdr x))))
+  (cptypes-equivalent-expansion?
+    '(lambda (f) (define x '(1 2 3)) (f x) (list-assuming-immutable? x))
+    '(lambda (f) (define x '(1 2 3)) (f x) #t))
+  (cptypes-equivalent-expansion?
+    '(lambda () (define x '(1 2 3)) (pair? x))
+    '(lambda () (define x '(1 2 3)) #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (vector? x) (#2%list->vector x) 1))
+    '(lambda (x) (when (vector? x) (#2%list->vector x) 2)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (unless (or (null? x) (pair? x)) (#2%list->vector x) 1))
+    '(lambda (x) (unless (or (null? x) (pair? x)) (#2%list->vector x) 2)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x f) (#2%list->vector x) (f) (or (null? x) (pair? x)))
+    '(lambda (x f) (#2%list->vector x) (f) #t))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x f) (list->vector x) (f) (list? x))
+         '(lambda (x f) (list->vector x) (f) #t)))
 )
 
 (mat cptypes-unsafe

--- a/s/cptypes.ss
+++ b/s/cptypes.ss
@@ -572,8 +572,8 @@ Notes:
     (cond
       [(#3%$record? d) '$record] ;check first to avoid double representation of rtd
       [(okay-to-copy? d) ir]
-      [(list? d) '$list-pair] ; quoted list should not be modified.
-      [(pair? d) 'pair]
+      [(list? d) list-pair-pred] ; quoted list should not be modified.
+      [(pair? d) pair-pred]
       [(box? d) box-pred]
       [(vector? d) vector*-pred]
       [(string? d) string*-pred]
@@ -1069,12 +1069,12 @@ Notes:
 
       (define-specialize 2 list
         [() (values null-rec null-rec ntypes #f #f)] ; should have been reduced by cp0
-        [e* (values `(call ,preinfo ,pr ,e* ...) 'pair ntypes #f #f)])
+        [e* (values `(call ,preinfo ,pr ,e* ...) pair-pred ntypes #f #f)])
 
       (define-specialize 2 cdr
         [(v) (values `(call ,preinfo ,pr ,v)
                      (cond
-                       [(predicate-implies? (predicate-intersect (get-type v) 'pair) '$list-pair)
+                       [(predicate-implies? (predicate-intersect (get-type v) pair-pred) list-pair-pred)
                         $list-pred]
                        [else
                         ptr-pred])
@@ -1515,7 +1515,7 @@ Notes:
     (define (cut-r* r* n)
       (let loop ([i n] [r* r*])
         (if (fx= i 0)
-            (list (if (null? r*) null-rec 'pair))
+            (list (if (null? r*) null-rec pair-pred))
             (cons (car r*) (loop (fx- i 1) (cdr r*))))))
     (let*-values ([(ntypes e* r* t* t-t* f-t*)
                    (map-Expr/delayed e* oldtypes plxc)])
@@ -1909,7 +1909,7 @@ Notes:
       [(immutable-list (,[e* 'value types plxc -> e* r* t* t-t* f-t*] ...)
                        ,[e 'value types plxc -> e ret types t-types f-types])
        (values `(immutable-list (,e*  ...) ,e)
-               (if (null? e*) null-rec '$list-pair) types #f #f)]
+               (if (null? e*) null-rec $list-pred) types #f #f)]
       [(immutable-vector (,[e* 'value types plxc -> e* r* t* t-t* f-t*] ...)
                          ,[e 'value types plxc -> e ret types t-types f-types])
        (values `(immutable-vector (,e*  ...) ,e)


### PR DESCRIPTION
Move `list` form the normalptr slot to the multiplet slot. In particular, this allows the reduction of

```
  (lambda (x f)
    (unless (list-assuming-immutable? x)
      (f)
      (list-assuming-immutable? x)))
```

`pair`s are split in `list-pairs` and `nonlist-pairs`. A `pair` may go from one classification to the other, so the internal representations of the `list?` predicate use both of them or neither.