### PR TITLE
fix foreign test for i3nt

### DIFF
--- a/mats/build.zuo
+++ b/mats/build.zuo
@@ -363,9 +363,6 @@
                                                  "cc")))
                         (cons "FTYPE_CFLAGS"
                               (build-shell (or (lookup 'CPPFLAGS) "")
-                                           (if (eq? 'windows (system-type))
-                                               "-DWIN32"
-                                               "")
                                            (or (lookup 'mdinclude) "")
                                            (or (lookup 'CFLAGS) "")
                                            (or (lookup 'mdcflags) "")))

--- a/mats/foreign3.c
+++ b/mats/foreign3.c
@@ -17,7 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <string.h>
 #endif
 
@@ -178,7 +178,7 @@ EXPORT char Srvtest_char(ptr code, ptr x1) {
     return (*((char (*)(ptr))Sforeign_callable_entry_point(code)))(x1);
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 EXPORT int __stdcall sum_stdcall(int a, int b) {
     return a + b;
 }
@@ -208,7 +208,7 @@ EXPORT com_instance_t *get_com_instance(void) {
   com_instance.data = -31;
   return &com_instance;
 }
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 /* foreign_callable example adapted from foreign.stex */
 typedef void (*CB)(char);

--- a/mats/ftype.h
+++ b/mats/ftype.h
@@ -31,7 +31,7 @@ typedef unsigned long long uint64_t;
 
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #define EXPORT extern __declspec (dllexport)
 #else
 #define EXPORT extern


### PR DESCRIPTION
For some build environments, `_WIN32` is needed (as in other "foreign*.c" files) instead of `WIN32` without the leading underscore.