### PR TITLE
makefiles/boot.zuo: remove broken main submodule

### DIFF
--- a/makefiles/boot.zuo
+++ b/makefiles/boot.zuo
@@ -6,19 +6,6 @@
          cross-build-boot
          clean-links)
 
-(module+ main
-  (command-line
-   :args (scheme machine)
-   (lambda (accum)
-     (define vars (hash))
-     (cross-build-boot #f (hash) '("all")
-                       machine
-                       (if (car (split-path scheme))
-                           scheme
-                           (find-executable-path scheme))
-                       #f
-                       (make-at-dir "xc") vars vars #f))))
-
 (define boot-file-names
   '(;; the boot files proper
     "petite.boot" "scheme.boot"


### PR DESCRIPTION
The main submodule hasn't worked since at least commit 10d59cc, and documented build modes have been added in the mean time that support its former uses.

Closes https://github.com/cisco/ChezScheme/issues/810

----

(The change to Guix to stop using `boot.zuo` directly has been live since April.)