### PR TITLE
fix incorrect wrapping in quote-syntax

### DIFF
--- a/mats/8.ms
+++ b/mats/8.ms
@@ -12031,6 +12031,12 @@
    (equal? (syntax->datum (quote-syntax (a b c))) '(a b c))
    (equal? (syntax->datum (quote-syntax ...)) '...)
    (identifier? (quote-syntax if))
+   (let* ([sfd (make-source-file-descriptor "src" (open-bytevector-input-port '#vu8()))]
+          [src (make-source-object sfd 1 2)])
+     (identifier? (eval
+                   (make-annotation `(quote-syntax ,(make-annotation 'if src 'if))
+                                    src
+                                    '(quote-syntax if)))))
    (bound-identifier=? (quote-syntax ...) (syntax (... ...)))
    (free-identifier=? (quote-syntax ...) (syntax (... ...)))
    (equal? (with-syntax ([x #'y]) (syntax->datum (quote-syntax x))) 'x)

--- a/mats/8.ms
+++ b/mats/8.ms
@@ -12030,6 +12030,7 @@
 (mat quote-syntax
    (equal? (syntax->datum (quote-syntax (a b c))) '(a b c))
    (equal? (syntax->datum (quote-syntax ...)) '...)
+   (identifier? (quote-syntax if))
    (bound-identifier=? (quote-syntax ...) (syntax (... ...)))
    (free-identifier=? (quote-syntax ...) (syntax (... ...)))
    (equal? (with-syntax ([x #'y]) (syntax->datum (quote-syntax x))) 'x)

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2728,9 +2728,8 @@ in fasl files does not generally make sense.
 
 \subsection{\scheme{quote-syntax} incorrectly applies wrap (10.1.0)}
 
-A bug in \scheme{quote-syntax} that caused \scheme{(identifier?
-(quote-syntax \var{symbol}))} to report the wrong result has been
-fixed.
+A bug in \scheme{quote-syntax} that caused \scheme{(identifier? (quote-syntax \var{symbol}))}
+to report the wrong result has been fixed.
 
 \subsection{Case-insensitive ``V'' format directive (10.1.0)}
 

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2726,6 +2726,12 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{\scheme{quote-syntax} incorrectly applies wrap (10.1.0)}
+
+A bug in \scheme{quote-syntax} that caused \scheme{(identifier?
+(quote-syntax \var{symbol}))} to report the wrong result has been
+fixed.
+
 \subsection{Case-insensitive ``V'' format directive (10.1.0)}
 
 The ``V'' format directive is now recognized in uppercase as well as lowercase.

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -6027,10 +6027,11 @@
          (_ (syntax-error (source-wrap e w ae))))))
 
 (global-extend 'core 'quote-syntax
-   (lambda (e r w ae)
+  (lambda (e r w ae)
+    (let ([e (source-wrap e w ae)])
       (syntax-case e ()
-         ((_ e) (build-data no-source (source-wrap (syntax e) w ae)))
-         (_ (syntax-error (source-wrap e w ae))))))
+         ((_ e) (build-data no-source (syntax e)))
+         (_ (syntax-error e))))))
 
 (global-extend 'core 'syntax
   (let ()


### PR DESCRIPTION
This fixes issue #861.

The mistake was an incorrect application of a wrap.