### PR TITLE
workaround Clang v15 AArch64 miscompile that affects parallel collection

### DIFF
--- a/c/gc.c
+++ b/c/gc.c
@@ -383,6 +383,11 @@ static ptr sweep_from;
 
 static int in_parallel_sweepers = 0;
 
+#ifdef USE_PAR_SWEEPERS_WORKAROUND
+FORCEINLINE int get_in_parallel_sweepers() { return in_parallel_sweepers; }
+# define PAR_SWEEPERS_WORKAROUND() int in_parallel_sweepers = get_in_parallel_sweepers()
+#endif
+
 #define HAS_SWEEPER_WRT(t_tc, tc) 1
 
 # define GC_MUTEX_ACQUIRE() alloc_mutex_acquire()
@@ -460,6 +465,10 @@ static void sweep_dirty(thread_gc *tgc);
 # define PARALLEL_UNUSED    /* empty */
 # define NO_PARALLEL_UNUSED UNUSED
 
+#endif
+
+#ifndef PAR_SWEEPERS_WORKAROUND
+# define PAR_SWEEPERS_WORKAROUND() do { } while (0)
 #endif
 
 #define SWEEP_NO_CHANGE        0

--- a/c/version.h
+++ b/c/version.h
@@ -61,6 +61,10 @@
 # define BIG_ENDIAN_IEEE_DOUBLE
 #endif
 
+#if defined(__arm64__) && defined(__clang__) && (__clang_major__ == 15)
+# define USE_PAR_SWEEPERS_WORKAROUND
+#endif
+
 #ifdef PORTABLE_BYTECODE
 # undef FLUSHCACHE
 # ifdef PORTABLE_BYTECODE_BIGENDIAN

--- a/mats/thread.ms
+++ b/mats/thread.ms
@@ -1637,6 +1637,59 @@
       ok?))
 )
 
+(mat parallel-gc-regression
+  (equal?
+   ;; Create threads that refer to data owned by other threads, and try to
+   ;; mix things up to see if we can provoke a problem in parallel collection.
+   (parameterize ([collect-request-handler (lambda () (collect 3 1 3))])
+     (let loop ([j 50])
+       (unless (= j 0)
+         (let* ([N 8]
+                [DEPTH 24]
+                [common (make-vector N)])
+
+           (define (spin i)
+             (define (fib n)
+               (cond
+                 [(= n 0) #t]
+                 [(= n 1) #f]
+                 [else (cons (fib (- n 1)) (fib (- n 2)))]))
+             (vector-set! common i (fib DEPTH))
+             (when (= i (sub1 N))
+               (collect-rendezvous)))
+
+           (define (work i)
+             (lambda ()
+               (thread-preserve-ownership!)
+               (set-virtual-register! 0 (make-vector 128))
+               (vector-set! (virtual-register 0) 0 (make-eq-hashtable))
+               (map (lambda (j)
+                      (let ([r (random N)])
+                        (vector-set! common r (make-vector 10 ))))
+                    '(1 2 3))
+               (map (lambda (j)
+                      (let ([r (random N)])
+                        (set-virtual-register! j (vector-ref common r))))
+                    '(1 2 3))
+               (spin i)
+               (unless (hashtable? (vector-ref (virtual-register 0) 0))
+                 (error 'oops "something went wrong"))))
+
+           (define ths
+             (let loop ([i 0])
+               (cond
+                 [(= i N) '()]
+                 [else
+                  (let ([th (fork-thread (work i))])
+                    (vector-set! common i th)
+                    (cons th (loop (add1 i))))])))
+
+           (for-each thread-join ths)
+
+           (loop (sub1 j))))))
+   (void))
+)
+
 (mat wait-for-threads
   (begin
     ;; To avoid breaking later tests that use `(collect)`,

--- a/s/mkgc.ss
+++ b/s/mkgc.ss
@@ -994,6 +994,7 @@
                    (cast uptr (FRAME tc 0)))
       (case-mode
        [(sweep)
+        (PAR_SWEEPERS_WORKAROUND)
         (set! (tc-U tc) 0)
         (set! (tc-V tc) 0)
         (set! (tc-W tc) 0)


### PR DESCRIPTION
This patch avoids a miscompile using Clang v15 on macOS. The default compiler on macOS was recently upgraded to Clang v16, which appears to fix the problem, and I have not been able to replicate the problem with Clang v15 variants that are available in Linux distributions. So, it might be ok to just ignore the problem. But since v15 installations are likely to hang around for a while in other macOS installations, since the workaround is simple, since Racket users who build themselves are affected, and since I spent *a lot* of time tracking down the problem, I'm inclined to include a workaround.

For details on the miscompile at it affects Chez Scheme, see [clang15-miscompile.zip](https://github.com/user-attachments/files/17355942/clang15-miscompile.zip).
