### PR TITLE
repair thread test for `make test-more`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
             os: windows-2022
             toolchain: gcc
             configure: CFLAGS+=-std=gnu89
+          - machine: ta6le
+            os: ubuntu-22.04
+            test: test-more
+            variant: more
     runs-on: ${{ matrix.config.os }}
     env:
       TARGET_MACHINE: ${{ matrix.config.machine }}

--- a/.github/workflows/summarytest-more
+++ b/.github/workflows/summarytest-more
@@ -1,0 +1,22 @@
+-------- o=0 spi=t spi --------
+-------- o=3 spi=t spi --------
+-------- o=0 hci=503 ctb=(/ (collect-trip-bytes) 64) cl=9 ctb --------
+-------- o=3 hci=503 ctb=(/ (collect-trip-bytes) 64) cl=9 ctb --------
+-------- o=0 spi=t cis=t cmg=1 cis --------
+-------- o=3 spi=t cis=t cmg=1 cis --------
+-------- o=0 hci=101 cis=t cmg=6 hci-cis --------
+-------- o=3 hci=101 cis=t cmg=6 hci-cis --------
+-------- o=0 spi=t cp0=t ctb=(/ (collect-trip-bytes) 64) cgr=6 ctb-cgr --------
+-------- o=3 spi=t cp0=t ctb=(/ (collect-trip-bytes) 64) cgr=6 ctb-cgr --------
+-------- o=0 spi=t hci=101 p=t eoc=f hci-p --------
+-------- o=3 spi=t hci=101 p=t eoc=f hci-p --------
+-------- o=0 hci=101 cp0=t p=t cl=9 hci-cl-p --------
+-------- o=3 hci=101 cp0=t p=t cl=9 hci-cl-p --------
+-------- o=0 eval=interpret spi --------
+-------- o=3 eval=interpret spi --------
+-------- o=0 cp0=t eval=interpret spi-cp0 --------
+-------- o=3 cp0=t eval=interpret spi-cp0 --------
+-------- o=0 spi=t hci=503 eval=interpret ctb=(/ (collect-trip-bytes) 64) spi-ctb --------
+-------- o=3 spi=t hci=503 eval=interpret ctb=(/ (collect-trip-bytes) 64) spi-ctb --------
+-------- o=0 spi=t hci=101 cp0=t p=t eval=interpret cgr=2 hci-cgr-p --------
+-------- o=3 spi=t hci=101 cp0=t p=t eval=interpret cgr=2 hci-cgr-p --------

--- a/c/version.h
+++ b/c/version.h
@@ -61,7 +61,7 @@
 # define BIG_ENDIAN_IEEE_DOUBLE
 #endif
 
-#if defined(__arm64__) && defined(__clang__) && (__clang_major__ == 15)
+#if defined(__arm64__) && defined(__clang__) && (__clang_major__ == 15) && defined(__apple_build_version__)
 # define USE_PAR_SWEEPERS_WORKAROUND
 #endif
 

--- a/mats/thread.ms
+++ b/mats/thread.ms
@@ -1641,7 +1641,10 @@
   (equal?
    ;; Create threads that refer to data owned by other threads, and try to
    ;; mix things up to see if we can provoke a problem in parallel collection.
-   (parameterize ([collect-request-handler (lambda () (collect 3 1 3))])
+   (parameterize ([collect-request-handler
+                   (lambda ()
+                     (let ([g (collect-maximum-generation)])
+                       (collect (- g 1) (min 1 (- g 1)) (- g 1))))])
      (let loop ([j 50])
        (unless (= j 0)
          (let* ([N 8]


### PR DESCRIPTION
Repair the test so that it works when the maximum collect generation is set to 1, and add a `test-more` case to the CI configuration.

Also, refine a workaround preprocessor check to enable it only when `defined(__apple_build_version__)`.