### PR TITLE
Add missing Smake_flvector implementation

### DIFF
--- a/boot/pb/scheme.h
+++ b/boot/pb/scheme.h
@@ -181,7 +181,7 @@ EXPORT ptr Ssymbol_to_string(ptr);
 EXPORT ptr Sflonum(double);
 EXPORT ptr Smake_vector(iptr, ptr);
 EXPORT ptr Smake_fxvector(iptr, ptr);
-EXPORT ptr Smake_flvector(iptr, ptr);
+EXPORT ptr Smake_flvector(iptr, double);
 EXPORT ptr Smake_bytevector(iptr, int);
 EXPORT ptr Smake_string(iptr, int);
 EXPORT ptr Smake_uninitialized_string(iptr);

--- a/c/schlib.c
+++ b/c/schlib.c
@@ -77,6 +77,14 @@ ptr Smake_fxvector(iptr n, ptr x) {
     return p;
 }
 
+ptr Smake_flvector(iptr n, double x) {
+    ptr p; iptr i;
+
+    p = S_flvector(n);
+    for (i = 0; i < n; i += 1) Sflvector_set(p, i, x);
+    return p;
+}
+
 ptr Smake_bytevector(iptr n, int x) {
     ptr p; iptr i;
 

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -3579,14 +3579,16 @@ that it takes a C string (character pointer) as input.
 \end{flushleft}
 
 \noindent
-\scheme{Smake_string}, \scheme{Smake_vector}, \scheme{Smake_bytevector},
-and \scheme{Smake_fxvector} are similar to their Scheme counterparts.
+\scheme{Smake_string}, \scheme{Smake_vector},
+\scheme{Smake_bytevector}, \scheme{Smake_fxvector}, and
+\scheme{Smake_flvector} are similar to their Scheme counterparts.
 
 \begin{flushleft}
 \cfunction{ptr}{Smake_string}{iptr \var{n}, int \var{c}}
 \cfunction{ptr}{Smake_vector}{iptr \var{n}, ptr \var{obj}}
 \cfunction{ptr}{Smake_bytevector}{iptr \var{n}, int \var{fill}}
 \cfunction{ptr}{Smake_fxvector}{iptr \var{n}, ptr \var{fixnum}}
+\cfunction{ptr}{Smake_flvector}{iptr \var{n}, double \var{flonum}}
 \end{flushleft}
 
 \noindent

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2812,6 +2812,12 @@ and \scheme{bytevector-reference-set!}. In addition, the garbage
 collector would fail to preserve the last few bytes of a reference
 bytevector whose length is not a multiple of the word size.
 
+\subsection{Missing C implementation for \scheme{Smake_flvector} (10.1.0)}
+
+The header file scheme.h Scheme defines \scheme{Smake_flvector}, but
+Chez Scheme does not provide an implmentation. The
+\scheme{Smake_flvector} function is now implemented.
+
 \subsection{\scheme{library-exports} for library that is not yet imported (10.0.0)}
 
 When visiting or loading a separately compiled library,

--- a/s/mkheader.ss
+++ b/s/mkheader.ss
@@ -391,7 +391,7 @@
         (export "ptr" "Sflonum" "(double)")
         (export "ptr" "Smake_vector" "(iptr, ptr)")
         (export "ptr" "Smake_fxvector" "(iptr, ptr)")
-        (export "ptr" "Smake_flvector" "(iptr, ptr)")
+        (export "ptr" "Smake_flvector" "(iptr, double)")
         (export "ptr" "Smake_bytevector" "(iptr, int)")
         (export "ptr" "Smake_string" "(iptr, int)")
         (export "ptr" "Smake_uninitialized_string" "(iptr)")


### PR DESCRIPTION
The header file scheme.h defines `Smake_flvector`, but Chez Scheme does not provide an implementation. C code can use the header, but calling `Smake_flvector` results in an error trying to reference an undefined symbol.