### PR TITLE
repair `with-continuation-mark` when accessing marks in key or value

### DIFF
--- a/mats/4.ms
+++ b/mats/4.ms
@@ -3789,6 +3789,26 @@
                                               (call/cc (lambda (k) k))))))
                  'x))
 
+  (equal? '42
+          (with-continuation-mark 'a 42
+            (with-continuation-mark 'b (continuation-marks-first (current-continuation-marks) 'a)
+              (continuation-marks-first (current-continuation-marks) 'b))))
+  (equal? '42
+          (with-continuation-mark 'a 42
+            (values
+             (with-continuation-mark 'b (continuation-marks-first (current-continuation-marks) 'a)
+               (continuation-marks-first (current-continuation-marks) 'b)))))
+
+  (equal? '43
+          (with-continuation-mark 'a 'b
+            (with-continuation-mark (continuation-marks-first (current-continuation-marks) 'a) 43
+              (continuation-marks-first (current-continuation-marks) 'b))))
+  (equal? '43
+          (with-continuation-mark 'a 'b
+            (values
+             (with-continuation-mark (continuation-marks-first (current-continuation-marks) 'a) 43
+               (continuation-marks-first (current-continuation-marks) 'b)))))
+
   ;; if this goes quadratic, then it will look like non-termination:
   (with-continuation-mark
       'x 'yes

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2755,6 +2755,13 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{\scheme{with-continuation-mark} key and value expressions (10.1.0)}
+
+A bug in the \scheme{with-continuation-mark} positioned the key and
+value expressions outside of the current continuation marks, which
+meant that attempting to look up a continuation mark in the key or
+value expression would fail.
+
 \subsection{\scheme{quote-syntax} incorrectly applies wrap (10.1.0)}
 
 A bug in \scheme{quote-syntax} that caused \scheme{(identifier? (quote-syntax \var{symbol}))}

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2757,7 +2757,7 @@ in fasl files does not generally make sense.
 
 \subsection{\scheme{with-continuation-mark} key and value expressions (10.1.0)}
 
-A bug in the \scheme{with-continuation-mark} positioned the key and
+A bug in \scheme{with-continuation-mark} positioned the key and
 value expressions outside of the current continuation marks, which
 meant that attempting to look up a continuation mark in the key or
 value expression would fail.

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -8358,18 +8358,19 @@
                              (set! y t) ...))])
                (dynamic-wind #t swap (lambda () e1 e2 ...) swap))))])))
 
-
 (define-syntax with-continuation-mark
   (lambda (x)
     (syntax-case x ()
       [(_ key val body)
-       #'($call-consuming-continuation-attachment
-          '()
-          (lambda (marks)
-            ($call-setting-continuation-attachment
-             ($update-mark marks key val)
-             (lambda ()
-               body))))])))
+       #'(let ([k key]
+               [v val])
+           ($call-consuming-continuation-attachment
+            '()
+            (lambda (marks)
+              ($call-setting-continuation-attachment
+               ($update-mark marks k v)
+               (lambda ()
+                 body)))))])))
 
 (define-syntax rec
   (lambda (x)


### PR DESCRIPTION
The expansion of `with-continuation-mark` positioned the key and value expressions outside of the current continuation marks, which meant that attempting to look up a continuation mark in the key or value expression would fail.

This is a repair for #885.