### PR TITLE
expose expeditor SIGWINCH state via `ee_pending_winch`

### DIFF
--- a/c/expeditor.c
+++ b/c/expeditor.c
@@ -1304,9 +1304,18 @@ static void s_ee_flush(void) {
   fflush(stdout);
 }
 
+static ptr s_ee_pending_winch() {
+#ifdef HANDLE_SIGWINCH
+  return winched ? Strue : Sfalse;
+#else
+  return Sfalse;
+#endif
+}
+
 void S_expeditor_init(void) {
   Sforeign_symbol("(cs)ee_init_term", (void *)s_ee_init_term);
   Sforeign_symbol("(cs)ee_read_char", (void *)s_ee_read_char);
+  Sforeign_symbol("(cs)ee_pending_winch", (void *)s_ee_pending_winch);
   Sforeign_symbol("(cs)ee_write_char", (void *)s_ee_write_char);
   Sforeign_symbol("(cs)ee_char_width", (void *)s_ee_char_width);
   Sforeign_symbol("(cs)ee_set_color", (void *)s_ee_set_color);


### PR DESCRIPTION
The `ee_` functions are internal support for expeditor, but Racket puts them to good use for a customized expeditor. This commit adds a small new function to expose the internal `winched` flag. That flag is normally accessed via `ee_read_char`, but calling `ee_read_char` commits to reading a character, while the new function can be used to just check whether input is ready (in combination with checking the input file descriptor).