### PR TITLE
anticipate back-end when inlining fxdiv-and-mod

### DIFF
--- a/mats/fx.ms
+++ b/mats/fx.ms
@@ -2561,6 +2561,12 @@
     (map (lambda (x) (let-values ([ls (fxdiv-and-mod x 64)]) ls))
       '(0 -5 -31 -32 -33 -63 -64 -65 -127 -128 -129))
     '((0 0) (-1 59) (-1 33) (-1 32) (-1 31) (-1 1) (-1 0) (-2 63) (-2 1) (-2 0) (-3 63)))
+  (test-cp0-expansion
+   '(#3%fxdiv-and-mod x 1000)
+   '(#3%fxdiv-and-mod x 1000))
+  (test-cp0-expansion
+   '(#3%fxdiv-and-mod x 1024)
+   '(let ([t x]) (#3%values (#3%fxdiv t 1024) (#3%fxmod t 1024))))
 )
 
 (mat fxdiv0-and-mod0

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2769,6 +2769,13 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Performance regression for \scheme{fxdiv-and-mod} at optimize-level 3 (10.2.0)}
+
+At optimize-level 3, the source optimizer (cp0) could replace calls to
+\scheme{fxdiv-and-mod}, where the second argument is constant, with calls to
+\scheme{fxdiv} and \scheme{fxmod} that the back-end would choose not to inline
+because the constant was not a power of two.
+
 \subsection{Repair executable-relative search for NetBSD (10.2.0)}
 
 An incorrect approach to finding the current executable's path on

--- a/s/base-lang.ss
+++ b/s/base-lang.ss
@@ -21,7 +21,7 @@
          preinfo-call-can-inline? preinfo-call-no-return? preinfo-call-single-valued?
          prelex? make-prelex prelex-name prelex-name-set! prelex-flags prelex-flags-set!
          prelex-source prelex-operand prelex-operand-set! prelex-uname make-prelex*
-         target-fixnum? target-bignum?)
+         target-fixnum? target-fixnum-power-of-two target-bignum?)
 
   (module (lookup-primref primref? primref-name primref-flags primref-arity primref-level)
     (include "primref.ss")

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -3367,7 +3367,7 @@
       (define-inline 3 fxdiv-and-mod
         [(x y)
          (and likely-to-be-compiled?
-              (cp0-constant? (result-exp (value-visit-operand! y)))
+              (cp0-constant? target-fixnum-power-of-two (result-exp (value-visit-operand! y)))
               (cp0
                 (let ([tx (cp0-make-temp #t)] [ty (cp0-make-temp #t)])
                   (let ([refx (build-ref tx)] [refy (build-ref ty)])

--- a/s/np-help.ss
+++ b/s/np-help.ss
@@ -159,13 +159,7 @@
                          [(= mask (constant byte-constant-mask)) (%inline eq? ,expr (immediate ,type))]
                          [else (%inline type-check? ,expr (immediate ,mask) (immediate ,type))])))))])))
 
-(define target-fixnum?
-  (if (and (= (constant most-negative-fixnum) (most-negative-fixnum))
-           (= (constant most-positive-fixnum) (most-positive-fixnum)))
-      fixnum?
-      (lambda (x)
-        (and (or (fixnum? x) (bignum? x))
-             (<= (constant most-negative-fixnum) x (constant most-positive-fixnum))))))
+(include "target-fixnum.ss")
 
 (define unfix
   (lambda (imm)

--- a/s/target-fixnum.ss
+++ b/s/target-fixnum.ss
@@ -36,3 +36,17 @@
      (lambda (x)
        (and (bignum? x)
             (not (<= (constant most-negative-fixnum) x (constant most-positive-fixnum)))))]))
+
+(define target-fixnum-power-of-two
+  (let ([vec (list->vector
+              (do ([i 0 (fx+ i 1)] [m 2 (* m 2)] [ls '() (cons m ls)])
+                  ((not (target-fixnum? m)) (reverse ls))))])
+    (lambda (x)
+      (and (target-fixnum? x)
+           (let ([end (vector-length vec)])
+             (let f ([i 0])
+               (and (fx< i end)
+                    (let ([n (vector-ref vec i)] [next (fx+ i 1)])
+                      (if (= x n)
+                          next
+                          (and (> x n) (f next)))))))))))


### PR DESCRIPTION
At optimize-level 3, cp0 can replace calls to `fxdiv-and-mod`, where the second argument is constant, with calls to `fxdiv` and `fxmod` that the back-end does not inline (when the constant is not a power of two). This aims to address issue #892 by helping cp0 anticipate how the back-end will handle the transformed code.