### PR TITLE
repair `fx-/wraparound` with `0` first argument, allow one argument

### DIFF
--- a/csug/numeric.stex
+++ b/csug/numeric.stex
@@ -338,10 +338,11 @@ dividing \var{fixnum_1} by the product of the remaining arguments
 
 %----------------------------------------------------------------------------
 \entryheader
-\formdef{fx+/wraparound}{\categoryprocedure}{(fx+/wraparound \var{fixnum} \dots)}
-\formdef{fx-/wraparound}{\categoryprocedure}{(fx-/wraparound \var{fixnum} \dots)}
-\formdef{fx*/wraparound}{\categoryprocedure}{(fx*/wraparound \var{fixnum} \dots)}
-\formdef{fxsll/wraparound}{\categoryprocedure}{(fxsll/wraparound \var{fixnum} \dots)}
+\formdef{fx+/wraparound}{\categoryprocedure}{(fx+/wraparound \var{fixnum} \var{fixnum})}
+\formdef{fx-/wraparound}{\categoryprocedure}{(fx-/wraparound \var{fixnum} \var{fixnum})}
+\formdef{fx-/wraparound}{\categoryprocedure}{(fx-/wraparound \var{fixnum})}
+\formdef{fx*/wraparound}{\categoryprocedure}{(fx*/wraparound \var{fixnum} \var{fixnum})}
+\formdef{fxsll/wraparound}{\categoryprocedure}{(fxsll/wraparound \var{fixnum} \var{fixnum})}
 \returns the arithmetic result, wrapping on overflow
 \listlibraries
 \endentryheader

--- a/mats/fx.ms
+++ b/mats/fx.ms
@@ -564,7 +564,9 @@
 (mat fx-/wraparound
    (eqv? (fx-/wraparound 3 0) 3)
    (eqv? (fx-/wraparound 3 1) 2)
+   (eqv? (fx-/wraparound 0 3) -3)
    (eqv? (fx-/wraparound -3 4) -7)
+   (eqv? (fx-/wraparound 3) -3)
    (error? (fx-/wraparound '(a . b) 0))
    (error? (fx- (add1 (most-positive-fixnum)) 1))
    (error? (fx- 1 (add1 (most-positive-fixnum))))

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -121,6 +121,12 @@ Online versions of both books can be found at
 The type recovery pass has improved support for \scheme{abs} with a fixnum argument
 and added support for \scheme{1+}, \scheme{1-}, and \scheme{-1+}.
 
+\subsection{Single-argument \scheme{fx-/wraparound} (10.2.0)}
+
+The \scheme{fx-/wraparound} function changed to accept a single
+argument, which makes it more consistent with the R6RS \scheme{fx-}
+function.
+
 \subsection{Constrain signal delivery to the main thread (10.1.0)}
 
 Signals are now always delivered to the main Scheme thread to avoid crashes when a signal
@@ -2768,6 +2774,13 @@ in fasl files does not generally make sense.
 
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
+
+\subsection{Fix \scheme{fx-/wraparound} with \scheme{0} first argument (10.2.0)}
+
+When \scheme{fx-/wraparound} was called with \scheme{0} as its first
+argument, the call could be rewritten to have a single argument, even though
+\scheme{fx-/wraparound} required two arguments. As part of the repair,
+\scheme{fx-/wraparound} changed to accept a single argument.
 
 \subsection{Performance regression for \scheme{fxdiv-and-mod} at optimize-level 3 (10.2.0)}
 

--- a/s/cpprim.ss
+++ b/s/cpprim.ss
@@ -1796,6 +1796,7 @@
       [(e) (%inline - (immediate 0) ,e)]
       [(e1 e2) (%inline - ,e1 ,e2)])
     (define-inline 3 fx-/wraparound
+      [(e) (%inline - (immediate 0) ,e)]
       [(e1 e2) (%inline - ,e1 ,e2)])
     (define-inline 3 fx1-
       [(e) (%inline - ,e (immediate ,(fix 1)))])
@@ -1840,6 +1841,11 @@
         [(e) (go src sexpr `(immediate ,(fix 0)) e)]
         [(e1 e2) (go src sexpr e1 e2)])
       (define-inline 2 fx-/wraparound
+        [(e)
+         (bind #t (e)
+           `(if ,(build-fixnums? (list e))
+                ,(%inline - (immediate 0) ,e)
+                ,(build-libcall #t src sexpr fx-/wraparound `(immediate 0) e)))]
         [(e1 e2)
          (bind #t (e1 e2)
            `(if ,(build-fixnums? (list e1 e2))

--- a/s/mathprims.ss
+++ b/s/mathprims.ss
@@ -353,8 +353,11 @@
        (#2%fx+/wraparound x1 x2)))
 
    (set-who! fx-/wraparound
-     (lambda (x1 x2)
-       (#2%fx-/wraparound x1 x2)))
+     (case-lambda
+      [(x)
+       (#2%fx-/wraparound x)]
+      [(x1 x2)
+       (#2%fx-/wraparound x1 x2)]))
 
    (set! fx1-
       (lambda (x)

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1389,7 +1389,7 @@
   (fx+ [sig [(fixnum ...) -> (fixnum)]] [flags arith-op partial-folder])  ; not restricted to 2 arguments
   (fx+/wraparound [sig [(fixnum fixnum) -> (fixnum)]] [flags arith-op partial-folder safeongoodargs])
   (fx- [sig [(fixnum fixnum ...) -> (fixnum)]] [flags arith-op partial-folder])  ; not restricted to 1 or 2 arguments
-  (fx-/wraparound [sig [(fixnum fixnum) -> (fixnum)]] [flags arith-op partial-folder safeongoodargs])
+  (fx-/wraparound [sig [(fixnum) -> (fixnum)] [(fixnum fixnum) -> (fixnum)]] [flags arith-op partial-folder safeongoodargs])
   (fx/ [sig [(fixnum fixnum ...) -> (fixnum)]] [flags arith-op partial-folder])  ; not restricted to 1 or 2 arguments
   (fx1+ [sig [(fixnum) -> (fixnum)]] [flags arith-op cp02])
   (fx1- [sig [(fixnum) -> (fixnum)]] [flags arith-op cp02])


### PR DESCRIPTION
The `fx-/wraparound` function was treated like R6RS `fx-` by cp0, which meant that it could reduce a 2-argument call with `0` as the first argument to a 1-argument call, even though `fx-/wraparound` was defined with only a 2-argument form. Making `fx-/wraparound` more like R6RS `fx-` seems like the path of least resistance and least likelihood of future bugs.