### PR TITLE
Symbol generation with lazily generated names that behave like standard symbols

### DIFF
--- a/c/intern.c
+++ b/c/intern.c
@@ -1,12 +1,12 @@
 /* intern.c
  * Copyright 1984-2017 Cisco Systems, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -151,6 +151,15 @@ ptr S_mkstring(const string_char *s, iptr n) {
   return mkstring(s, n);
 }
 
+static ptr real_symname(ptr sym) {
+  ptr name = SYMNAME(sym);
+  if (!GENSYMP(sym))
+    return name;
+  if (Scdr(name) != Strue)
+    return Sfalse;
+  return Scar(name);
+}
+
 /* handles single-byte characters, implicit length */
 ptr S_intern(const unsigned char *s) {
   iptr n = strlen((const char *)s);
@@ -164,8 +173,8 @@ ptr S_intern(const unsigned char *s) {
   b = S_G.oblist[idx];
   while (b != NULL) {
     sym = b->sym;
-    if (!GENSYMP(sym)) {
-       ptr str = SYMNAME(sym);
+    ptr str = real_symname(sym);
+    if (str != Sfalse) {
        if (Sstring_length(str) == n) {
           iptr i;
           for (i = 0; ; i += 1) {
@@ -203,8 +212,8 @@ ptr S_intern_sc(const string_char *name, iptr n, ptr name_str) {
   b = S_G.oblist[idx];
   while (b != NULL) {
     sym = b->sym;
-    if (!GENSYMP(sym)) {
-       ptr str = SYMNAME(sym);
+    ptr str = real_symname(sym);
+    if (str != Sfalse) {
        if (Sstring_length(str) == n) {
           iptr i;
           for (i = 0; ; i += 1) {

--- a/csug/objects.stex
+++ b/csug/objects.stex
@@ -1,11 +1,11 @@
 % Copyright 2005-2017 Cisco Systems, Inc.
-% 
+%
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
 % You may obtain a copy of the License at
-% 
+%
 % http://www.apache.org/licenses/LICENSE-2.0
-% 
+%
 % Unless required by applicable law or agreed to in writing, software
 % distributed under the License is distributed on an "AS IS" BASIS,
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -71,7 +71,7 @@ This predicate is not defined by the Revised$^6$ Report, but should be.
 \var{n} must be an exact nonnegative integer less than or equal to
 the length of \var{list}.
 
-\scheme{list-head} and the standard Scheme procedure \scheme{list-tail} 
+\scheme{list-head} and the standard Scheme procedure \scheme{list-tail}
 may be used together to split a list into two separate lists.
 While \scheme{list-tail} performs no allocation but instead returns a
 sublist of the original list, \scheme{list-head} always returns a copy
@@ -581,10 +581,10 @@ source before the operation began.
 
 (string-copy! s1 3 s2 1 3)
 s2 ;=> "-bol------"
- 
+
 (string-copy! s1 7 s2 4 2)
 s2 ;=> "-bolly----"
- 
+
 (string-copy! s2 2 s2 5 4)
 s2 ;=> "-bollolly-"
 \endschemedisplay
@@ -943,7 +943,7 @@ In the case of \scheme{immutable-vector-copy}, \scheme{immutable-vector-append},
 \formdef{self-evaluating-vectors}{\categorythreadparameter}{self-evaluating-vectors}
 \listlibraries
 \endentryheader
-    
+
 \noindent
 The default value of this parameter is \scheme{#f}, meaning that vector literals must be quoted, as
 required by the Revised$^6$ Report.
@@ -1154,7 +1154,7 @@ as \var{fxvector}.
 \endschemedisplay
 
 
-    
+
 \section{Flonum-Only Vectors\label{SECTFLVECTORS}}
 
 \index{flvectors}%
@@ -1352,7 +1352,7 @@ as \var{flvector}.
 \endschemedisplay
 
 
-    
+
 \section{Bytevectors\label{SECTBYTEVECTORS}}
 
 As with vectors, {\ChezScheme} extends the syntax of bytevectors to allow
@@ -1403,7 +1403,7 @@ A negative fill value is treated as its two's complement equivalent.
 
 The values in the returned list are exact eight-bit signed integers,
 i.e., values in the range -128 to 127 inclusive.
-\scheme{bytevector->s8-list} is similar to the Revised$^6$ Report 
+\scheme{bytevector->s8-list} is similar to the Revised$^6$ Report
 \scheme{bytevector->u8-list} except the values in the returned list
 are signed rather than unsigned.
 
@@ -1424,7 +1424,7 @@ are signed rather than unsigned.
 
 \var{list} must consist entirely of exact eight-bit signed integers, i.e.,
 values in the range -128 to 127 inclusive.
-\scheme{s8-list->bytevector} is similar to the Revised$^6$ Report 
+\scheme{s8-list->bytevector} is similar to the Revised$^6$ Report
 procedure
 \scheme{u8-list->bytevector}, except the elements of the input list
 are signed rather than unsigned.
@@ -1464,21 +1464,21 @@ bv ;=> #vu8(19 19 19)
 %----------------------------------------------------------------------------
 \entryheader
 \formdef{bytevector-u24-ref}{\categoryprocedure}{(bytevector-u24-ref \var{bytevector} \var{n} \var{eness})}
-\returns the 24-bit unsigned integer at index \var{n} (zero-based) of \var{bytevector} 
+\returns the 24-bit unsigned integer at index \var{n} (zero-based) of \var{bytevector}
 \formdef{bytevector-s24-ref}{\categoryprocedure}{(bytevector-s24-ref \var{bytevector} \var{n} \var{eness})}
-\returns the 24-bit signed integer at index \var{n} (zero-based) of \var{bytevector} 
+\returns the 24-bit signed integer at index \var{n} (zero-based) of \var{bytevector}
 \formdef{bytevector-u40-ref}{\categoryprocedure}{(bytevector-u40-ref \var{bytevector} \var{n} \var{eness})}
-\returns the 40-bit unsigned integer at index \var{n} (zero-based) of \var{bytevector} 
+\returns the 40-bit unsigned integer at index \var{n} (zero-based) of \var{bytevector}
 \formdef{bytevector-s40-ref}{\categoryprocedure}{(bytevector-s40-ref \var{bytevector} \var{n} \var{eness})}
-\returns the 40-bit signed integer at index \var{n} (zero-based) of \var{bytevector} 
+\returns the 40-bit signed integer at index \var{n} (zero-based) of \var{bytevector}
 \formdef{bytevector-u48-ref}{\categoryprocedure}{(bytevector-u48-ref \var{bytevector} \var{n} \var{eness})}
-\returns the 48-bit unsigned integer at index \var{n} (zero-based) of \var{bytevector} 
+\returns the 48-bit unsigned integer at index \var{n} (zero-based) of \var{bytevector}
 \formdef{bytevector-s48-ref}{\categoryprocedure}{(bytevector-s48-ref \var{bytevector} \var{n} \var{eness})}
-\returns the 48-bit signed integer at index \var{n} (zero-based) of \var{bytevector} 
+\returns the 48-bit signed integer at index \var{n} (zero-based) of \var{bytevector}
 \formdef{bytevector-u56-ref}{\categoryprocedure}{(bytevector-u56-ref \var{bytevector} \var{n} \var{eness})}
-\returns the 56-bit unsigned integer at index \var{n} (zero-based) of \var{bytevector} 
+\returns the 56-bit unsigned integer at index \var{n} (zero-based) of \var{bytevector}
 \formdef{bytevector-s56-ref}{\categoryprocedure}{(bytevector-s56-ref \var{bytevector} \var{n} \var{eness})}
-\returns the 56-bit signed integer at index \var{n} (zero-based) of \var{bytevector} 
+\returns the 56-bit signed integer at index \var{n} (zero-based) of \var{bytevector}
 \listlibraries
 \endentryheader
 
@@ -1988,7 +1988,7 @@ Symbol names may begin with \scheme{@}, but \scheme{,@abc} is parsed
 as \scheme{(unquote-splicing abc)}; to produce \scheme{(unquote @abc)}
 one can type \scheme{, @abc}, \scheme{\x40;abc}, or \scheme{,|@abc|}.
 
-\item 
+\item
 The single-character sequences \scheme{\schlbrace} and \scheme{\schrbrace}
 are read as symbols.
 
@@ -2024,7 +2024,6 @@ They may also be printed using the pretty name only with the prefix
 These extensions are disabled in an input stream after \scheme{#!r6rs} has
 been seen by the reader, unless \scheme{#!chezscheme} has been seen more
 recently.
-
 
 %----------------------------------------------------------------------------
 \entryheader\label{desc:gensym}
@@ -2167,7 +2166,7 @@ These parameters are not consulted until that time; setting them when
 \endschemedisplay
 
 
-%----------------------------------------------------------------------------
+% ----------------------------------------------------------------------------
 \entryheader
 \formdef{gensym->unique-string}{\categoryprocedure}{(gensym->unique-string \var{gensym})}
 \returns the unique name of \var{gensym}
@@ -2196,7 +2195,38 @@ These parameters are not consulted until that time; setting them when
 \endschemedisplay
 
 
-%----------------------------------------------------------------------------
+% ----------------------------------------------------------------------------
+\entryheader
+\formdef{generate-symbol}{\categoryprocedure}{(generate-symbol)}
+\formdef{generate-symbol}{\categoryprocedure}{(generate-symbol \var{pretty-name})}
+\returns an unguessable standard symbol
+\listlibraries
+\endentryheader
+
+\noindent
+\index{generated symbols}Each call to \scheme{generate-symbol} returns
+a symbol that is not identical to any existing or potentially existing
+symbol. Contrary to the gensyms returned by \scheme{gensym}, the
+symbols returned by \scheme{generate-symbol} are standard Revised$^6$
+Report symbols, two of which are identical if and only if their names
+are spelled the same.
+
+As with gensyms, the symbol's name is generated lazily. If, as in the
+second form above, a pretty name is given as a string, it is used as a
+prefix for the generated name. Otherwise, the single character string
+\scheme{"g"} is used.
+
+\schemedisplay
+(generate-symbol) ;=> g-jj13vro48lgrjzoe5yun7fp9k
+(generate-symbol "hello") ;=> hello-clo1em9up7ajy9ihclroexrfk
+(let ([s (generate-symbol)])
+  (symbol=? s (string->symbol (symbol->string s)))) ;=> #t
+(gensym? (generate-symbol)) ;=> #f
+(uninterned-symbol? (generate-symbol)) ;=> #f
+\endschemedisplay
+
+
+% ----------------------------------------------------------------------------
 \entryheader
 \formdef{string->uninterned-symbol}{\categoryprocedure}{(string->uninterned-symbol \var{str})}
 \returns a fresh uninterned symbol
@@ -2287,14 +2317,14 @@ the \var{default} argument is not supplied.
 
 \schemedisplay
 (putprop 'fred 'species 'snurd)
-(putprop 'fred 'age 4)  
+(putprop 'fred 'age 4)
 (putprop 'fred 'colors '(black white))
 
 (getprop 'fred 'species) ;=> snurd
 (getprop 'fred 'colors) ;=> (black white)
 (getprop 'fred 'nonkey) ;=> #f
 (getprop 'fred 'nonkey 'unknown) ;=> unknown
- 
+
 (putprop 'fred 'species #f)
 (getprop 'fred 'species 'unknown) ;=> #f
 \endschemedisplay
@@ -2630,7 +2660,7 @@ may return different subsets of \var{hashtable}'s entries.
 (hashtable-set! ht 'a "one")
 (hashtable-set! ht 'b "two")
 (hashtable-entries ht) ;=> #(a b) #("one" "two") \var{or the other permutation}
-(hashtable-entries ht 1) ;=> #(a) #("one") \var{or} #(b) #("two") 
+(hashtable-entries ht 1) ;=> #(a) #("one") \var{or} #(b) #("two")
 \endschemedisplay
 
 %----------------------------------------------------------------------------
@@ -3575,7 +3605,7 @@ and \scheme{y}, and defines the following procedures:
 The names of these procedures follow a regular naming convention by
 default, but the programmer can override the defaults if desired.
 \scheme{define-record} allows the programmer to control which fields
-are arguments to the generated constructor procedure and which 
+are arguments to the generated constructor procedure and which
 are explicitly initialized by the constructor procedure.
 Fields are mutable by default, but may be declared immutable.
 Fields can generally contain any Scheme value, but the internal
@@ -3723,9 +3753,9 @@ where \var{name} is the ``pretty'' name of the record (not the full
 gensym) or the reader name first assigned to the record
 type.
 
-%%% need more define-record examples 
+%%% need more define-record examples
 %%%   - show use of field types other than ptr
-%%%   - show non-top-level use 
+%%%   - show non-top-level use
 
 %%% make-record-type and company
 %%%   - (scan primvars for record-related primitives)
@@ -3769,7 +3799,7 @@ If the \scheme{immutable} class specifier is present, the field is
 immutable; otherwise, the field is mutable.
 \var{type}, if present, specifies how the field is represented,
 as described below.
- 
+
 \begin{tabular}{ll}\label{record-field-types}
 \scheme{ptr} &            any Scheme object\\
 \scheme{scheme-object} &  same as \scheme{ptr}\\
@@ -4159,7 +4189,7 @@ When passed only one argument, \scheme{record-writer} returns the
 record writer associated with \var{rtd}, which is initially the
 default record writer for all records.
 The default print method prints all records in a uniform syntax that
-includes the generated name for the record 
+includes the generated name for the record
 and the values of each of the fields, as described in the introduction
 to this section.
 

--- a/csug/syntax.stex
+++ b/csug/syntax.stex
@@ -533,6 +533,17 @@ This procedure is identical to the Revised$^6$ Report
 \scheme{free-identifier=?}, and is provided for backward
 compatibility only.
 
+%----------------------------------------------------------------------------
+\entryheader\label{generate-temporaries}
+\formdef{generate-temporaries}{\categoryprocedure}{(generate-temporaries \var{list})}
+\returns a list of distinct generated identifiers
+\listlibraries
+\endentryheader
+
+This procedure is identical to the Revised$^6$ Report
+\scheme{generate-temporaries} except that the symbolic names of the
+generated identifiers are gensyms and not standard Revised$^6$ Report symbols.
+
 \section{Compile-time Values and Properties\label{SECTSYNTAXCTVS}}
 
 When defining sets of dependent macros, it is often convenient to attach

--- a/mats/5_7.ms
+++ b/mats/5_7.ms
@@ -1,12 +1,12 @@
 ;;; 5-7.ms
 ;;; Copyright 1984-2017 Cisco Systems, Inc.
-;;; 
+;;;
 ;;; Licensed under the Apache License, Version 2.0 (the "License");
 ;;; you may not use this file except in compliance with the License.
 ;;; You may obtain a copy of the License at
-;;; 
+;;;
 ;;; http://www.apache.org/licenses/LICENSE-2.0
-;;; 
+;;;
 ;;; Unless required by applicable law or agreed to in writing, software
 ;;; distributed under the License is distributed on an "AS IS" BASIS,
 ;;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -153,3 +153,41 @@
                 (equal? "hello" (symbol->string (car r)))))))
 
      )
+
+(mat generate-symbol
+  (symbol? (generate-symbol))
+  (symbol? (generate-symbol "pretty"))
+  (symbol? (let ([x (generate-symbol)])
+             (symbol->string x)         ; intern
+             x))
+  (symbol? (let ([x (generate-symbol "pretty")])
+             (symbol->string x)         ; intern
+             x))
+  (not (uninterned-symbol? (generate-symbol)))
+  (not (uninterned-symbol? (generate-symbol "beautiful")))
+  (not (uninterned-symbol? (let ([x (generate-symbol)])
+                  (symbol->string x)      ; intern
+                  x)))
+  (not (uninterned-symbol? (let ([x (generate-symbol "beautiful")])
+                  (symbol->string x)      ; intern
+                  x)))
+  (not (gensym? (generate-symbol)))
+  (not (gensym? (generate-symbol "handsome")))
+  (not (gensym? (let ([x (generate-symbol)])
+                  (symbol->string x)      ; intern
+                  x)))
+  (not (gensym? (let ([x (generate-symbol "handsome")])
+                  (symbol->string x)      ; intern
+                  x)))
+  (let ([s (generate-symbol)])
+    (symbol=? s s))
+  (let ([s1 (generate-symbol)] [s2 (generate-symbol)])
+    (not (symbol=? s1 s2)))
+  (let ([s1 (generate-symbol "g1")] [s2 (generate-symbol "g1")])
+    (not (symbol=? s1 s2)))
+  (let ([s1 (generate-symbol "g1")] [s2 'g1])
+    (not (symbol=? s1 s2)))
+  (let ([s (generate-symbol "g1")])
+    (not (string=? (symbol->string s) "g1")))
+  (let ([s (generate-symbol)])          ;FIXME
+    (symbol=? (string->symbol (symbol->string s)) s)))

--- a/mats/5_7.ms
+++ b/mats/5_7.ms
@@ -189,5 +189,5 @@
     (not (symbol=? s1 s2)))
   (let ([s (generate-symbol "g1")])
     (not (string=? (symbol->string s) "g1")))
-  (let ([s (generate-symbol)])          ;FIXME
+  (let ([s (generate-symbol)])
     (symbol=? (string->symbol (symbol->string s)) s)))

--- a/mats/8.ms
+++ b/mats/8.ms
@@ -792,6 +792,40 @@
   (equal? $gt-x '(53 -10 . 17))
 )
 
+(mat r6rs:generate-temporaries
+  (error? (r6rs:generate-temporaries))
+  (error? (r6rs:generate-temporaries '(a b c) '(d e f)))
+  (error? (r6rs:generate-temporaries '(a b . c)))
+  (error? (r6rs:generate-temporaries (let ([x (list 'a 'b 'c)]) (set-cdr! (cddr x) (cdr x)) x)))
+  (andmap identifier? (r6rs:generate-temporaries '(a b c)))
+  (= (length (r6rs:generate-temporaries '(a b c))) 3)
+  (andmap identifier? (r6rs:generate-temporaries #'(a b c)))
+  (= (length (r6rs:generate-temporaries #'(a b c))) 3)
+  (andmap identifier? (r6rs:generate-temporaries (cons 'q #'(1 2 3))))
+  (= (length (r6rs:generate-temporaries (cons 'q #'(1 2 3)))) 4)
+  (andmap (lambda (x) (not (gensym? (syntax->datum x)))) (r6rs:generate-temporaries '(a b c)))
+ ; make sure r6rs:generate-temporaries isn't confused by annotations
+  (begin
+    (let ((op (open-output-file "testfile.ss" 'replace)))
+      (pretty-print
+        '(begin
+           (define-syntax $gt-a
+             (lambda (x)
+               (syntax-case x ()
+                 [(_ x)
+                  (with-syntax ([(t1 t2 t3) (r6rs:generate-temporaries #'(1 1 1))])
+                    #'(define x (let ([t1 17] [t2 53] [t3 -10]) (cons* t2 t3 t1))))])))
+           ($gt-a $gt-x))
+        op)
+        (close-output-port op)
+        (compile-file "testfile.ss"))
+    #t)
+  (begin
+    (load "testfile.so")
+    #t)
+  (equal? $gt-x '(53 -10 . 17))
+)
+
 (mat syntax->list
   (error? (syntax->list #'a))
   (error? (syntax->list #'(a b . e)))

--- a/mats/patch-compile-0-f-f-t
+++ b/mats/patch-compile-0-f-f-t
@@ -1,7 +1,7 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Fri Feb 24 19:33:45 2023
---- output-compile-0-f-f-t-experr/errors-compile-0-f-f-t	Fri Feb 24 19:33:41 2023
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2025-01-31 10:14:10.594298664 +0100
+--- output-compile-0-f-f-t-experr/errors-compile-0-f-f-t	2025-01-31 10:14:02.370971352 +0100
 ***************
-*** 4052,4058 ****
+*** 4057,4063 ****
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation "static"".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: 17 is not a procedure".
@@ -9,7 +9,7 @@
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation oldgen".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation -1".
   misc.mo:Expected error in mat make-object-finder: "incorrect number of arguments 1 to #<procedure find-next>".
---- 4052,4058 ----
+--- 4057,4063 ----
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation "static"".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: 17 is not a procedure".
@@ -18,7 +18,7 @@
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation -1".
   misc.mo:Expected error in mat make-object-finder: "incorrect number of arguments 1 to #<procedure find-next>".
 ***************
-*** 7881,7891 ****
+*** 7953,7963 ****
   7.mo:Expected error in mat sstats: "set-sstats-gc-bytes!: twelve is not an exact integer".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation yuk".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation -1".
@@ -30,7 +30,7 @@
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
---- 7881,7891 ----
+--- 7953,7963 ----
   7.mo:Expected error in mat sstats: "set-sstats-gc-bytes!: twelve is not an exact integer".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation yuk".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation -1".
@@ -43,7 +43,7 @@
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
 ***************
-*** 9412,9424 ****
+*** 9490,9502 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -57,7 +57,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9412,9424 ----
+--- 9490,9502 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".

--- a/mats/patch-compile-0-f-t-f
+++ b/mats/patch-compile-0-f-t-f
@@ -1,7 +1,7 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Fri Feb 24 19:33:45 2023
---- output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	Fri Feb 24 19:33:42 2023
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2025-01-31 10:14:10.594298664 +0100
+--- output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	2025-01-31 10:18:40.839547447 +0100
 ***************
-*** 207,213 ****
+*** 212,218 ****
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable c".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable m".
@@ -9,7 +9,7 @@
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable y".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
---- 207,213 ----
+--- 212,218 ----
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable c".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable m".
@@ -18,26 +18,24 @@
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
 ***************
-*** 226,233 ****
+*** 231,237 ****
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
+! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
-- 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
-  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
---- 226,233 ----
+--- 231,237 ----
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
-+ 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
+! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
-  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
 ***************
-*** 273,282 ****
+*** 278,287 ****
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 0 values to single value return context".
@@ -48,7 +46,7 @@
   3.mo:Expected error in mat mrvs: "variable $mrvs-foo is not bound".
   3.mo:Expected error in mat mrvs: "attempt to apply non-procedure 17".
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
---- 273,282 ----
+--- 278,287 ----
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 0 values to single value return context".
@@ -60,7 +58,7 @@
   3.mo:Expected error in mat mrvs: "attempt to apply non-procedure 17".
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
 ***************
-*** 4094,4100 ****
+*** 4101,4107 ****
   misc.mo:Expected error in mat cpletrec: "foreign-procedure: no entry for "foo"".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable q".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable bar".
@@ -68,7 +66,7 @@
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable a".
---- 4094,4100 ----
+--- 4101,4107 ----
   misc.mo:Expected error in mat cpletrec: "foreign-procedure: no entry for "foo"".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable q".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable bar".
@@ -77,7 +75,7 @@
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable a".
 ***************
-*** 7891,7898 ****
+*** 7963,7970 ****
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -86,7 +84,7 @@
   record.mo:Expected error in mat record2: "invalid value 3 for foreign type double-float".
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
---- 7891,7898 ----
+--- 7963,7970 ----
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -96,7 +94,7 @@
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
 ***************
-*** 7900,7914 ****
+*** 7972,7986 ****
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -112,7 +110,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid input #f".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
---- 7900,7914 ----
+--- 7972,7986 ----
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -129,7 +127,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
 ***************
-*** 7921,7946 ****
+*** 7993,8018 ****
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -156,7 +154,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: 0 is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
---- 7921,7946 ----
+--- 7993,8018 ----
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -184,7 +182,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
 ***************
-*** 8075,8113 ****
+*** 8147,8185 ****
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -224,7 +222,7 @@
   record.mo:Expected error in mat record?: "record?: 4 is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
---- 8075,8113 ----
+--- 8147,8185 ----
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -265,7 +263,7 @@
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
 ***************
-*** 8124,8181 ****
+*** 8196,8253 ****
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: invalid protocol flimflam".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure not-a-procedure".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure spam".
@@ -324,7 +322,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "cannot extend define-record-type parent fratrat".
---- 8124,8181 ----
+--- 8196,8253 ----
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: invalid protocol flimflam".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure not-a-procedure".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure spam".

--- a/mats/patch-compile-0-f-t-t
+++ b/mats/patch-compile-0-f-t-t
@@ -1,7 +1,7 @@
-*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	Fri Feb 24 19:33:42 2023
---- output-compile-0-f-t-t-experr/errors-compile-0-f-t-t	Fri Feb 24 19:33:36 2023
+*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	2025-01-31 10:18:40.839547447 +0100
+--- output-compile-0-f-t-t-experr/errors-compile-0-f-t-t	2025-01-31 10:18:43.348271940 +0100
 ***************
-*** 9412,9424 ****
+*** 9490,9502 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -15,7 +15,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9412,9424 ----
+--- 9490,9502 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".

--- a/mats/patch-compile-0-t-f-f
+++ b/mats/patch-compile-0-t-f-f
@@ -1,5 +1,5 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Sat Oct 26 11:30:13 2024
---- output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Sat Oct 26 11:34:11 2024
+*** errors-compile-0-f-f-f	2025-01-31 07:30:30.869627363 +0100
+--- output-compile-0-t-f-f-spi-rmg/errors-compile-0-t-f-f	2025-01-31 07:41:21.423357785 +0100
 ***************
 *** 180,186 ****
   3.mo:Expected error in mat case-lambda: "incorrect number of arguments 2 to #<procedure foo>".
@@ -4634,24 +4634,22 @@
   7.mo:Expected error in mat top-level-value-functions: "define-top-level-value: #<environment *scheme*> is not a symbol".
   7.mo:Expected error in mat top-level-value-functions: "variable i-am-not-bound-i-hope is not bound".
 ***************
-*** 8202,8209 ****
+*** 8202,8208 ****
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
-- record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
-  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
---- 8202,8209 ----
+--- 8202,8208 ----
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
-+ record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
-  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
 ***************
 *** 8293,8412 ****
   hash.mo:Expected error in mat old-hash-table: "hash-table-for-each: ((a . b)) is not an eq hashtable".
@@ -5224,7 +5222,7 @@
   hash.mo:Expected error in mat fasl-other-hashtable: "fasl-write: invalid fasl object #<eqv hashtable>".
   hash.mo:Expected error in mat fasl-other-hashtable: "fasl-write: invalid fasl object #<hashtable>".
 ***************
-*** 8702,8709 ****
+*** 8702,8713 ****
   8.mo:Expected error in mat with-syntax: "invalid syntax a".
   8.mo:Expected error in mat with-syntax: "duplicate pattern variable x in (x x)".
   8.mo:Expected error in mat with-syntax: "duplicate pattern variable x in (x x)".
@@ -5232,8 +5230,12 @@
 ! 8.mo:Expected error in mat generate-temporaries: "incorrect argument count in call (generate-temporaries (quote (a b c)) (quote (d e f)))".
   8.mo:Expected error in mat generate-temporaries: "generate-temporaries: improper list structure (a b . c)".
   8.mo:Expected error in mat generate-temporaries: "generate-temporaries: cyclic list structure (a b c b c b ...)".
+! 8.mo:Expected error in mat r6rs:generate-temporaries: "incorrect argument count in call (generate-temporaries)".
+! 8.mo:Expected error in mat r6rs:generate-temporaries: "incorrect argument count in call (generate-temporaries (quote (a b c)) (quote (d e f)))".
+  8.mo:Expected error in mat r6rs:generate-temporaries: "generate-temporaries: improper list structure (a b . c)".
+  8.mo:Expected error in mat r6rs:generate-temporaries: "generate-temporaries: cyclic list structure (a b c b c b ...)".
   8.mo:Expected error in mat syntax->list: "syntax->list: invalid argument #<syntax a>".
---- 8702,8709 ----
+--- 8702,8713 ----
   8.mo:Expected error in mat with-syntax: "invalid syntax a".
   8.mo:Expected error in mat with-syntax: "duplicate pattern variable x in (x x)".
   8.mo:Expected error in mat with-syntax: "duplicate pattern variable x in (x x)".
@@ -5241,9 +5243,13 @@
 ! 8.mo:Expected error in mat generate-temporaries: "incorrect number of arguments 2 to #<procedure generate-temporaries>".
   8.mo:Expected error in mat generate-temporaries: "generate-temporaries: improper list structure (a b . c)".
   8.mo:Expected error in mat generate-temporaries: "generate-temporaries: cyclic list structure (a b c b c b ...)".
+! 8.mo:Expected error in mat r6rs:generate-temporaries: "incorrect number of arguments 0 to #<procedure generate-temporaries>".
+! 8.mo:Expected error in mat r6rs:generate-temporaries: "incorrect number of arguments 2 to #<procedure generate-temporaries>".
+  8.mo:Expected error in mat r6rs:generate-temporaries: "generate-temporaries: improper list structure (a b . c)".
+  8.mo:Expected error in mat r6rs:generate-temporaries: "generate-temporaries: cyclic list structure (a b c b c b ...)".
   8.mo:Expected error in mat syntax->list: "syntax->list: invalid argument #<syntax a>".
 ***************
-*** 9320,9335 ****
+*** 9324,9339 ****
   8.mo:Expected error in mat rnrs-eval: "attempt to assign unbound identifier foo".
   8.mo:Expected error in mat rnrs-eval: "invalid definition in immutable environment (define cons (quote #<procedure vector>))".
   8.mo:Expected error in mat top-level-syntax-functions: "top-level-syntax: "hello" is not a symbol".
@@ -5260,7 +5266,7 @@
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: hello is not an environment".
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: #<environment *scheme*> is not a symbol".
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: cannot modify immutable environment #<environment *scheme*>".
---- 9320,9335 ----
+--- 9324,9339 ----
   8.mo:Expected error in mat rnrs-eval: "attempt to assign unbound identifier foo".
   8.mo:Expected error in mat rnrs-eval: "invalid definition in immutable environment (define cons (quote #<procedure vector>))".
   8.mo:Expected error in mat top-level-syntax-functions: "top-level-syntax: "hello" is not a symbol".
@@ -5278,7 +5284,7 @@
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: #<environment *scheme*> is not a symbol".
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: cannot modify immutable environment #<environment *scheme*>".
 ***************
-*** 9428,9450 ****
+*** 9432,9454 ****
   fx.mo:Expected error in mat fx=?: "fx=?: (a) is not a fixnum".
   fx.mo:Expected error in mat fx=?: "fx=?: <int> is not a fixnum".
   fx.mo:Expected error in mat fx=?: "fx=?: <-int> is not a fixnum".
@@ -5302,7 +5308,7 @@
   fx.mo:Expected error in mat $fxu<: "incorrect number of arguments 1 to #<procedure $fxu<>".
   fx.mo:Expected error in mat $fxu<: "incorrect number of arguments 3 to #<procedure $fxu<>".
   fx.mo:Expected error in mat $fxu<: "$fxu<: <-int> is not a fixnum".
---- 9428,9450 ----
+--- 9432,9454 ----
   fx.mo:Expected error in mat fx=?: "fx=?: (a) is not a fixnum".
   fx.mo:Expected error in mat fx=?: "fx=?: <int> is not a fixnum".
   fx.mo:Expected error in mat fx=?: "fx=?: <-int> is not a fixnum".
@@ -5327,7 +5333,7 @@
   fx.mo:Expected error in mat $fxu<: "incorrect number of arguments 3 to #<procedure $fxu<>".
   fx.mo:Expected error in mat $fxu<: "$fxu<: <-int> is not a fixnum".
 ***************
-*** 9486,9498 ****
+*** 9490,9502 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -5341,7 +5347,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9486,9498 ----
+--- 9490,9502 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -5356,7 +5362,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
 ***************
-*** 9547,9559 ****
+*** 9551,9563 ****
   fx.mo:Expected error in mat fx1+: "fx1+: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx1+: "fx1+: <int> is not a fixnum".
   fx.mo:Expected error in mat fx1+: "fx1+: a is not a fixnum".
@@ -5370,7 +5376,7 @@
   fx.mo:Expected error in mat fxmax: "fxmax: a is not a fixnum".
   fx.mo:Expected error in mat fxmax: "fxmax: <int> is not a fixnum".
   fx.mo:Expected error in mat fxmax: "fxmax: <-int> is not a fixnum".
---- 9547,9559 ----
+--- 9551,9563 ----
   fx.mo:Expected error in mat fx1+: "fx1+: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx1+: "fx1+: <int> is not a fixnum".
   fx.mo:Expected error in mat fx1+: "fx1+: a is not a fixnum".
@@ -5385,7 +5391,7 @@
   fx.mo:Expected error in mat fxmax: "fxmax: <int> is not a fixnum".
   fx.mo:Expected error in mat fxmax: "fxmax: <-int> is not a fixnum".
 ***************
-*** 9659,9668 ****
+*** 9663,9672 ****
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments <int> and 10".
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments -4097 and <int>".
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments <-int> and 1".
@@ -5396,7 +5402,7 @@
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 35.0 is not a fixnum".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 5.0 is not a valid start index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 8.0 is not a valid end index".
---- 9659,9668 ----
+--- 9663,9672 ----
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments <int> and 10".
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments -4097 and <int>".
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments <-int> and 1".
@@ -5408,7 +5414,7 @@
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 5.0 is not a valid start index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 8.0 is not a valid end index".
 ***************
-*** 9676,9709 ****
+*** 9680,9713 ****
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid end index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid start index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid end index".
@@ -5443,7 +5449,7 @@
   fx.mo:Expected error in mat fxif: "fxif: a is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: 3.4 is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: (a) is not a fixnum".
---- 9676,9709 ----
+--- 9680,9713 ----
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid end index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid start index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid end index".
@@ -5479,7 +5485,7 @@
   fx.mo:Expected error in mat fxif: "fxif: 3.4 is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: (a) is not a fixnum".
 ***************
-*** 9713,9756 ****
+*** 9717,9760 ****
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
@@ -5524,7 +5530,7 @@
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: 3.4 is not a fixnum".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: "3" is not a fixnum".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: <int> is not a fixnum".
---- 9713,9756 ----
+--- 9717,9760 ----
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
@@ -5570,7 +5576,7 @@
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: "3" is not a fixnum".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: <int> is not a fixnum".
 ***************
-*** 9759,9769 ****
+*** 9763,9773 ****
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index -1".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index <int>".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index <int>".
@@ -5582,7 +5588,7 @@
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: "3" is not a fixnum".
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: 3.4 is not a valid start index".
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: 3/4 is not a valid end index".
---- 9759,9769 ----
+--- 9763,9773 ----
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index -1".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index <int>".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index <int>".
@@ -5595,7 +5601,7 @@
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: 3.4 is not a valid start index".
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: 3/4 is not a valid end index".
 ***************
-*** 9823,9832 ****
+*** 9827,9836 ****
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: (a) is not a fixnum".
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: undefined for 0".
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: undefined for 0".
@@ -5606,7 +5612,7 @@
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 1.0 is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 3.0 is not a fixnum".
---- 9823,9832 ----
+--- 9827,9836 ----
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: (a) is not a fixnum".
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: undefined for 0".
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: undefined for 0".
@@ -5618,7 +5624,7 @@
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 3.0 is not a fixnum".
 ***************
-*** 9842,9851 ****
+*** 9846,9855 ****
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
@@ -5629,7 +5635,7 @@
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 1.0 is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 3.0 is not a fixnum".
---- 9842,9851 ----
+--- 9846,9855 ----
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
@@ -5641,7 +5647,7 @@
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 3.0 is not a fixnum".
 ***************
-*** 9861,9870 ****
+*** 9865,9874 ****
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
@@ -5652,7 +5658,7 @@
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 1.0 is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 3.0 is not a fixnum".
---- 9861,9870 ----
+--- 9865,9874 ----
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
@@ -5664,7 +5670,7 @@
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 3.0 is not a fixnum".
 ***************
-*** 9880,9890 ****
+*** 9884,9894 ****
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
@@ -5676,7 +5682,7 @@
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: a is not a fixnum".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid start index 0.0".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index 2.0".
---- 9880,9890 ----
+--- 9884,9894 ----
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
@@ -5689,7 +5695,7 @@
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid start index 0.0".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index 2.0".
 ***************
-*** 9907,9916 ****
+*** 9911,9920 ****
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: count 1 is greater than difference between end index 5 and start index 5".
@@ -5700,7 +5706,7 @@
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: a is not a fixnum".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid start index 0.0".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index 2.0".
---- 9907,9916 ----
+--- 9911,9920 ----
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: count 1 is greater than difference between end index 5 and start index 5".
@@ -5712,7 +5718,7 @@
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid start index 0.0".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index 2.0".
 ***************
-*** 9926,9943 ****
+*** 9930,9947 ****
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index <-int>".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: start index 7 is greater than end index 5".
@@ -5731,7 +5737,7 @@
   fl.mo:Expected error in mat fl=: "fl=: (a) is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: a is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: a is not a flonum".
---- 9926,9943 ----
+--- 9930,9947 ----
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index <-int>".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: start index 7 is greater than end index 5".
@@ -5751,7 +5757,7 @@
   fl.mo:Expected error in mat fl=: "fl=: a is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: a is not a flonum".
 ***************
-*** 9945,9951 ****
+*** 9949,9955 ****
   fl.mo:Expected error in mat fl=: "fl=: 3 is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: 7/2 is not a flonum".
@@ -5759,7 +5765,7 @@
   fl.mo:Expected error in mat fl<: "fl<: (a) is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: a is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: a is not a flonum".
---- 9945,9951 ----
+--- 9949,9955 ----
   fl.mo:Expected error in mat fl=: "fl=: 3 is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: 7/2 is not a flonum".
@@ -5768,7 +5774,7 @@
   fl.mo:Expected error in mat fl<: "fl<: a is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: a is not a flonum".
 ***************
-*** 9953,9959 ****
+*** 9957,9963 ****
   fl.mo:Expected error in mat fl<: "fl<: 3 is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: 7/2 is not a flonum".
@@ -5776,7 +5782,7 @@
   fl.mo:Expected error in mat fl>: "fl>: (a) is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: a is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: a is not a flonum".
---- 9953,9959 ----
+--- 9957,9963 ----
   fl.mo:Expected error in mat fl<: "fl<: 3 is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: 7/2 is not a flonum".
@@ -5785,7 +5791,7 @@
   fl.mo:Expected error in mat fl>: "fl>: a is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: a is not a flonum".
 ***************
-*** 9961,9967 ****
+*** 9965,9971 ****
   fl.mo:Expected error in mat fl>: "fl>: 3 is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: 7/2 is not a flonum".
@@ -5793,7 +5799,7 @@
   fl.mo:Expected error in mat fl<=: "fl<=: (a) is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: a is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: a is not a flonum".
---- 9961,9967 ----
+--- 9965,9971 ----
   fl.mo:Expected error in mat fl>: "fl>: 3 is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: 7/2 is not a flonum".
@@ -5802,7 +5808,7 @@
   fl.mo:Expected error in mat fl<=: "fl<=: a is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: a is not a flonum".
 ***************
-*** 9969,9975 ****
+*** 9973,9979 ****
   fl.mo:Expected error in mat fl<=: "fl<=: 3 is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: 7/2 is not a flonum".
@@ -5810,7 +5816,7 @@
   fl.mo:Expected error in mat fl>=: "fl>=: (a) is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: a is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: a is not a flonum".
---- 9969,9975 ----
+--- 9973,9979 ----
   fl.mo:Expected error in mat fl<=: "fl<=: 3 is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: 7/2 is not a flonum".
@@ -5819,7 +5825,7 @@
   fl.mo:Expected error in mat fl>=: "fl>=: a is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: a is not a flonum".
 ***************
-*** 9977,10016 ****
+*** 9981,10020 ****
   fl.mo:Expected error in mat fl>=: "fl>=: 3 is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: 7/2 is not a flonum".
@@ -5860,7 +5866,7 @@
   fl.mo:Expected error in mat fl>=?: "fl>=?: a is not a flonum".
   fl.mo:Expected error in mat fl>=?: "fl>=?: a is not a flonum".
   fl.mo:Expected error in mat fl>=?: "fl>=?: 3 is not a flonum".
---- 9977,10016 ----
+--- 9981,10020 ----
   fl.mo:Expected error in mat fl>=: "fl>=: 3 is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: 7/2 is not a flonum".
@@ -5902,7 +5908,7 @@
   fl.mo:Expected error in mat fl>=?: "fl>=?: a is not a flonum".
   fl.mo:Expected error in mat fl>=?: "fl>=?: 3 is not a flonum".
 ***************
-*** 10020,10026 ****
+*** 10024,10030 ****
   fl.mo:Expected error in mat fl+: "fl+: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl+: "fl+: 1 is not a flonum".
   fl.mo:Expected error in mat fl+: "fl+: 2/3 is not a flonum".
@@ -5910,7 +5916,7 @@
   fl.mo:Expected error in mat fl-: "fl-: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl-: "fl-: 1 is not a flonum".
   fl.mo:Expected error in mat fl-: "fl-: a is not a flonum".
---- 10020,10026 ----
+--- 10024,10030 ----
   fl.mo:Expected error in mat fl+: "fl+: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl+: "fl+: 1 is not a flonum".
   fl.mo:Expected error in mat fl+: "fl+: 2/3 is not a flonum".
@@ -5919,7 +5925,7 @@
   fl.mo:Expected error in mat fl-: "fl-: 1 is not a flonum".
   fl.mo:Expected error in mat fl-: "fl-: a is not a flonum".
 ***************
-*** 10030,10119 ****
+*** 10034,10123 ****
   fl.mo:Expected error in mat fl*: "fl*: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl*: "fl*: 1 is not a flonum".
   fl.mo:Expected error in mat fl*: "fl*: 2/3 is not a flonum".
@@ -6010,7 +6016,7 @@
   fl.mo:Expected error in mat flsingle: "flsingle: a is not a flonum".
   fl.mo:Expected error in mat flsingle: "flsingle: 3 is not a flonum".
   fl.mo:Expected error in mat flsingle: "flsingle: 2.0+1.0i is not a flonum".
---- 10030,10119 ----
+--- 10034,10123 ----
   fl.mo:Expected error in mat fl*: "fl*: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl*: "fl*: 1 is not a flonum".
   fl.mo:Expected error in mat fl*: "fl*: 2/3 is not a flonum".
@@ -6102,7 +6108,7 @@
   fl.mo:Expected error in mat flsingle: "flsingle: 3 is not a flonum".
   fl.mo:Expected error in mat flsingle: "flsingle: 2.0+1.0i is not a flonum".
 ***************
-*** 10132,10167 ****
+*** 10136,10171 ****
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: 3 is not a flonum".
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: 3/4 is not a flonum".
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: hi is not a flonum".
@@ -6139,7 +6145,7 @@
   fl.mo:Expected error in mat fleven?: "fleven?: a is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: 3 is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: 3.2 is not an integer".
---- 10132,10167 ----
+--- 10136,10171 ----
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: 3 is not a flonum".
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: 3/4 is not a flonum".
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: hi is not a flonum".
@@ -6177,7 +6183,7 @@
   fl.mo:Expected error in mat fleven?: "fleven?: 3 is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: 3.2 is not an integer".
 ***************
-*** 10169,10176 ****
+*** 10173,10180 ****
   fl.mo:Expected error in mat fleven?: "fleven?: 1+1i is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: +inf.0 is not an integer".
   fl.mo:Expected error in mat fleven?: "fleven?: +nan.0 is not an integer".
@@ -6186,7 +6192,7 @@
   fl.mo:Expected error in mat flodd?: "flodd?: a is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: 3 is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: 3.2 is not an integer".
---- 10169,10176 ----
+--- 10173,10180 ----
   fl.mo:Expected error in mat fleven?: "fleven?: 1+1i is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: +inf.0 is not an integer".
   fl.mo:Expected error in mat fleven?: "fleven?: +nan.0 is not an integer".
@@ -6196,7 +6202,7 @@
   fl.mo:Expected error in mat flodd?: "flodd?: 3 is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: 3.2 is not an integer".
 ***************
-*** 10178,10184 ****
+*** 10182,10188 ****
   fl.mo:Expected error in mat flodd?: "flodd?: 3+1i is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: +inf.0 is not an integer".
   fl.mo:Expected error in mat flodd?: "flodd?: +nan.0 is not an integer".
@@ -6204,7 +6210,7 @@
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
---- 10178,10184 ----
+--- 10182,10188 ----
   fl.mo:Expected error in mat flodd?: "flodd?: 3+1i is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: +inf.0 is not an integer".
   fl.mo:Expected error in mat flodd?: "flodd?: +nan.0 is not an integer".
@@ -6213,7 +6219,7 @@
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
 ***************
-*** 10186,10192 ****
+*** 10190,10196 ****
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: 0.0+1.0i is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: 0+1i is not a flonum".
@@ -6221,7 +6227,7 @@
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 3 is not a flonum".
---- 10186,10192 ----
+--- 10190,10196 ----
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: 0.0+1.0i is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: 0+1i is not a flonum".
@@ -6230,7 +6236,7 @@
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 3 is not a flonum".
 ***************
-*** 10194,10207 ****
+*** 10198,10211 ****
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 0.0+1.0i is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 0+1i is not a flonum".
@@ -6245,7 +6251,7 @@
   fl.mo:Expected error in mat fldenominator: "fldenominator: a is not a flonum".
   fl.mo:Expected error in mat fldenominator: "fldenominator: 3 is not a flonum".
   fl.mo:Expected error in mat fldenominator: "fldenominator: 0+1i is not a flonum".
---- 10194,10207 ----
+--- 10198,10211 ----
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 0.0+1.0i is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 0+1i is not a flonum".
@@ -6261,7 +6267,7 @@
   fl.mo:Expected error in mat fldenominator: "fldenominator: 3 is not a flonum".
   fl.mo:Expected error in mat fldenominator: "fldenominator: 0+1i is not a flonum".
 ***************
-*** 10230,10238 ****
+*** 10234,10242 ****
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: 17 is not a flonum".
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: a is not a flonum".
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: (a) is not a flonum".
@@ -6271,7 +6277,7 @@
   fl.mo:Expected error in mat flbit-field: "flbit-field: 0 is not a flonum".
   fl.mo:Expected error in mat flbit-field: "flbit-field: invalid start index -1".
   fl.mo:Expected error in mat flbit-field: "flbit-field: invalid end index 1".
---- 10230,10238 ----
+--- 10234,10242 ----
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: 17 is not a flonum".
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: a is not a flonum".
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: (a) is not a flonum".
@@ -6282,7 +6288,7 @@
   fl.mo:Expected error in mat flbit-field: "flbit-field: invalid start index -1".
   fl.mo:Expected error in mat flbit-field: "flbit-field: invalid end index 1".
 ***************
-*** 10258,10264 ****
+*** 10262,10268 ****
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
@@ -6290,7 +6296,7 @@
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
---- 10258,10264 ----
+--- 10262,10268 ----
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
@@ -6299,7 +6305,7 @@
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
 ***************
-*** 10268,10281 ****
+*** 10272,10285 ****
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
@@ -6314,7 +6320,7 @@
   foreign.mo:Expected error in mat load-shared-object: "load-shared-object: invalid path 3".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: no entry for "i do not exist"".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: no entry for "i do not exist"".
---- 10268,10281 ----
+--- 10272,10285 ----
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
@@ -6330,7 +6336,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: no entry for "i do not exist"".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: no entry for "i do not exist"".
 ***************
-*** 10310,10317 ****
+*** 10314,10321 ****
   foreign.mo:Expected error in mat foreign-procedure: "id: invalid foreign-procedure argument foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle abcde".
   foreign.mo:Expected error in mat foreign-procedure: "float_id: invalid foreign-procedure argument 0".
@@ -6339,7 +6345,7 @@
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
   foreign.mo:Expected error in mat foreign-bytevectors: "u8*->u8*: invalid foreign-procedure argument "hello"".
---- 10310,10317 ----
+--- 10314,10321 ----
   foreign.mo:Expected error in mat foreign-procedure: "id: invalid foreign-procedure argument foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle abcde".
   foreign.mo:Expected error in mat foreign-procedure: "float_id: invalid foreign-procedure argument 0".
@@ -6349,7 +6355,7 @@
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
   foreign.mo:Expected error in mat foreign-bytevectors: "u8*->u8*: invalid foreign-procedure argument "hello"".
 ***************
-*** 10831,10843 ****
+*** 10843,10855 ****
   unix.mo:Expected error in mat file-operations: "file-access-time: failed for "testlink": no such file or directory".
   unix.mo:Expected error in mat file-operations: "file-change-time: failed for "testlink": no such file or directory".
   unix.mo:Expected error in mat file-operations: "file-modification-time: failed for "testlink": no such file or directory".
@@ -6363,7 +6369,7 @@
   windows.mo:Expected error in mat registry: "get-registry: pooh is not a string".
   windows.mo:Expected error in mat registry: "put-registry!: 3 is not a string".
   windows.mo:Expected error in mat registry: "put-registry!: 3 is not a string".
---- 10831,10843 ----
+--- 10843,10855 ----
   unix.mo:Expected error in mat file-operations: "file-access-time: failed for "testlink": no such file or directory".
   unix.mo:Expected error in mat file-operations: "file-change-time: failed for "testlink": no such file or directory".
   unix.mo:Expected error in mat file-operations: "file-modification-time: failed for "testlink": no such file or directory".
@@ -6378,7 +6384,7 @@
   windows.mo:Expected error in mat registry: "put-registry!: 3 is not a string".
   windows.mo:Expected error in mat registry: "put-registry!: 3 is not a string".
 ***************
-*** 10865,10936 ****
+*** 10877,10948 ****
   ieee.mo:Expected error in mat flonum->fixnum: "flonum->fixnum: result for -inf.0 would be outside of fixnum range".
   ieee.mo:Expected error in mat flonum->fixnum: "flonum->fixnum: result for +nan.0 would be outside of fixnum range".
   ieee.mo:Expected error in mat fllp: "fllp: 3 is not a flonum".
@@ -6451,7 +6457,7 @@
   date.mo:Expected error in mat time: "time>=?: 3 is not a time record".
   date.mo:Expected error in mat time: "time>=?: #<procedure car> is not a time record".
   date.mo:Expected error in mat time: "time>=?: types of <time> and <time> differ".
---- 10865,10936 ----
+--- 10877,10948 ----
   ieee.mo:Expected error in mat flonum->fixnum: "flonum->fixnum: result for -inf.0 would be outside of fixnum range".
   ieee.mo:Expected error in mat flonum->fixnum: "flonum->fixnum: result for +nan.0 would be outside of fixnum range".
   ieee.mo:Expected error in mat fllp: "fllp: 3 is not a flonum".
@@ -6525,7 +6531,7 @@
   date.mo:Expected error in mat time: "time>=?: #<procedure car> is not a time record".
   date.mo:Expected error in mat time: "time>=?: types of <time> and <time> differ".
 ***************
-*** 10938,10951 ****
+*** 10950,10963 ****
   date.mo:Expected error in mat time: "add-duration: <time> does not have type time-duration".
   date.mo:Expected error in mat time: "subtract-duration: <time> does not have type time-duration".
   date.mo:Expected error in mat time: "copy-time: <date> is not a time record".
@@ -6540,7 +6546,7 @@
   date.mo:Expected error in mat date: "make-date: invalid nanosecond -1".
   date.mo:Expected error in mat date: "make-date: invalid nanosecond <int>".
   date.mo:Expected error in mat date: "make-date: invalid nanosecond zero".
---- 10938,10951 ----
+--- 10950,10963 ----
   date.mo:Expected error in mat time: "add-duration: <time> does not have type time-duration".
   date.mo:Expected error in mat time: "subtract-duration: <time> does not have type time-duration".
   date.mo:Expected error in mat time: "copy-time: <date> is not a time record".
@@ -6556,7 +6562,7 @@
   date.mo:Expected error in mat date: "make-date: invalid nanosecond <int>".
   date.mo:Expected error in mat date: "make-date: invalid nanosecond zero".
 ***************
-*** 10971,11031 ****
+*** 10983,11043 ****
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset 90000".
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset est".
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset "est"".
@@ -6618,7 +6624,7 @@
   date.mo:Expected error in mat date: "current-date: invalid time-zone offset -90000".
   date.mo:Expected error in mat date: "current-date: invalid time-zone offset 90000".
   date.mo:Expected error in mat conversions/sleep: "date->time-utc: <time> is not a date record".
---- 10971,11031 ----
+--- 10983,11043 ----
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset 90000".
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset est".
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset "est"".

--- a/mats/patch-compile-0-t-f-f
+++ b/mats/patch-compile-0-t-f-f
@@ -1,5 +1,5 @@
-*** errors-compile-0-f-f-f	2025-01-31 07:30:30.869627363 +0100
---- output-compile-0-t-f-f-spi-rmg/errors-compile-0-t-f-f	2025-01-31 07:41:21.423357785 +0100
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2025-01-31 10:14:10.594298664 +0100
+--- output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2025-01-31 10:20:19.547355131 +0100
 ***************
 *** 180,186 ****
   3.mo:Expected error in mat case-lambda: "incorrect number of arguments 2 to #<procedure foo>".

--- a/mats/patch-compile-0-t-f-t
+++ b/mats/patch-compile-0-t-f-t
@@ -1,7 +1,7 @@
-*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Feb 24 19:38:21 2023
---- output-compile-0-t-f-t-experr/errors-compile-0-t-f-t	Fri Feb 24 19:41:49 2023
+*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2025-01-31 10:20:19.547355131 +0100
+--- output-compile-0-t-f-t-experr/errors-compile-0-t-f-t	2025-01-31 10:23:26.508411833 +0100
 ***************
-*** 4052,4058 ****
+*** 4057,4063 ****
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation "static"".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: 17 is not a procedure".
@@ -9,7 +9,7 @@
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation oldgen".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation -1".
   misc.mo:Expected error in mat make-object-finder: "incorrect number of arguments 1 to #<procedure find-next>".
---- 4052,4058 ----
+--- 4057,4063 ----
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation "static"".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: 17 is not a procedure".
@@ -18,7 +18,7 @@
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation -1".
   misc.mo:Expected error in mat make-object-finder: "incorrect number of arguments 1 to #<procedure find-next>".
 ***************
-*** 7881,7891 ****
+*** 7953,7963 ****
   7.mo:Expected error in mat sstats: "set-sstats-gc-bytes!: twelve is not an exact integer".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation yuk".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation -1".
@@ -30,7 +30,7 @@
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
---- 7881,7891 ----
+--- 7953,7963 ----
   7.mo:Expected error in mat sstats: "set-sstats-gc-bytes!: twelve is not an exact integer".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation yuk".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation -1".

--- a/mats/patch-compile-0-t-t-f
+++ b/mats/patch-compile-0-t-t-f
@@ -1,26 +1,24 @@
-*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Feb 24 19:38:21 2023
---- output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	Fri Feb 24 19:40:20 2023
+*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2025-01-31 10:20:19.547355131 +0100
+--- output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	2025-01-31 10:25:15.942916057 +0100
 ***************
-*** 226,233 ****
+*** 231,237 ****
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
+! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
-- 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
-  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
---- 226,233 ----
+--- 231,237 ----
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
-+ 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
+! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
-  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
 ***************
-*** 4094,4100 ****
+*** 4101,4107 ****
   misc.mo:Expected error in mat cpletrec: "foreign-procedure: no entry for "foo"".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable q".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable bar".
@@ -28,7 +26,7 @@
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable a".
---- 4094,4100 ----
+--- 4101,4107 ----
   misc.mo:Expected error in mat cpletrec: "foreign-procedure: no entry for "foo"".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable q".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable bar".
@@ -37,7 +35,7 @@
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable a".
 ***************
-*** 7891,7898 ****
+*** 7963,7970 ****
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -46,7 +44,7 @@
   record.mo:Expected error in mat record2: "invalid value 3 for foreign type double-float".
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
---- 7891,7898 ----
+--- 7963,7970 ----
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -56,7 +54,7 @@
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
 ***************
-*** 7900,7914 ****
+*** 7972,7986 ****
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -72,7 +70,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid input #f".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
---- 7900,7914 ----
+--- 7972,7986 ----
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -89,7 +87,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
 ***************
-*** 7921,7946 ****
+*** 7993,8018 ****
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -116,7 +114,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: 0 is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
---- 7921,7946 ----
+--- 7993,8018 ----
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -144,7 +142,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
 ***************
-*** 8075,8113 ****
+*** 8147,8185 ****
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -184,7 +182,7 @@
   record.mo:Expected error in mat record?: "record?: 4 is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
---- 8075,8113 ----
+--- 8147,8185 ----
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -225,7 +223,7 @@
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
 ***************
-*** 8135,8171 ****
+*** 8207,8243 ****
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
   record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
@@ -263,7 +261,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "parent record type is sealed ex3".
---- 8135,8171 ----
+--- 8207,8243 ----
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
   record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".

--- a/mats/patch-interpret-0-f-f-f
+++ b/mats/patch-interpret-0-f-f-f
@@ -1,5 +1,5 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Fri Dec 20 18:19:27 2024
---- output-interpret-0-f-f-f-experr/errors-interpret-0-f-f-f	Fri Dec 20 18:20:50 2024
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2025-01-31 10:14:10.594298664 +0100
+--- output-interpret-0-f-f-f-experr/errors-interpret-0-f-f-f	2025-01-31 10:15:20.766985505 +0100
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -255,23 +255,21 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
 ***************
-*** 7763,7770 ****
+*** 7763,7769 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7763,7770 ----
+--- 7763,7769 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
+! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
-+ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
 *** 8158,8164 ****
@@ -291,26 +289,24 @@
   record.mo:Expected error in mat record25: "invalid value 13.0 for foreign type unsigned-long-long".
   record.mo:Expected error in mat record25: "invalid value 3.0 for foreign type int".
 ***************
-*** 8202,8209 ****
+*** 8202,8208 ****
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
-- record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
-  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
---- 8202,8209 ----
+--- 8202,8208 ----
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
-+ record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
-  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
 ***************
-*** 9486,9498 ****
+*** 9490,9502 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -324,7 +320,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9486,9498 ----
+--- 9490,9502 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -339,7 +335,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
 ***************
-*** 10283,10307 ****
+*** 10287,10311 ****
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
@@ -365,7 +361,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier booleen".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier integer-34".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure result type specifier chare".
---- 10283,10307 ----
+--- 10287,10311 ----
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
@@ -392,7 +388,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier integer-34".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure result type specifier chare".
 ***************
-*** 10314,10345 ****
+*** 10318,10349 ****
   foreign.mo:Expected error in mat foreign-sizeof: "incorrect argument count in call (foreign-sizeof (quote int) (quote int))".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
@@ -425,7 +421,7 @@
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
---- 10314,10345 ----
+--- 10318,10349 ----
   foreign.mo:Expected error in mat foreign-sizeof: "incorrect argument count in call (foreign-sizeof (quote int) (quote int))".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
@@ -459,7 +455,7 @@
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
 ***************
-*** 10347,10372 ****
+*** 10351,10376 ****
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
@@ -486,7 +482,7 @@
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
---- 10347,10372 ----
+--- 10351,10376 ----
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
@@ -514,7 +510,7 @@
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
 ***************
-*** 10378,10412 ****
+*** 10382,10416 ****
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
@@ -550,7 +546,7 @@
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
---- 10378,10412 ----
+--- 10382,10416 ----
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
@@ -587,7 +583,7 @@
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
 ***************
-*** 10451,10459 ****
+*** 10455,10463 ****
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: 1000000 is not a string".
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: no entry for "i am not defined"".
   foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name outside pointer field A".
@@ -597,7 +593,7 @@
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
---- 10451,10459 ----
+--- 10455,10463 ----
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: 1000000 is not a string".
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: no entry for "i am not defined"".
   foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name outside pointer field A".
@@ -608,7 +604,7 @@
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 ***************
-*** 11042,11051 ****
+*** 11046,11055 ****
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".
@@ -619,7 +615,7 @@
   oop.mo:Expected error in mat oop: "m1: not applicable to 17".
   oop.mo:Expected error in mat oop: "variable <a>-x1 is not bound".
   oop.mo:Expected error in mat oop: "variable <a>-x1-set! is not bound".
---- 11042,11051 ----
+--- 11046,11055 ----
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".

--- a/mats/patch-interpret-0-f-t-f
+++ b/mats/patch-interpret-0-f-t-f
@@ -1,5 +1,5 @@
-*** output-compile-0-f-t-f-cl3/errors-compile-0-f-t-f	Sat Aug  5 10:44:46 2023
---- output-interpret-0-f-t-f-rmg2/errors-interpret-0-f-t-f	Sat Aug  5 10:50:31 2023
+*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	2025-01-31 10:18:40.839547447 +0100
+--- output-interpret-0-f-t-f-experr/errors-interpret-0-f-t-f	2025-01-31 10:15:12.792306231 +0100
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -207,7 +207,7 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7453,7461 ****
+*** 7488,7496 ****
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect argument count in call (make-codec-buffer (lambda (bp) (make-bytevector 4)) "extra arg")".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -217,7 +217,7 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: foo is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
---- 7453,7461 ----
+--- 7488,7496 ----
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect argument count in call (make-codec-buffer (lambda (bp) (make-bytevector 4)) "extra arg")".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -228,26 +228,24 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
 ***************
-*** 7728,7735 ****
+*** 7763,7769 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7728,7735 ----
+--- 7763,7769 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
+! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
-+ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
-*** 7928,7935 ****
+*** 7963,7970 ****
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -256,7 +254,7 @@
   record.mo:Expected error in mat record2: "invalid value 3 for foreign type double-float".
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
---- 7928,7935 ----
+--- 7963,7970 ----
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -266,7 +264,7 @@
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
 ***************
-*** 7937,7951 ****
+*** 7972,7986 ****
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -282,7 +280,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid input #f".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
---- 7937,7951 ----
+--- 7972,7986 ----
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -299,7 +297,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
 ***************
-*** 7958,7983 ****
+*** 7993,8018 ****
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -326,7 +324,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: 0 is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
---- 7958,7983 ----
+--- 7993,8018 ----
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -354,7 +352,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
 ***************
-*** 8112,8150 ****
+*** 8147,8185 ****
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -394,7 +392,7 @@
   record.mo:Expected error in mat record?: "record?: 4 is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
---- 8112,8150 ----
+--- 8147,8185 ----
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -435,7 +433,7 @@
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
 ***************
-*** 8161,8218 ****
+*** 8196,8253 ****
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: invalid protocol flimflam".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure not-a-procedure".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure spam".
@@ -494,7 +492,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "cannot extend define-record-type parent fratrat".
---- 8161,8218 ----
+--- 8196,8253 ----
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: invalid protocol flimflam".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure not-a-procedure".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure spam".
@@ -554,7 +552,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "cannot extend define-record-type parent fratrat".
 ***************
-*** 9449,9461 ****
+*** 9490,9502 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -568,7 +566,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9449,9461 ----
+--- 9490,9502 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -583,7 +581,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
 ***************
-*** 10973,10982 ****
+*** 11046,11055 ****
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".
@@ -594,7 +592,7 @@
   oop.mo:Expected error in mat oop: "m1: not applicable to 17".
   oop.mo:Expected error in mat oop: "variable <a>-x1 is not bound".
   oop.mo:Expected error in mat oop: "variable <a>-x1-set! is not bound".
---- 10973,10982 ----
+--- 11046,11055 ----
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".

--- a/mats/patch-interpret-0-t-f-f
+++ b/mats/patch-interpret-0-t-f-f
@@ -1,5 +1,5 @@
-*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Dec 20 18:23:34 2024
---- output-interpret-0-t-f-f-experr/errors-interpret-0-t-f-f	Fri Dec 20 18:25:02 2024
+*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2025-01-31 10:20:19.547355131 +0100
+--- output-interpret-0-t-f-f-experr/errors-interpret-0-t-f-f	2025-01-31 10:21:36.567891353 +0100
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -220,23 +220,21 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
 ***************
-*** 7763,7770 ****
+*** 7763,7769 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7763,7770 ----
+--- 7763,7769 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
+! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
-+ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
 *** 8158,8164 ****
@@ -256,7 +254,7 @@
   record.mo:Expected error in mat record25: "invalid value 13.0 for foreign type unsigned-long-long".
   record.mo:Expected error in mat record25: "invalid value 3.0 for foreign type int".
 ***************
-*** 10283,10307 ****
+*** 10287,10311 ****
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
@@ -282,7 +280,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier booleen".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier integer-34".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure result type specifier chare".
---- 10283,10307 ----
+--- 10287,10311 ----
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
@@ -309,7 +307,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier integer-34".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure result type specifier chare".
 ***************
-*** 10314,10345 ****
+*** 10318,10349 ****
   foreign.mo:Expected error in mat foreign-sizeof: "incorrect number of arguments 2 to #<procedure foreign-sizeof>".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
@@ -342,7 +340,7 @@
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
---- 10314,10345 ----
+--- 10318,10349 ----
   foreign.mo:Expected error in mat foreign-sizeof: "incorrect number of arguments 2 to #<procedure foreign-sizeof>".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
@@ -376,7 +374,7 @@
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
 ***************
-*** 10347,10372 ****
+*** 10351,10376 ****
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
@@ -403,7 +401,7 @@
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
---- 10347,10372 ----
+--- 10351,10376 ----
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
@@ -431,7 +429,7 @@
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
 ***************
-*** 10378,10412 ****
+*** 10382,10416 ****
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
@@ -467,7 +465,7 @@
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
---- 10378,10412 ----
+--- 10382,10416 ----
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
@@ -504,7 +502,7 @@
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
 ***************
-*** 10451,10459 ****
+*** 10455,10463 ****
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: 1000000 is not a string".
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: no entry for "i am not defined"".
   foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name outside pointer field A".
@@ -514,7 +512,7 @@
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
---- 10451,10459 ----
+--- 10455,10463 ----
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: 1000000 is not a string".
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: no entry for "i am not defined"".
   foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name outside pointer field A".
@@ -525,7 +523,7 @@
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 ***************
-*** 11042,11051 ****
+*** 11046,11055 ****
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".
@@ -536,7 +534,7 @@
   oop.mo:Expected error in mat oop: "m1: not applicable to 17".
   oop.mo:Expected error in mat oop: "variable <a>-x1 is not bound".
   oop.mo:Expected error in mat oop: "variable <a>-x1-set! is not bound".
---- 11042,11051 ----
+--- 11046,11055 ----
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".

--- a/mats/patch-interpret-0-t-t-f
+++ b/mats/patch-interpret-0-t-t-f
@@ -1,5 +1,5 @@
-*** output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	Sat Aug  5 15:06:57 2023
---- output-interpret-0-t-t-f-experr/errors-interpret-0-t-t-f	Sat Aug  5 15:07:21 2023
+*** output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	2025-01-31 10:25:15.942916057 +0100
+--- output-interpret-0-t-t-f-experr/errors-interpret-0-t-t-f	2025-01-31 10:25:04.087256495 +0100
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -199,7 +199,7 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7453,7461 ****
+*** 7488,7496 ****
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect number of arguments 2 to #<procedure make-codec-buffer>".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -209,7 +209,7 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: foo is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
---- 7453,7461 ----
+--- 7488,7496 ----
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect number of arguments 2 to #<procedure make-codec-buffer>".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -220,26 +220,24 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
 ***************
-*** 7728,7735 ****
+*** 7763,7769 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7728,7735 ----
+--- 7763,7769 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
+! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
-+ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
-*** 7928,7935 ****
+*** 7963,7970 ****
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -248,7 +246,7 @@
   record.mo:Expected error in mat record2: "invalid value 3 for foreign type double-float".
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
---- 7928,7935 ----
+--- 7963,7970 ----
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -258,7 +256,7 @@
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
 ***************
-*** 7937,7951 ****
+*** 7972,7986 ****
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -274,7 +272,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid input #f".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
---- 7937,7951 ----
+--- 7972,7986 ----
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -291,7 +289,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
 ***************
-*** 7958,7983 ****
+*** 7993,8018 ****
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -318,7 +316,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: 0 is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
---- 7958,7983 ----
+--- 7993,8018 ----
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -346,7 +344,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
 ***************
-*** 8112,8150 ****
+*** 8147,8185 ****
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -386,7 +384,7 @@
   record.mo:Expected error in mat record?: "record?: 4 is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
---- 8112,8150 ----
+--- 8147,8185 ----
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -427,7 +425,7 @@
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
 ***************
-*** 8172,8208 ****
+*** 8207,8243 ****
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
   record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
@@ -465,7 +463,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "parent record type is sealed ex3".
---- 8172,8208 ----
+--- 8207,8243 ----
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
   record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
@@ -504,7 +502,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "parent record type is sealed ex3".
 ***************
-*** 10973,10982 ****
+*** 11046,11055 ****
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".
@@ -515,7 +513,7 @@
   oop.mo:Expected error in mat oop: "m1: not applicable to 17".
   oop.mo:Expected error in mat oop: "variable <a>-x1 is not bound".
   oop.mo:Expected error in mat oop: "variable <a>-x1-set! is not bound".
---- 10973,10982 ----
+--- 11046,11055 ----
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".

--- a/mats/root-experr-compile-0-f-f-f
+++ b/mats/root-experr-compile-0-f-f-f
@@ -8706,6 +8706,10 @@ enum.mo:Expected error in mat enumeration: "make-record-type: cannot extend seal
 8.mo:Expected error in mat generate-temporaries: "incorrect argument count in call (generate-temporaries (quote (a b c)) (quote (d e f)))".
 8.mo:Expected error in mat generate-temporaries: "generate-temporaries: improper list structure (a b . c)".
 8.mo:Expected error in mat generate-temporaries: "generate-temporaries: cyclic list structure (a b c b c b ...)".
+8.mo:Expected error in mat r6rs:generate-temporaries: "incorrect argument count in call (generate-temporaries)".
+8.mo:Expected error in mat r6rs:generate-temporaries: "incorrect argument count in call (generate-temporaries (quote (a b c)) (quote (d e f)))".
+8.mo:Expected error in mat r6rs:generate-temporaries: "generate-temporaries: improper list structure (a b . c)".
+8.mo:Expected error in mat r6rs:generate-temporaries: "generate-temporaries: cyclic list structure (a b c b c b ...)".
 8.mo:Expected error in mat syntax->list: "syntax->list: invalid argument #<syntax a>".
 8.mo:Expected error in mat syntax->list: "syntax->list: invalid argument #<syntax (a b . e)>".
 8.mo:Expected error in mat syntax->vector: "syntax->vector: invalid argument #<syntax a>".

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -116,6 +116,18 @@ Online versions of both books can be found at
 %-----------------------------------------------------------------------------
 \section{Functionality Changes}\label{section:functionality}
 
+\subsection{New procedure \scheme{generate-symbol} (10.2.0)}
+
+The \scheme{generate-symbol} function has been added. It returns
+(interned) unique symbols like \scheme{gensym}, but the symbols
+procedured by \scheme{generate-symbol} are valid R6RS symbols; in
+particular, they are written and read as ordinary symbols.
+
+The version of \scheme{generate-temporaries} exported by the
+\scheme{(rnrs)} and \scheme{(rnrs syntax-case)} libraries now uses
+\scheme{generate-symbol} to generate symbolic names for the temporary
+identifiers for R6RS compatibility.
+
 \subsection{Type recovery improvements (10.2.0)}
 
 The type recovery pass has improved support for \scheme{abs} with a fixnum argument

--- a/s/5_7.ss
+++ b/s/5_7.ss
@@ -1,12 +1,12 @@
 ;;; 5_7.ss
 ;;; Copyright 1984-2017 Cisco Systems, Inc.
-;;; 
+;;;
 ;;; Licensed under the Apache License, Version 2.0 (the "License");
 ;;; you may not use this file except in compliance with the License.
 ;;; You may obtain a copy of the License at
-;;; 
+;;;
 ;;; http://www.apache.org/licenses/LICENSE-2.0
-;;; 
+;;;
 ;;; Unless required by applicable law or agreed to in writing, software
 ;;; distributed under the License is distributed on an "AS IS" BASIS,
 ;;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -192,7 +192,7 @@
       [(x)
        (unless (and (or (fixnum? x) (bignum? x)) (>= x 0))
          ($oops 'gensym-count "~s is not a nonnegative integer" x))
-       (set! count x)])) 
+       (set! count x)]))
   (set-who! gensym
     (case-lambda
       [() (#3%gensym)]
@@ -215,4 +215,13 @@
       [(pretty-name unique-name)
        (unless (immutable-string? pretty-name) ($oops who "~s is not an immutable string" pretty-name))
        (unless (immutable-string? unique-name) ($oops who "~s is not an immutable string" unique-name))
-       ($strings->gensym pretty-name unique-name)])))
+       ($strings->gensym pretty-name unique-name)]))
+  (set-who! generate-symbol
+    (case-lambda
+      [() (#3%$generate-symbol)]
+      [(pretty-name)
+       (if (immutable-string? pretty-name)
+           (#3%$generate-symbol pretty-name)
+           (if (string? pretty-name)
+               (#3%$generate-symbol (string->immutable-string pretty-name))
+               ($oops who "~s is not a string" pretty-name)))])))

--- a/s/5_7.ss
+++ b/s/5_7.ss
@@ -218,17 +218,18 @@
        ($strings->gensym pretty-name unique-name)]))
   (set! $generated-symbol->name
     (lambda (x)
+      ;; do not generate name within the mutex...
       (with-tc-mutex
         (let ([name ($symbol-name x)])
           (cond
             [(pair? name)
-             (if (eq? (cdr name) #t)
-                 (car name)
-                 (let ([uname (string-append (car name) "-" (generate-unique-name))])
+             (if (eq? (car name) #t)
+                 (let ([uname (string-append (cdr name) "-" (generate-unique-name))])
                    ;; FIXME: (generate-unique-name) is not quite right.
                    ($string-set-immutable! uname)
                    ($intern-gensym x (cons uname #t))
-                   uname))]
+                   uname)
+                 (car name))]
             [else
               (let ([uname (generate-unique-name)])
                 ($string-set-immutable! uname)

--- a/s/5_7.ss
+++ b/s/5_7.ss
@@ -216,6 +216,24 @@
        (unless (immutable-string? pretty-name) ($oops who "~s is not an immutable string" pretty-name))
        (unless (immutable-string? unique-name) ($oops who "~s is not an immutable string" unique-name))
        ($strings->gensym pretty-name unique-name)]))
+  (set! $generated-symbol->name
+    (lambda (x)
+      (with-tc-mutex
+        (let ([name ($symbol-name x)])
+          (cond
+            [(pair? name)
+             (if (eq? (cdr name) #t)
+                 (car name)
+                 (let ([uname (string-append (car name) "-" (generate-unique-name))])
+                   ;; FIXME: (generate-unique-name) is not quite right.
+                   ($string-set-immutable! uname)
+                   ($intern-gensym x (cons uname #t))
+                   uname))]
+            [else
+              (let ([uname (generate-unique-name)])
+                ($string-set-immutable! uname)
+                ($intern-gensym x (cons uname #t))
+                uname)])))))
   (set-who! generate-symbol
     (case-lambda
       [() (#3%$generate-symbol)]

--- a/s/5_7.ss
+++ b/s/5_7.ss
@@ -242,4 +242,10 @@
            (#3%$generate-symbol pretty-name)
            (if (string? pretty-name)
                (#3%$generate-symbol (string->immutable-string pretty-name))
-               ($oops who "~s is not a string" pretty-name)))])))
+               ($oops who "~s is not a string" pretty-name)))]))
+  (set-who! $generate-symbol
+    (case-lambda
+      [() (#3%$generate-symbol)]
+      [(pretty-name)
+       (unless (immutable-string? pretty-name) ($oops who "~s is not an immutable string" pretty-name))
+       (#3%$generate-symbol pretty-name)])))

--- a/s/cp0.ss
+++ b/s/cp0.ss
@@ -1,12 +1,12 @@
 ;;; cp0.ss
 ;;; Copyright 1984-2017 Cisco Systems, Inc.
-;;; 
+;;;
 ;;; Licensed under the Apache License, Version 2.0 (the "License");
 ;;; you may not use this file except in compliance with the License.
 ;;; You may obtain a copy of the License at
-;;; 
+;;;
 ;;; http://www.apache.org/licenses/LICENSE-2.0
-;;; 
+;;;
 ;;; Unless required by applicable law or agreed to in writing, software
 ;;; distributed under the License is distributed on an "AS IS" BASIS,
 ;;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -231,7 +231,7 @@
                            (if (null? old-ids)
                                (reverse rnew-ids)
                                (loop
-                                 (cdr old-ids) 
+                                 (cdr old-ids)
                                  (and opnds (cdr opnds))
                                  (cons
                                    (let ([old-id (car old-ids)]
@@ -250,7 +250,7 @@
                                        id))
                                    rnew-ids))))])
             (values (make-env (list->vector old-ids) (list->vector new-ids) old-env) new-ids))))
-      
+
       (define deinitialize-ids!
         (lambda (ids)
           ; clear operand field (a) to release storage the operands occupy and (b) to
@@ -749,7 +749,12 @@
 
     (define (symbol->lambda-name sym)
       (let ([x ($symbol-name sym)])
-        (if (pair? x) (or (cdr x) (car x)) x)))
+        (if (pair? x)
+            (if (eq? #t (cdr x))
+                (car x)
+                (or (cdr x) (car x)))
+            (and (not (eq? x #t))
+                 x))))
 
     (define (preinfo-lambda-set-name-and-flags preinfo name flags)
       (let ([new-name (and
@@ -1231,7 +1236,7 @@
               [(case-lambda ,preinfo ,cl* ...) #t]
               [(if ,e1 ,e2 ,e3) (memoize (and (ivory1? e1) (ivory? e2) (ivory? e3)))]
               [(seq ,e1 ,e2) (memoize (and (ivory? e1) (ivory? e2)))]
-              [(record-ref ,rtd ,type ,index ,e) 
+              [(record-ref ,rtd ,type ,index ,e)
                ; here ivory? differs from pure?
                (and (rtd-immutable-field? rtd index)
                     (memoize (ivory1? e)))]
@@ -1728,11 +1733,11 @@
                     ; (let ((x e)) x) => e
                     ; x is clearly not assigned, even if flags are polluted and say it is
                     (make-nontail (app-ctxt ctxt) (car rhs*))]
-                   ; we drop the RHS of a let binding into the let body when the body expression is a call 
+                   ; we drop the RHS of a let binding into the let body when the body expression is a call
                    ; and we can do so without violating evaluation order of bindings wrt the let body:
                    ;  * for pure, singly referenced bindings, we drop them to the variable reference site
                    ;  * for impure, singly referenced bindings, we drop them only into the most deeply
-                   ;    nested call of the let body to ensure the expression is fully evaluated before 
+                   ;    nested call of the let body to ensure the expression is fully evaluated before
                    ;    any body (sub-)expressions
                    ; when we drop an impure let binding, we require the other bindings at the same level
                    ; to be unassigned so the location creation for the other bindings remains in the
@@ -3471,7 +3476,7 @@
               (values #t ctrtd-opaque-known)
               (nanopass-case (Lsrc Expr) (if x (result-exp (value-visit-operand! x)) false-rec)
                 [(quote ,d)
-                 (if d 
+                 (if d
                      (values #t ctrtd-opaque-known)
                      (if (and (not d) (or (not prtd) (and (record-type-opaque-known? prtd) (not (record-type-opaque? prtd)))))
                          (values #f ctrtd-opaque-known)
@@ -4509,7 +4514,7 @@
                            (let ([main
                                   (let f ([t** temp**] [e** (reverse e**)] [ls* (cons ?ls ?ls*)])
                                     (if (null? t**)
-                                        (let ([results 
+                                        (let ([results
                                                (let ([preinfo (app-preinfo ctxt)])
                                                  (let g ([t** temp**])
                                                    (if (null? (car t**))
@@ -4526,7 +4531,7 @@
                                                   (make-seq* (app-ctxt ctxt) results))))
                                         (non-result-exp (value-visit-operand! (car ls*))
                                           (build-let (car t**) (car e**)
-                                            (f (cdr t**) (cdr e**) (cdr ls*))))))]) 
+                                            (f (cdr t**) (cdr e**) (cdr ls*))))))])
                              (if (fx= lvl 2)
                                (make-seq (app-ctxt ctxt)
                                  `(if ,(build-primcall 2 'procedure? (list `(ref #f ,p)))
@@ -5377,7 +5382,7 @@
           (inline-make-guardian ctxt empty-env sc wd name moi
                 formal*
                 (lambda (ref-tc)
-                  (list 
+                  (list
                     (let* ([obj (cp0-make-temp #t)] [ref-obj (build-ref obj)])
                       (list (list obj)
                         (build-primcall 3 '$install-guardian
@@ -5386,7 +5391,7 @@
                       (list (list obj rep)
                         (build-primcall 3 '$install-guardian
                           (list (build-ref obj) (build-ref rep) ref-tc ordered?-bool))))))))
-      
+
         (define-inline 2 make-guardian
           [() (build-make-guardian '() false-rec ctxt empty-env sc wd name moi)]
           [(?ordered?)

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -659,7 +659,7 @@
               (let ([seqno next-lambda-seqno])
                 (set! next-lambda-seqno (fx+ seqno 1))
                 seqno))))
-    
+
     (include "np-info.ss")
 
     (module ()
@@ -791,7 +791,12 @@
               [(string? x) x]
               [(symbol? x)
                (let ([name ($symbol-name x)])
-                 (if (pair? name) (or (cdr name) (car name)) name))]
+                 (if (pair? name)
+                     (if (eq? #t (cdr name))
+                         (car name)
+                         (or (cdr name) (car name)))
+                     (and (not (eq? name #t))
+                          name)))]
               [(eq? #f x) #f]
               [else (error 'np-discover-names "x is not a name" x)]))))
       (Expr : Expr (ir name moi) -> Expr ()
@@ -5203,7 +5208,7 @@
                                ,(if (not reify?)
                                     `(set! ,lvalue ,t)
                                     (%seq
-                                     (set! ,lvalue ,t) 
+                                     (set! ,lvalue ,t)
                                      (set! ,%td (inline ,(intrinsic-info-asmlib reify-1cc #f) ,%asmlibcall))))
                                ;; Reified with attachment
                                ,(let ([get `(set! ,lvalue ,(%mref ,ats ,(constant pair-car-disp)))])
@@ -8501,7 +8506,7 @@
               (fx- offset (fx- (constant size-rp-header)
                                (constant size-rp-compact-header)))
               offset)))
-      
+
       (define asm-data-label
         (lambda (code* l offset func code-size)
           (let ([rel (make-funcrel 'abs l offset)])

--- a/s/cpprim.ss
+++ b/s/cpprim.ss
@@ -8282,6 +8282,15 @@
       [(e-sym)
        (bind #t (e-sym)
          (bind #t ([e-name (%mref ,e-sym ,(constant symbol-name-disp))])
+          ; the symbol name can be of the following forms:
+          ;  - <string>: ordinary symbol
+          ;  - #f: gensym, yet uninterned
+          ;  - #t: generated symbol, yet uninterned
+          ;  - (<string> . #f): uninterned symbol
+          ;  - (#f . <pname>): gensym with pretty name, yet uninterned
+          ;  - (#t . <pname>): generated symbol with pretty name, yet uninterned
+          ;  - (<uname> . <pname>): gensym, interned
+          ;  - (<uname> . #t): generated symbol, interned
            `(if ,e-name
                 (if ,(%type-check mask-pair type-pair ,e-name)
                     ,(bind #t ([e-car (%mref ,e-name ,(constant pair-car-disp))]

--- a/s/cpprim.ss
+++ b/s/cpprim.ss
@@ -8285,7 +8285,9 @@
                        `(if ,e-cdr
                             ,e-cdr
                             ,(%mref ,e-name ,(constant pair-car-disp))))
-                    ,e-name)
+                    (if ,(%inline eq? ,e-name ,(%constant strue))
+                        ,(%primcall #f sexpr $generated-symbol->name ,e-sym)
+                        ,e-name))
                 ,(%primcall #f sexpr $gensym->pretty-name ,e-sym))))])
     (define-inline 3 $fxaddress
       [(e) (%inline logand

--- a/s/cpprim.ss
+++ b/s/cpprim.ss
@@ -8199,10 +8199,10 @@
            (bind #t ([t (%mref ,e ,(constant symbol-name-disp))])
              `(if ,t
                   ,(build-and (%type-check mask-pair type-pair ,t)
-                     (bind #t ([t2 (%mref ,t ,(constant pair-cdr-disp))])
-                       (build-and t2
+                     (bind #t ([e-cdr (%mref ,t ,(constant pair-cdr-disp))])
+                       (build-and e-cdr
                          (build-and
-                           (build-not (%inline eq? ,t2 ,(%constant strue)))
+                           (build-not (%inline eq? ,e-cdr ,(%constant strue)))
                            (build-not (%inline eq? ,(%mref ,t ,(constant pair-car-disp)) ,(%constant strue)))))))
                   ,(%constant strue)))))])
     (define-inline 2 uninterned-symbol?
@@ -8284,9 +8284,14 @@
          (bind #t ([e-name (%mref ,e-sym ,(constant symbol-name-disp))])
            `(if ,e-name
                 (if ,(%type-check mask-pair type-pair ,e-name)
-                    ,(bind #t ([e-cdr (%mref ,e-name ,(constant pair-cdr-disp))])
+                    ,(bind #t ([e-car (%mref ,e-name ,(constant pair-car-disp))]
+                               [e-cdr (%mref ,e-name ,(constant pair-cdr-disp))])
                        `(if ,e-cdr
-                            ,e-cdr
+                            (if ,(%inline eq? ,e-cdr ,(%constant strue))
+                                ,e-car
+                                (if ,(%inline eq? ,e-car ,(%constant strue))
+                                    ,(%primcall #f sexpr $generated-symbol->name ,e-sym)
+                                    ,e-cdr))
                             ,(%mref ,e-name ,(constant pair-car-disp))))
                     (if ,(%inline eq? ,e-name ,(%constant strue))
                         ,(%primcall #f sexpr $generated-symbol->name ,e-sym)

--- a/s/cpprim.ss
+++ b/s/cpprim.ss
@@ -8199,8 +8199,11 @@
            (bind #t ([t (%mref ,e ,(constant symbol-name-disp))])
              `(if ,t
                   ,(build-and (%type-check mask-pair type-pair ,t)
-                              (build-and (%mref ,t ,(constant pair-cdr-disp))
-                                         (%constant strue)))
+                     (bind #t ([t2 (%mref ,t ,(constant pair-cdr-disp))])
+                       (build-and t2
+                         (build-and
+                           (build-not (%inline eq? ,t2 ,(%constant strue)))
+                           (build-not (%inline eq? ,(%mref ,t ,(constant pair-car-disp)) ,(%constant strue)))))))
                   ,(%constant strue)))))])
     (define-inline 2 uninterned-symbol?
       [(e)

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -2217,6 +2217,7 @@
   ($gc-real-time [flags true])
   ($generation [flags single-valued])
   ($generate-symbol [sig [() (immutable-string) -> (symbol)]] [flags alloc]) ; needs immutable strings
+  ($generated-symbol->name [flags single-valued])
   ($gensym [sig [() (immutable-string) (immutable-string immutable-string) -> (gensym)]] [flags alloc]) ; needs immutable strings
   ($gensym->pretty-name [flags single-valued])
   ($get-timer [flags single-valued])

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -297,7 +297,7 @@
   (map [sig [(procedure list list ...) -> (list)]] [flags cp02 cp03 ieee r5rs true])
   (for-each [sig [(procedure list list ...) -> (ptr ...)]] [flags cp02 cp03 ieee r5rs])
   (symbol? [sig [(ptr) -> (boolean)]] [pred symbol] [flags pure unrestricted mifoldable discard ieee r5rs])
-  (symbol->string [sig [(symbol) -> (string)]] [flags true mifoldable discard safeongoodargs ieee r5rs])
+  (symbol->string [sig [(symbol) -> (string)]] [flags true mifoldable safeongoodargs ieee r5rs])
   (symbol=? [sig [(symbol symbol symbol ...) -> (boolean)]] [flags pure mifoldable discard cp03 safeongoodargs])
   (string->symbol [sig [(string) -> (interned-symbol)]] [flags true mifoldable discard safeongoodargs ieee r5rs])
   (char? [sig [(ptr) -> (boolean)]] [pred char] [flags pure unrestricted mifoldable discard ieee r5rs])
@@ -1434,6 +1434,7 @@
   (fxvector-ref [sig [(nonempty-fxvector sub-index) -> (fixnum)]] [flags mifoldable discard cp02])
   (fxvector-set! [sig [(nonempty-fxvector sub-index fixnum) -> (void)]] [flags true])
   (fxvector? [sig [(ptr) -> (boolean)]]  [pred fxvector] [flags pure unrestricted mifoldable discard])
+  (generate-symbol [sig [() (string) -> (symbol)]] [flags alloc safeongoodargs])
   (gensym [sig [() (string) (string string) -> (gensym)]] [flags alloc safeongoodargs])
   (gensym? [sig [(ptr) -> (boolean)]] [pred gensym] [flags pure unrestricted mifoldable discard])
   (gensym->unique-string [sig [(gensym) -> (string)]] [flags true mifoldable]) ; can't discard ... if we have our hands on it, it must be in the oblist after this
@@ -2215,6 +2216,7 @@
   ($gc-cpu-time [flags true])
   ($gc-real-time [flags true])
   ($generation [flags single-valued])
+  ($generate-symbol [sig [() (immutable-string) -> (symbol)]] [flags alloc]) ; needs immutable strings
   ($gensym [sig [() (immutable-string) (immutable-string immutable-string) -> (gensym)]] [flags alloc]) ; needs immutable strings
   ($gensym->pretty-name [flags single-valued])
   ($get-timer [flags single-valued])

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -799,7 +799,7 @@
   (free-identifier=? [sig [(identifier identifier) -> (boolean)]] [flags pure mifoldable discard cp03])
   (syntax->datum [sig [(ptr) -> (ptr)]] [flags pure unrestricted mifoldable discard])
   (datum->syntax [sig [(identifier ptr) -> (syntax)]] [flags pure mifoldable discard true])
-  (generate-temporaries [sig [(ptr) -> (list)]] [flags alloc]) ; the argument can be a list or a syntax with a list or an annotation
+  ((r6rs: generate-temporaries) [sig [(ptr) -> (list)]] [flags alloc]) ; the argument can be a list or a syntax with a list or an annotation
   (syntax-violation [sig [(maybe-who string ptr) (maybe-who string ptr ptr) -> (bottom)]] [flags abort-op])
 )
 
@@ -1435,6 +1435,7 @@
   (fxvector-set! [sig [(nonempty-fxvector sub-index fixnum) -> (void)]] [flags true])
   (fxvector? [sig [(ptr) -> (boolean)]]  [pred fxvector] [flags pure unrestricted mifoldable discard])
   (generate-symbol [sig [() (string) -> (symbol)]] [flags alloc safeongoodargs])
+  (generate-temporaries [sig [(ptr) -> (list)]] [flags alloc]) ; the argument can be a list or a syntax with a list or an annotation
   (gensym [sig [() (string) (string string) -> (gensym)]] [flags alloc safeongoodargs])
   (gensym? [sig [(ptr) -> (boolean)]] [pred gensym] [flags pure unrestricted mifoldable discard])
   (gensym->unique-string [sig [(gensym) -> (string)]] [flags true mifoldable]) ; can't discard ... if we have our hands on it, it must be in the oblist after this

--- a/s/reboot.ss
+++ b/s/reboot.ss
@@ -297,6 +297,7 @@
 
 (define-primitive symbol? (lambda (x) (and (#%symbol? x)
                                            (not (eq? x $the-unbound-object)))))
+(define-primitive generate-symbol gensym)
 (define-primitive gensym? (lambda (x) (and (symbol? x) (#%gensym? x))))
 (define-primitive uninterned-symbol? (lambda (x) #f)) ; assuming not used in compiler
 

--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -7334,6 +7334,28 @@
                                 (f (cdr fast) (cdr slow))
                                 ($oops who "improper list structure ~s" x)))))]
                    [else ($oops who "improper list structure ~s" x)])))]
+            [else ($oops who "improper list structure ~s" x)])))))
+  (set-who! #(r6rs: generate-temporaries)
+    (lambda (x)
+      (define (gen-temp) (wrap (generate-symbol) top-wrap))
+      (let f ([fast x] [slow x])
+        (let ([fast (strip-outer fast)])
+          (cond
+            [(null? fast) '()]
+            [(pair? fast)
+             (cons (gen-temp)
+               (let ([fast (strip-outer (cdr fast))])
+                 (cond
+                   [(null? fast) '()]
+                   [(pair? fast)
+                    (cons (gen-temp)
+                      (let ([slow (strip-outer slow)])
+                        (if (eq? fast slow)
+                            ($oops who "cyclic list structure ~s" x)
+                            (if (pair? slow)
+                                (f (cdr fast) (cdr slow))
+                                ($oops who "improper list structure ~s" x)))))]
+                   [else ($oops who "improper list structure ~s" x)])))]
             [else ($oops who "improper list structure ~s" x)]))))))
 
 (set-who! free-identifier=?


### PR DESCRIPTION
This patch implements the `(generate-symbol [pretty-name])` procedure. As `(gensym)`, it returns a symbol with a lazily generated unique name; however, the resulting symbol is not a gensym but an ordinary symbol.

Such a procedure is useful in situations where it is expected that symbols are identical if and only if their names (as returned by `symbol->string`) are spelled the same.

In particular, this is the case for R6RS code. Strictly speaking, by section 11.10 of the R6RS, gensyms are non-conformant. This patch improves R6RS compatibility by providing an R6RS version of `generate-temporaries` where the symbols are generated by `generate-symbol` and not by `gensym`. Moreover, ordinary symbols have write/read invariance even when only standard lexical syntax is allowed.

For the context of this patch, see also [SRFI 260](https://srfi.schemers.org/srfi-260/srfi-260.html).