### PR TITLE
building with MinGW: link to MSVCRT/UCRT for `pow`, `sin`, and `cos`

### DIFF
--- a/c/build.zuo
+++ b/c/build.zuo
@@ -1,7 +1,8 @@
 #lang zuo
 (require "../makefiles/lib.zuo"
          "../makefiles/version.zuo"
-         "lib.zuo")
+         "lib.zuo"
+         "mingw.zuo")
 
 (provide-targets targets-at)
 
@@ -233,7 +234,7 @@
               ,void
               :recur]
 
-     [:target ,exe (,kernel-dep ,@main-objs ,@res-deps ,@preload-files)
+     [:target ,exe (,kernel-dep ,@main-objs ,@res-deps ,@preload-files ,(at-source "mingw.zuo"))
               ,(lambda (path token)
                  (mkdir-p (path-only path))
                  (c-link path
@@ -242,12 +243,16 @@
                                  (append
                                   (list kernel-dep)
                                   (if zlib-system-lib '() (list zlib-lib))
-                                  (if lz4-system-lib '() (list lz4-lib))))
+                                  (if lz4-system-lib '() (list lz4-lib)))
+                                 (if (and (not msvc?)
+                                          (for-windows? config))
+                                     (make-mingw-to-ms-link-libraries m (at-dir) config)
+                                     '()))
                          (let* ([config (config-merge (add-preloads config preload-files)
                                                       'LDFLAGS
                                                       (or (lookup 'mdlinkflags) ""))]
-				[config (if (and (for-windows? config)
-						 (not (is-msvc? config)))
+				[config (if (and (not msvc?)
+						 (for-windows? config))
 					    (config-merge config
 							  'LDFLAGS
 							  ;; for tests, at least:

--- a/c/mingw.zuo
+++ b/c/mingw.zuo
@@ -1,0 +1,98 @@
+#lang zuo
+
+(provide make-mingw-to-ms-link-libraries)
+
+(define (make-mingw-to-ms-link-libraries m dir config)
+  (cond
+    [(member m '("ta6nt" "a6nt" "ti3nt" "i3nt"))
+     ;; Synthesize a library that links `sin`, `cos` and `pow` to MSVCRT,
+     ;; instead of using MinGW's implementation, because the MSVCRT
+     ;; implementation is more precise
+
+     (define dlls (get-linked-dlls dir config))
+     (define math-dll
+       ;; infer whether toolchain uses MSVCRT or UCRT
+       (ormap (lambda (s)
+                (cond
+                  [(string=? s "msvcrt.dll") s]
+                  [(glob-match? "*ms-win-crt-math*" s) s]
+                  [else #f]))
+              dlls))
+
+     (cond
+       [(not math-dll)
+        (alert "could not find DLL likely to export `pow`, etc.")
+        '()]
+       [else
+        (define dlltool (find-cc-like-tool config 'DLLTOOL "dlltool"))
+
+        (define msfuns-def (build-path dir "msfuns.def"))
+        (define out (fd-open-output msfuns-def :truncate))
+        (fd-write out (~a "LIBRARY " (path-replace-extension math-dll "") "\n"
+                          "EXPORTS\n"
+                          "  sin\n"
+                          "  cos\n"
+                          "  pow\n"))
+        (fd-close out)
+
+        (define msfuns-a (path-replace-extension msfuns-def ".a"))
+
+        (define proc (hash-ref
+                      (shell dlltool "-d" msfuns-def "-l" msfuns-a)
+                      'process))
+
+        (process-wait proc)
+        (or (and (equal? 0 (process-status proc))
+                 (list msfuns-a))
+            '())])]
+    [else '()]))
+
+(define (get-linked-dlls dir config)
+  (define tmp-c (build-path dir "math_tmp.c"))
+  (define out (fd-open-output tmp-c :truncate))
+  (fd-write out (~a "#include <math.h>\n"
+                    "int main() { return pow(1.0, 2.0) > 0.0; }\n"))
+  (fd-close out)
+
+  (define tmp-o (path-replace-extension tmp-c ".obj"))
+  (c-compile tmp-o tmp-c config)
+
+  (define tmp-exe (path-replace-extension tmp-c ".exe"))
+  (c-compile tmp-exe (list tmp-o) config)
+
+  (define objdump (find-cc-like-tool config 'OBJDUMP "objdump"))
+  (define p (shell objdump "-p" tmp-exe (hash 'stdout 'pipe)))
+  (define proc (hash-ref p 'process))
+  (define in (fd-read (hash-ref p 'stdout) eof))
+
+  (define ins (string-split (string-join (string-split in "\r") "")
+			    "\n"))
+
+  (process-wait proc)
+
+  (define dlls
+    (filter (lambda (v) v)
+            (map (lambda (s)
+                   (cond
+                     [(glob-match? "*DLL Name: *" s)
+                      (define l (string-split s "DLL Name: "))
+                      (and (= (length l) 2) (cadr l))]
+                     [else #f]))
+                 ins)))
+
+  (rm tmp-exe)
+  (rm tmp-o)
+  (rm tmp-c)
+
+  dlls)
+
+(define (find-cc-like-tool config key name)
+  (or (hash-ref config key #f)
+      (let ([cc (hash-ref config 'CC #f)])
+        (cond
+          [(and cc (glob-match? "*gcc" cc))
+           (~a (substring cc 0 (- (string-length cc) 3)) name)]
+          [(and cc (glob-match? "*cc" cc))
+           (~a (substring cc 0 (- (string-length cc) 2)) name)]
+          [else
+           name]))))

--- a/c/prim5.c
+++ b/c/prim5.c
@@ -1472,25 +1472,20 @@ static double s_pow(double x, double y) { return pow(x, y); }
 #endif /* i3fb/ti3fb */
 
 #ifdef __MINGW32__
-/* cos() and sin() do not handle large values nicely,
-   so use fmod() to get reasonably close */
-# define INTO_SINCOS_RANGE(x) (((x > 1e9) || (x < -1e9)) \
-			       ? fmod(x, 2*atan2(0.0, -1.0)) \
-			       : x)
 /* asinh() and atanh() sometimes get zero sign wrong */
 # define CHECK_ASINTAN_ZERO(x, e) ((x == 0.0) \
                                    ? (signbit(x) ? -0.0 : 0.0)  \
                                    : e)
+/* see also "mingw.zuo" */
 #else
-# define INTO_SINCOS_RANGE(x) x
 # define CHECK_ASINTAN_ZERO(x, e) e
 #endif
 
 static double s_sqrt(double x) { return sqrt(x); }
 
-static double s_sin(double x) { return sin(INTO_SINCOS_RANGE(x)); }
+static double s_sin(double x) { return sin(x); }
 
-static double s_cos(double x) { return cos(INTO_SINCOS_RANGE(x)); }
+static double s_cos(double x) { return cos(x); }
 
 static double s_tan(double x) { return tan(x); }
 

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2840,6 +2840,13 @@ At optimize-level 3, the source optimizer (cp0) could replace calls to
 \scheme{fxdiv} and \scheme{fxmod} that the back-end would choose not to inline
 because the constant was not a power of two.
 
+\subsection{Link to system libraries for some math functions with MinGW (10.2.0)}
+
+When building with MinGW, the C libraries for i3nt and a6nt implement
+less precise versions of \scheme{pow}, \scheme{sin}, and \scheme{cos},
+so link instead to the MSVCRT or UCRT implementations of those
+functions.
+
 \subsection{Repair executable-relative search for NetBSD (10.2.0)}
 
 An incorrect approach to finding the current executable's path on


### PR DESCRIPTION
The MinGW C library's implementations of `pow`, `sin`, and `cos` have precision issues on i386 and amd64. The MSVCRT and UCRT implementations are good (I think the MSVCRT ones may have been worse 10-15 years ago), and the build links to those, anyway, so adjust linking to use `pow`, `sin`, and `cos`  from MSVCRT/UCRT when building with MinGW. There's no issue with AArch64.

Thanks to @bdeket for tracking down these issues.

Background: https://github.com/racket/racket/issues/5191, https://github.com/racket/racket/pull/5211