### PR TITLE
Fix comment on ARM register r18

### DIFF
--- a/s/arm64.ss
+++ b/s/arm64.ss
@@ -5,8 +5,8 @@
 ;;;  Register usage:
 ;;;   r0-r7: C argument/result registers, caller-save
 ;;;   r8: indirect-result register, caller-save
-;;;   r9-18: caller-save
-;;;   r19-28: callee-save
+;;;   r9-17: caller-save
+;;;   r18-28: callee-save
 ;;;   r29: frame pointer, callee-save
 ;;;   r30: a.k.a. lr, link register
 ;;;   sp: stack pointer or (same register number) zero register


### PR DESCRIPTION
The comment said r18 is `caller-save` but the Apple docs says register r18 is a callee-save one. The exact words are [1]:

> The platforms reserve register x18. Don’t use this register.

The Arm docs [2] call  r18 (x18) a platform register. I interpret this as the each platform ABI can decide how to use it on their own. That is, Apple's restriction follows the Arm spec.

Digging a little more: Apple uses r18 for Rosetta. 

Since register r18 is missing from the `define-registers` form, it isn't in use. Potentially, `r18` could be used on Linux.

[1]
https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms [2]
https://developer.arm.com/documentation/102374/0102/Procedure-Call-Standard