### PR TITLE
change `TARGET_OS_IPHONE` preprocessor handling

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -568,7 +568,8 @@ To cross compile for iOS, provide an iOS SDK path and define the
  ./configure \
    --cross \
    -m=tarm64ios \
-   CFLAGS="-arch arm64 -isysroot $(xcrun -sdk iphoneos --show-sdk-path) -DTARGET_OS_IPHONE -DDISABLE_CURSES -liconv" \
+   CFLAGS="-arch arm64 -isysroot $(xcrun -sdk iphoneos --show-sdk-path) -DTARGET_OS_IPHONE=1 -DDISABLE_CURSES" \
+   LDFLAGS="-liconv" \
    CC_FOR_BUILD=clang
  make
 

--- a/c/clearcache.c
+++ b/c/clearcache.c
@@ -22,7 +22,7 @@
 #include <sys/types.h>
 #include <sys/mman.h>
 
-#ifdef TARGET_OS_IPHONE
+#ifdef S_TARGET_OS_IPHONE
 # include <libkern/OSCacheControl.h>
 #endif
 
@@ -42,7 +42,7 @@ void S_doflush(uptr start, uptr end) {
   printf("  doflush(%x, %x)\n", start, end); fflush(stdout);
 #endif
 
-#ifdef TARGET_OS_IPHONE
+#ifdef S_TARGET_OS_IPHONE
   sys_icache_invalidate((void *)start, (char *)end-(char *)start);
 #else
   __clear_cache((char *)start, (char *)end);

--- a/c/version.h
+++ b/c/version.h
@@ -311,9 +311,10 @@ typedef int tputsputcchar;
 #define MMAP_HEAP
 #define IEEE_DOUBLE
 /* for both iPhone and iPhoneSimulator */
-#if defined(TARGET_OS_IPHONE)
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 # define SYSTEM(s) ((void)s, -1)
 # define WRITE_XOR_EXECUTE_CODE
+# define S_TARGET_OS_IPHONE
 #endif
 #if defined(__arm64__)
 # if !defined(WRITE_XOR_EXECUTE_CODE)


### PR DESCRIPTION
Recent versions of the build tools on macOS define `TARGET_OS_IPHONE` as 0 when not compiling for iOS.

Closes #896 and #928