### PR TITLE
Simpified lookup of property values

### DIFF
--- a/boot/pb/equates.h
+++ b/boot/pb/equates.h
@@ -1062,7 +1062,7 @@ typedef uint64_t U64;
 #define size_rp_header 0x20
 #define size_rtd_counts 0x810
 #define size_symbol 0x30
-#define size_tc 0x7D0
+#define size_tc 0x7E0
 #define size_thread 0x10
 #define size_tlc 0x20
 #define size_typed_object 0x10
@@ -1117,8 +1117,8 @@ typedef uint64_t U64;
 #define symbol_pvalue_disp 0xD
 #define symbol_splist_disp 0x25
 #define symbol_value_disp 0x5
-#define tc_DSTBV_disp 0x2B8
-#define tc_SRCBV_disp 0x2C0
+#define tc_DSTBV_disp 0x2C0
+#define tc_SRCBV_disp 0x2C8
 #define tc_U_disp 0x190
 #define tc_V_disp 0x198
 #define tc_W_disp 0x1A0
@@ -1127,7 +1127,7 @@ typedef uint64_t U64;
 #define tc_ac0_disp 0x38
 #define tc_ac1_disp 0x40
 #define tc_active_disp 0x14C
-#define tc_alloc_counter_disp 0x2A8
+#define tc_alloc_counter_disp 0x2B0
 #define tc_ap_disp 0x60
 #define tc_arg_regs_disp 0x0
 #define tc_attachments_disp 0x178
@@ -1135,37 +1135,38 @@ typedef uint64_t U64;
 #define tc_cached_frame_disp 0x188
 #define tc_cchain_disp 0x138
 #define tc_code_ranges_to_flush_disp 0x140
-#define tc_compile_profile_disp 0x240
-#define tc_compress_format_disp 0x288
-#define tc_compress_level_disp 0x290
+#define tc_compile_profile_disp 0x248
+#define tc_compress_format_disp 0x290
+#define tc_compress_level_disp 0x298
 #define tc_cp_disp 0x50
 #define tc_current_error_disp 0x200
 #define tc_current_input_disp 0x1F0
 #define tc_current_mso_disp 0x218
 #define tc_current_output_disp 0x1F8
-#define tc_default_record_equal_procedure_disp 0x278
-#define tc_default_record_hash_procedure_disp 0x280
+#define tc_default_record_equal_procedure_disp 0x280
+#define tc_default_record_hash_procedure_disp 0x288
 #define tc_disable_count_disp 0x1C8
 #define tc_eap_disp 0x68
 #define tc_esp_disp 0x58
-#define tc_fpregs_disp 0x2C8
+#define tc_expand_time_environment_disp 0x240
+#define tc_fpregs_disp 0x2D0
 #define tc_fxfirst_bit_set_bv_disp 0x230
 #define tc_fxlength_bv_disp 0x228
-#define tc_gc_data_disp 0x7C8
-#define tc_generate_inspector_information_disp 0x248
-#define tc_generate_procedure_source_information_disp 0x250
-#define tc_generate_profile_forms_disp 0x258
+#define tc_gc_data_disp 0x7D0
+#define tc_generate_inspector_information_disp 0x250
+#define tc_generate_procedure_source_information_disp 0x258
+#define tc_generate_profile_forms_disp 0x260
 #define tc_guardian_entries_disp 0x130
 #define tc_handler_stack_disp 0x180
-#define tc_instr_counter_disp 0x2A0
+#define tc_instr_counter_disp 0x2A8
 #define tc_keyboard_interrupt_pending_disp 0x1E0
-#define tc_lz4_out_buffer_disp 0x298
+#define tc_lz4_out_buffer_disp 0x2A0
 #define tc_meta_level_disp 0x238
-#define tc_optimize_level_disp 0x260
-#define tc_parameters_disp 0x2B0
-#define tc_pb_call_arena_disp 0x3C8
-#define tc_pb_fpregs_disp 0x388
-#define tc_pb_regs_disp 0x308
+#define tc_optimize_level_disp 0x268
+#define tc_parameters_disp 0x2B8
+#define tc_pb_call_arena_disp 0x3D0
+#define tc_pb_fpregs_disp 0x390
+#define tc_pb_regs_disp 0x310
 #define tc_random_seed_disp 0x148
 #define tc_real_eap_disp 0xA0
 #define tc_ret_disp 0x70
@@ -1179,8 +1180,8 @@ typedef uint64_t U64;
 #define tc_something_pending_disp 0x1B8
 #define tc_stack_cache_disp 0x158
 #define tc_stack_link_disp 0x160
-#define tc_subset_mode_disp 0x268
-#define tc_suppress_primitive_inlining_disp 0x270
+#define tc_subset_mode_disp 0x270
+#define tc_suppress_primitive_inlining_disp 0x278
 #define tc_target_machine_disp 0x220
 #define tc_td_disp 0x98
 #define tc_threadno_disp 0x1E8
@@ -1569,8 +1570,8 @@ typedef uint64_t U64;
 #define THREADTC(x) (*((uptr *)TO_VOIDP((uptr)(x)+9)))
 
 /* thread-context data */
-#define DSTBV(x) (*((ptr *)TO_VOIDP((uptr)(x)+696)))
-#define SRCBV(x) (*((ptr *)TO_VOIDP((uptr)(x)+704)))
+#define DSTBV(x) (*((ptr *)TO_VOIDP((uptr)(x)+704)))
+#define SRCBV(x) (*((ptr *)TO_VOIDP((uptr)(x)+712)))
 #define U(x) (*((ptr *)TO_VOIDP((uptr)(x)+400)))
 #define V(x) (*((ptr *)TO_VOIDP((uptr)(x)+408)))
 #define W(x) (*((ptr *)TO_VOIDP((uptr)(x)+416)))
@@ -1579,7 +1580,7 @@ typedef uint64_t U64;
 #define AC0(x) (*((xptr *)TO_VOIDP((uptr)(x)+56)))
 #define AC1(x) (*((xptr *)TO_VOIDP((uptr)(x)+64)))
 #define ACTIVE(x) (*((I32 *)TO_VOIDP((uptr)(x)+332)))
-#define ALLOCCOUNTER(x) (*((U64 *)TO_VOIDP((uptr)(x)+680)))
+#define ALLOCCOUNTER(x) (*((U64 *)TO_VOIDP((uptr)(x)+688)))
 #define AP(x) (*((xptr *)TO_VOIDP((uptr)(x)+96)))
 #define ARGREGS(x,i) (((xptr *)TO_VOIDP((uptr)(x)+0))[i])
 #define ATTACHMENTS(x) (*((ptr *)TO_VOIDP((uptr)(x)+376)))
@@ -1587,37 +1588,38 @@ typedef uint64_t U64;
 #define CACHEDFRAME(x) (*((ptr *)TO_VOIDP((uptr)(x)+392)))
 #define CCHAIN(x) (*((ptr *)TO_VOIDP((uptr)(x)+312)))
 #define CODERANGESTOFLUSH(x) (*((ptr *)TO_VOIDP((uptr)(x)+320)))
-#define COMPILEPROFILE(x) (*((ptr *)TO_VOIDP((uptr)(x)+576)))
-#define COMPRESSFORMAT(x) (*((ptr *)TO_VOIDP((uptr)(x)+648)))
-#define COMPRESSLEVEL(x) (*((ptr *)TO_VOIDP((uptr)(x)+656)))
+#define COMPILEPROFILE(x) (*((ptr *)TO_VOIDP((uptr)(x)+584)))
+#define COMPRESSFORMAT(x) (*((ptr *)TO_VOIDP((uptr)(x)+656)))
+#define COMPRESSLEVEL(x) (*((ptr *)TO_VOIDP((uptr)(x)+664)))
 #define CP(x) (*((xptr *)TO_VOIDP((uptr)(x)+80)))
 #define CURRENTERROR(x) (*((ptr *)TO_VOIDP((uptr)(x)+512)))
 #define CURRENTINPUT(x) (*((ptr *)TO_VOIDP((uptr)(x)+496)))
 #define CURRENTMSO(x) (*((ptr *)TO_VOIDP((uptr)(x)+536)))
 #define CURRENTOUTPUT(x) (*((ptr *)TO_VOIDP((uptr)(x)+504)))
-#define DEFAULTRECORDEQUALPROCEDURE(x) (*((ptr *)TO_VOIDP((uptr)(x)+632)))
-#define DEFAULTRECORDHASHPROCEDURE(x) (*((ptr *)TO_VOIDP((uptr)(x)+640)))
+#define DEFAULTRECORDEQUALPROCEDURE(x) (*((ptr *)TO_VOIDP((uptr)(x)+640)))
+#define DEFAULTRECORDHASHPROCEDURE(x) (*((ptr *)TO_VOIDP((uptr)(x)+648)))
 #define DISABLECOUNT(x) (*((ptr *)TO_VOIDP((uptr)(x)+456)))
 #define EAP(x) (*((xptr *)TO_VOIDP((uptr)(x)+104)))
 #define ESP(x) (*((xptr *)TO_VOIDP((uptr)(x)+88)))
-#define FPREGS(x,i) (((double *)TO_VOIDP((uptr)(x)+712))[i])
+#define EXPANDTIMEENVIRONMENT(x) (*((ptr *)TO_VOIDP((uptr)(x)+576)))
+#define FPREGS(x,i) (((double *)TO_VOIDP((uptr)(x)+720))[i])
 #define FXFIRSTBITSETBV(x) (*((ptr *)TO_VOIDP((uptr)(x)+560)))
 #define FXLENGTHBV(x) (*((ptr *)TO_VOIDP((uptr)(x)+552)))
-#define GCDATA(x) (*((xptr *)TO_VOIDP((uptr)(x)+1992)))
-#define GENERATEINSPECTORINFORMATION(x) (*((ptr *)TO_VOIDP((uptr)(x)+584)))
-#define GENERATEPROCEDURESOURCEINFORMATION(x) (*((ptr *)TO_VOIDP((uptr)(x)+592)))
-#define GENERATEPROFILEFORMS(x) (*((ptr *)TO_VOIDP((uptr)(x)+600)))
+#define GCDATA(x) (*((xptr *)TO_VOIDP((uptr)(x)+2000)))
+#define GENERATEINSPECTORINFORMATION(x) (*((ptr *)TO_VOIDP((uptr)(x)+592)))
+#define GENERATEPROCEDURESOURCEINFORMATION(x) (*((ptr *)TO_VOIDP((uptr)(x)+600)))
+#define GENERATEPROFILEFORMS(x) (*((ptr *)TO_VOIDP((uptr)(x)+608)))
 #define GUARDIANENTRIES(x) (*((ptr *)TO_VOIDP((uptr)(x)+304)))
 #define HANDLERSTACK(x) (*((ptr *)TO_VOIDP((uptr)(x)+384)))
-#define INSTRCOUNTER(x) (*((U64 *)TO_VOIDP((uptr)(x)+672)))
+#define INSTRCOUNTER(x) (*((U64 *)TO_VOIDP((uptr)(x)+680)))
 #define KEYBOARDINTERRUPTPENDING(x) (*((ptr *)TO_VOIDP((uptr)(x)+480)))
-#define LZ4OUTBUFFER(x) (*((xptr *)TO_VOIDP((uptr)(x)+664)))
+#define LZ4OUTBUFFER(x) (*((xptr *)TO_VOIDP((uptr)(x)+672)))
 #define METALEVEL(x) (*((ptr *)TO_VOIDP((uptr)(x)+568)))
-#define OPTIMIZELEVEL(x) (*((ptr *)TO_VOIDP((uptr)(x)+608)))
-#define PARAMETERS(x) (*((ptr *)TO_VOIDP((uptr)(x)+688)))
-#define PBCALLARENA(x,i) (((uptr *)TO_VOIDP((uptr)(x)+968))[i])
-#define PBFPREGS(x,i) (((double *)TO_VOIDP((uptr)(x)+904))[i])
-#define PBREGS(x,i) (((uptr *)TO_VOIDP((uptr)(x)+776))[i])
+#define OPTIMIZELEVEL(x) (*((ptr *)TO_VOIDP((uptr)(x)+616)))
+#define PARAMETERS(x) (*((ptr *)TO_VOIDP((uptr)(x)+696)))
+#define PBCALLARENA(x,i) (((uptr *)TO_VOIDP((uptr)(x)+976))[i])
+#define PBFPREGS(x,i) (((double *)TO_VOIDP((uptr)(x)+912))[i])
+#define PBREGS(x,i) (((uptr *)TO_VOIDP((uptr)(x)+784))[i])
 #define RANDOMSEED(x) (*((U32 *)TO_VOIDP((uptr)(x)+328)))
 #define REAL_EAP(x) (*((xptr *)TO_VOIDP((uptr)(x)+160)))
 #define RET(x) (*((xptr *)TO_VOIDP((uptr)(x)+112)))
@@ -1631,8 +1633,8 @@ typedef uint64_t U64;
 #define SOMETHINGPENDING(x) (*((ptr *)TO_VOIDP((uptr)(x)+440)))
 #define STACKCACHE(x) (*((ptr *)TO_VOIDP((uptr)(x)+344)))
 #define STACKLINK(x) (*((ptr *)TO_VOIDP((uptr)(x)+352)))
-#define SUBSETMODE(x) (*((ptr *)TO_VOIDP((uptr)(x)+616)))
-#define SUPPRESSPRIMITIVEINLINING(x) (*((ptr *)TO_VOIDP((uptr)(x)+624)))
+#define SUBSETMODE(x) (*((ptr *)TO_VOIDP((uptr)(x)+624)))
+#define SUPPRESSPRIMITIVEINLINING(x) (*((ptr *)TO_VOIDP((uptr)(x)+632)))
 #define TARGETMACHINE(x) (*((ptr *)TO_VOIDP((uptr)(x)+544)))
 #define TD(x) (*((xptr *)TO_VOIDP((uptr)(x)+152)))
 #define THREADNO(x) (*((ptr *)TO_VOIDP((uptr)(x)+488)))

--- a/boot/pb/gc-ocd.inc
+++ b/boot/pb/gc-ocd.inc
@@ -836,6 +836,7 @@ static void sweep(thread_gc *tgc, ptr p, IGEN from_g)
             relocate_pure(&(WINDERS(tc)));
             relocate_pure(&(ATTACHMENTS(tc)));
             relocate_pure(&(HANDLERSTACK(tc)));
+            relocate_pure(&(EXPANDTIMEENVIRONMENT(tc)));
             CACHEDFRAME(tc) = Sfalse;
             {
               ptr xcp = FRAME(tc, 0);
@@ -1471,6 +1472,7 @@ static void sweep_object_in_old(thread_gc *tgc, ptr p)
             relocate_pure(&(WINDERS(tc)));
             relocate_pure(&(ATTACHMENTS(tc)));
             relocate_pure(&(HANDLERSTACK(tc)));
+            relocate_pure(&(EXPANDTIMEENVIRONMENT(tc)));
             {
               ptr xcp = FRAME(tc, 0);
               {
@@ -2315,6 +2317,7 @@ static void sweep_thread(thread_gc *tgc, ptr p)
         relocate_pure(&(WINDERS(tc)));
         relocate_pure(&(ATTACHMENTS(tc)));
         relocate_pure(&(HANDLERSTACK(tc)));
+        relocate_pure(&(EXPANDTIMEENVIRONMENT(tc)));
         CACHEDFRAME(tc) = Sfalse;
         {
           ptr xcp = FRAME(tc, 0);

--- a/boot/pb/gc-oce.inc
+++ b/boot/pb/gc-oce.inc
@@ -958,6 +958,7 @@ static void sweep(thread_gc *tgc, ptr p, IGEN from_g)
             relocate_pure(&(WINDERS(tc)));
             relocate_pure(&(ATTACHMENTS(tc)));
             relocate_pure(&(HANDLERSTACK(tc)));
+            relocate_pure(&(EXPANDTIMEENVIRONMENT(tc)));
             CACHEDFRAME(tc) = Sfalse;
             {
               ptr xcp = FRAME(tc, 0);
@@ -1594,6 +1595,7 @@ static void sweep_object_in_old(thread_gc *tgc, ptr p)
             relocate_pure(&(WINDERS(tc)));
             relocate_pure(&(ATTACHMENTS(tc)));
             relocate_pure(&(HANDLERSTACK(tc)));
+            relocate_pure(&(EXPANDTIMEENVIRONMENT(tc)));
             {
               ptr xcp = FRAME(tc, 0);
               {
@@ -2449,6 +2451,7 @@ static void sweep_thread(thread_gc *tgc, ptr p)
         relocate_pure(&(WINDERS(tc)));
         relocate_pure(&(ATTACHMENTS(tc)));
         relocate_pure(&(HANDLERSTACK(tc)));
+        relocate_pure(&(EXPANDTIMEENVIRONMENT(tc)));
         CACHEDFRAME(tc) = Sfalse;
         {
           ptr xcp = FRAME(tc, 0);
@@ -4559,6 +4562,11 @@ static void measure(thread_gc *tgc, ptr p)
           }
           { /* measure */
             ptr r_p = HANDLERSTACK(tc);
+            if (!FIXMEDIATE(r_p))
+              push_measure(tgc, r_p);
+          }
+          { /* measure */
+            ptr r_p = EXPANDTIMEENVIRONMENT(tc);
             if (!FIXMEDIATE(r_p))
               push_measure(tgc, r_p);
           }

--- a/boot/pb/gc-par.inc
+++ b/boot/pb/gc-par.inc
@@ -830,6 +830,7 @@ static void sweep(thread_gc *tgc, ptr p, IGEN from_g)
             relocate_pure(&(WINDERS(tc)));
             relocate_pure(&(ATTACHMENTS(tc)));
             relocate_pure(&(HANDLERSTACK(tc)));
+            relocate_pure(&(EXPANDTIMEENVIRONMENT(tc)));
             CACHEDFRAME(tc) = Sfalse;
             {
               ptr xcp = FRAME(tc, 0);
@@ -1475,6 +1476,7 @@ static void sweep_object_in_old(thread_gc *tgc, ptr p)
             relocate_pure(&(WINDERS(tc)));
             relocate_pure(&(ATTACHMENTS(tc)));
             relocate_pure(&(HANDLERSTACK(tc)));
+            relocate_pure(&(EXPANDTIMEENVIRONMENT(tc)));
             {
               ptr xcp = FRAME(tc, 0);
               {
@@ -2358,6 +2360,7 @@ static void sweep_thread(thread_gc *tgc, ptr p)
         relocate_pure(&(WINDERS(tc)));
         relocate_pure(&(ATTACHMENTS(tc)));
         relocate_pure(&(HANDLERSTACK(tc)));
+        relocate_pure(&(EXPANDTIMEENVIRONMENT(tc)));
         CACHEDFRAME(tc) = Sfalse;
         {
           ptr xcp = FRAME(tc, 0);

--- a/boot/pb/heapcheck.inc
+++ b/boot/pb/heapcheck.inc
@@ -247,6 +247,7 @@ static void check_object(ptr p, uptr seg, ISPC s_in, IBOOL aftergc)
           check_pointer(&(WINDERS(tc)), 1, 0, p, seg, s_in, aftergc);
           check_pointer(&(ATTACHMENTS(tc)), 1, 0, p, seg, s_in, aftergc);
           check_pointer(&(HANDLERSTACK(tc)), 1, 0, p, seg, s_in, aftergc);
+          check_pointer(&(EXPANDTIMEENVIRONMENT(tc)), 1, 0, p, seg, s_in, aftergc);
           {
             ptr xcp = FRAME(tc, 0);
             {

--- a/c/thread.c
+++ b/c/thread.c
@@ -1,12 +1,12 @@
 /* thread.c
  * Copyright 1984-2017 Cisco Systems, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -111,7 +111,7 @@ ptr S_create_thread_object(const char *who, ptr p_tc) {
 
     for (i = 0; i < n; i += 1)
       INITVECTIT(v, i) = Svector_ref(p_v, i);
-    
+
     PARAMETERS(tc) = v;
     CODERANGESTOFLUSH(tc) = Snil;
   }
@@ -181,6 +181,8 @@ ptr S_create_thread_object(const char *who, ptr p_tc) {
   /* if a collection is needed, then ask the new thread to check right away */
   if (Sboolean_value(S_symbol_value(S_G.collect_request_pending_id)))
     TRAP(tc) = (ptr)1;
+
+  EXPANDTIMEENVIRONMENT(tc) = Sfalse;
 
   tc_mutex_release();
 
@@ -316,7 +318,7 @@ static IBOOL destroy_thread(ptr tc) {
       free_thread_gcs = THREAD_GC(tc);
 
       free(TO_VOIDP(tc));
-      
+
       THREADTC(thread) = 0; /* mark it dead */
       status = 1;
 

--- a/csug/syntax.stex
+++ b/csug/syntax.stex
@@ -574,6 +574,9 @@ With two arguments, \var{id} and \var{key}, \var{lookup} returns the
 value of  \var{id}'s \var{key} property, or \scheme{#f} if \var{id}
 has no \var{key} property.
 
+However, in the case of properties, there is a second, usually easier
+way, to obtain property values, namely by calling the
+\scheme{property-value} procedure described below.
 
 %----------------------------------------------------------------------------
 \entryheader
@@ -709,6 +712,27 @@ Attaching a new property with the same name as an property already
 attached to a binding shadows the existing property with the new
 property.
 
+%----------------------------------------------------------------------------
+\entryheader
+\formdef{property-value}{\categoryprocedure}{(property-value \var{identifier} \var{key-identifier})}
+\formdef{property-value}{\categoryprocedure}{(property-value \var{identifier} \var{key-identifier} \var{default})}
+\returns see below
+\listlibraries
+\endentryheader
+
+If \scheme{property-value} is not called within the dynamic extent of
+the expander's call to a macro transformer, an exception with
+condition type \scheme{&assertion} is raised.  Otherwise,
+\scheme{property-value} returns the value of the \var{key-identifier}
+property of \var{identifier} in the lexical environment of the macro
+use.  If \var{identifier} has no \var{key-identifier} property,
+\var{default} is returned.  If omitted, \var{default} defaults to
+\scheme{#f}.
+
+If \var{identifier} or \var{key-identifier} have no visible binding in
+the lexical environment of the macro use, an exception with condition
+type \scheme{&undefined} is raised.
+
 The following example defines a macro, \scheme{get-info}, that retrieves
 the \scheme{info} property of a binding, defines the variable \scheme{x},
 attaches an \scheme{info} property to the binding of \scheme{x}, retrieves
@@ -721,11 +745,10 @@ properties are shadowed as well as the outer binding of \scheme{x}.
 (define info)
 (define-syntax get-info
   (lambda (x)
-    (lambda (lookup)
-      (syntax-case x ()
-        [(_ q)
-         (let ([info-value (lookup #'q #'info)])
-           #`'#,(datum->syntax #'* info-value))]))))
+    (syntax-case x ()
+      [(_ q)
+       (let ([info-value (property-value #'q #'info)])
+         #`'#,(datum->syntax #'* info-value))])))
 (define x "x-value")
 (define-property x info "x-info")
 (get-info x) ;=> "x-info"
@@ -741,10 +764,9 @@ just that.
 \schemedisplay
 (define-syntax get-property
   (lambda (x)
-    (lambda (r)
-      (syntax-case x ()
-        [(_ id key)
-         #`'#,(datum->syntax #'* (r #'id #'key))]))))
+    (syntax-case x ()
+      [(_ id key)
+       #`'#,(datum->syntax #'* (property-value #'id #'key))])))
 (get-property x info) ;=> "x-info"
 \endschemedisplay
 
@@ -810,11 +832,10 @@ cannot be accessed or forged.
          (do-drt #'rname #'(fname ...) #f)]
         [(_ rname pname (fname ...))
          (for-all identifier? #'(rname pname fname ...))
-         (lambda (lookup)
-           (let ([prtd (lookup #'pname #'drt-key)])
-             (unless prtd
-               (syntax-error #'pname "unrecognized parent record type"))
-             (do-drt #'rname #'(fname ...) prtd)))]))))
+         (let ([prtd (property-value #'pname #'drt-key)])
+           (unless prtd
+             (syntax-error #'pname "unrecognized parent record type"))
+           (do-drt #'rname #'(fname ...) prtd)))])))
 \endschemedisplay
 
 \schemedisplay

--- a/mats/8.ms
+++ b/mats/8.ms
@@ -7373,27 +7373,1008 @@
     '((a . b) (c . d)))
 )
 
+(mat property-value
+  (begin
+    (library (dp get-property) (export get-property) (import (scheme))
+      (define-syntax get-property
+        (lambda (x)
+          (syntax-case x ()
+            [(_ q prop) #`'#,(datum->syntax #'* (property-value #'q #'prop))]))))
+    (import (dp get-property))
+    #t)
+  (begin
+    (define-property cons frotz 'spamgle)
+    (equal?
+      (cons (get-property cons frotz) (get-property cons fratz))
+      '(spamgle . #f)))
+  (equal?
+    (cons (get-property cons frotz) (get-property cons fratz))
+    '(spamgle . #f))
+  (equal?
+    (let ()
+      (import scheme)
+      (cons (get-property cons frotz) (get-property cons fratz)))
+    (if (free-identifier=? #'cons (let () (import scheme) #'cons))
+        '(spamgle . #f)
+        '(#f . #f)))
+  (equal?
+    (let ()
+      (define-property cons fratz 'yubah)
+      (cons (get-property cons frotz) (get-property cons fratz)))
+    '(spamgle . yubah))
+  (equal?
+    (cons (get-property cons frotz) (get-property cons fratz))
+    '(spamgle . #f))
+ ; restore
+  (begin
+    (meta-cond
+      [(free-identifier=? #'cons (let () (import scheme) #'cons))
+       (import (only scheme cons))]
+      [else (define cons (let () (import scheme) cons))])
+    #t)
+  (equal?
+    (cons (get-property cons frotz) (get-property cons fratz))
+    '(#f . #f))
+  (equal?
+    (let ()
+      (import scheme)
+      (cons (get-property cons frotz) (get-property cons fratz)))
+    '(#f . #f))
+  (equal?
+    (let ()
+      (import scheme)
+      (define-property list type "procedure")
+      (list (get-property list type) (get-property car type)))
+    '("procedure" #f))
+  (equal?
+    (let ()
+      (define list (lambda x x))
+      (define-property list type "procedure")
+      (list (get-property list type) (get-property car type)))
+    '("procedure" #f))
+  (error? ; multiple definitions for list
+    (let ()
+      (define-property list type "procedure")
+      (define list (lambda x x))
+      (list (get-property list type) (get-property car type))))
+  (error? ; multiple definitions for list
+    (module m (list)
+      (define-property list type "procedure")
+      (define list (lambda x x))
+      (list (get-property list type) (get-property car type))))
+  (error? ; immutable environment
+    (eval '(define-property frot rat 3) (scheme-environment)))
+  (error? ; immutable environment
+    (eval '(define-property cons rat 3) (scheme-environment)))
+  (error? ; no visible binding
+    (eval '(let () (define-property frot cons 3) 3) (scheme-environment)))
+  (error? ; no visible binding
+    (eval '(let () (define-property cons rat 3) 3) (scheme-environment)))
+  (error? ; no visible binding
+    (library (dp err1) (export x) (import (scheme))
+      (define-property x cons "frap")))
+  (error? ; no visible binding
+    (library (dp err1) (export x) (import (scheme))
+      (define-property cons frip "frap")))
+  (error? ; no visible binding
+    (module (x) (import-only (scheme))
+      (define-property x cons "frap")))
+  (error? ; no visible binding
+    (module (x) (import-only (scheme))
+      (define-property cons frip "frap")))
+  (not (get-property list type))
+  (equal?
+    (let ()
+      (define type)
+      (define-property list type "proc")
+      (list
+        (get-property list type)
+        (let () (define type) (get-property list type))))
+    '("proc" #f))
+  (equal?
+    (let ()
+      (module (type iface list)
+        (define type)
+        (define iface)
+        (define-property list type "a proc")
+        (define-property list iface -1))
+      (list
+        (get-property list type)
+        (get-property list iface)))
+    '("a proc" -1))
+  (equal?
+    (let ()
+      (module (type list)
+        (define type)
+        (define iface)
+        (define-property list type "a proc")
+        (define-property list iface -1))
+      (list
+        (get-property list type)
+        (get-property list iface)))
+    '("a proc" #f))
+  (equal?
+    (let ()
+      (module (iface list)
+        (define type)
+        (define iface)
+        (define-property list type "a proc")
+        (define-property list iface -1))
+      (list
+        (get-property list type)
+        (get-property list iface)))
+    '(#f -1))
+  (equal?
+    (let ()
+      (module (list)
+        (define type)
+        (define iface)
+        (define-property list type "a proc")
+        (define-property list iface -1))
+      (list
+        (get-property list type)
+        (get-property list iface)))
+    '(#f #f))
+  (equal?
+    (let ()
+      (module (type iface)
+        (define type)
+        (define iface)
+        (define-property list type "a proc")
+        (define-property list iface -1))
+      (list
+        (get-property list type)
+        (get-property list iface)))
+    '(#f #f))
+  (begin
+    (define dp-out (open-output-string))
+    (module dp-m1 (x)
+      (import (scheme) (dp get-property))
+      (define x 444)
+      (define-property x frob "x-frob")
+      (define-property x spam "x-spam")
+      (fprintf dp-out "~s ~s ~s ~s\n"
+        (get-property x spam)
+        (get-property x frob)
+        (get-property x rats)
+        x))
+    (equal?
+      (get-output-string dp-out)
+      "\"x-spam\" \"x-frob\" #f 444\n"))
+  (equal?
+    (let ()
+      (import dp-m1)
+      (list
+        (get-property x spam)
+        (get-property x frob)
+        (get-property x rats)
+        x))
+    '("x-spam" "x-frob" #f 444))
+  (begin
+    (define dp-out (open-output-string))
+    (module dp-m1 ()
+      (import (scheme) (dp get-property))
+      (define-property dp-out spam "dp-out-spam")
+      (define-property dp-out frob "dp-out-frob")
+      (fprintf dp-out "~s ~s ~s\n"
+        (get-property dp-out spam)
+        (get-property dp-out frob)
+        (get-property dp-out rats)))
+    (and
+      (equal?
+        (get-output-string dp-out)
+        "\"dp-out-spam\" \"dp-out-frob\" #f\n")
+      (not (get-property dp-out spam))
+      (not (get-property dp-out frob))))
+  (equal?
+    (let ()
+      (import dp-m1)
+      (list
+        (get-property x spam)
+        (get-property x frob)
+        (get-property x rats)))
+    '(#f #f #f))
+  (begin
+    (module dp-m1 (m2 (f x y))
+      (import (scheme) (dp get-property))
+      (define y "yval")
+      (define-property y a "y-a")
+      (module m2 (x)
+        (define x "xval")
+        (define-property x a "x-a")
+        (define-property y b "y-b"))
+      (import m2)
+      (define-property x b "x-b")
+      (define-syntax f
+        (identifier-syntax
+          (list (list x (get-property x a) (get-property x b))
+                (list y (get-property y a) (get-property y b))))))
+    #t)
+  (equal?
+    (let () (import dp-m1) f)
+    '(("xval" "x-a" "x-b") ("yval" "y-a" #f)))
+  (equal?
+    (let ()
+      (import dp-m1)
+      (import m2)
+      (list
+        (get-property x a)
+        (get-property x b)
+        (get-property x c)
+        x))
+    '("x-a" #f #f "xval"))
+  (begin
+    (library (dp l1) (export x spam frob rats) (import (scheme) (dp get-property))
+      (define spam)
+      (define frob)
+      (define rats)
+      (define x (make-parameter 444))
+      (define-property x spam "x-spam")
+      (define-property x frob "x-frob")
+      (printf "~s ~s ~s ~s\n"
+        (get-property x spam)
+        (get-property x frob)
+        (get-property x rats)
+        (x)))
+    #t)
+  (begin (define dp-f) #t)
+  (equal?
+    (with-output-to-string
+      (lambda ()
+        (set! dp-f
+          (eval
+            '(lambda ()
+               (import (dp l1))
+               (printf "~s ~s ~s ~s\n"
+                 (get-property x spam)
+                 (get-property x frob)
+                 (get-property x rats)
+                 (x)))))))
+    "\"x-spam\" \"x-frob\" #f 444\n")
+  (equal?
+    (with-output-to-string
+      (lambda ()
+        (dp-f)))
+    "\"x-spam\" \"x-frob\" #f 444\n")
+  (begin
+    (library (dp l1) (export x spam frob rats) (import (scheme) (dp get-property))
+      (define spam)
+      (define frob)
+      (define rats)
+      (define-syntax x
+        (identifier-syntax
+          (list
+            (get-property x spam)
+            (get-property x frob)
+            (get-property x rats))))
+      (define-property x spam "x-spam")
+      (define-property x frob "x-frob")
+      (printf "~s ~s ~s ~s\n"
+        (get-property x spam)
+        (get-property x frob)
+        (get-property x rats)
+        x))
+    #t)
+  (begin (define dp-f) #t)
+  (equal?
+    (with-output-to-string
+      (lambda ()
+        (set! dp-f
+          (eval
+            '(lambda ()
+               (import (dp l1))
+               (printf "~s ~s ~s ~s\n"
+                 (get-property x spam)
+                 (get-property x frob)
+                 (get-property x rats)
+                 x))))))
+    "")
+  (equal?
+    (with-output-to-string
+      (lambda ()
+        (dp-f)))
+    "\"x-spam\" \"x-frob\" #f (\"x-spam\" \"x-frob\" #f)\n")
+  (begin
+    (library (dp l1) (export x qq spam frob rats) (import (scheme) (dp get-property))
+      (define spam)
+      (define frob)
+      (define rats)
+      (define qq (make-parameter 33))
+      (define-syntax x
+        (identifier-syntax
+          (list
+            (get-property x spam)
+            (get-property x frob)
+            (get-property x rats))))
+      (define-property x spam "x-spam")
+      (define-property x frob "x-frob")
+      (printf "~s ~s ~s ~s\n"
+        (get-property x spam)
+        (get-property x frob)
+        (get-property x rats)
+        x))
+    #t)
+  (begin (define dp-f) #t)
+  (equal?
+    (with-output-to-string
+      (lambda ()
+        (set! dp-f
+          (eval
+            '(lambda ()
+               (import (dp l1))
+               (printf "~s ~s ~s ~s ~s\n"
+                 (get-property x spam)
+                 (get-property x frob)
+                 (get-property x rats)
+                 x (qq)))))))
+    "\"x-spam\" \"x-frob\" #f (\"x-spam\" \"x-frob\" #f)\n")
+  (equal?
+    (with-output-to-string
+      (lambda ()
+        (dp-f)))
+    "\"x-spam\" \"x-frob\" #f (\"x-spam\" \"x-frob\" #f) 33\n")
+  (begin
+    (library (dp l1) (export qq spam frob rats) (import (scheme) (dp get-property))
+      (define spam)
+      (define frob)
+      (define rats)
+      (define qq (make-parameter 77))
+      (define x (make-parameter 444))
+      (define-property x spam "x-spam")
+      (define-property x frob "x-frob")
+      (printf "~s ~s ~s ~s\n"
+        (get-property x spam)
+        (get-property x frob)
+        (get-property x rats)
+        (x)))
+    #t)
+  (begin (define dp-f) #t)
+  (equal?
+    (with-output-to-string
+      (lambda ()
+        (set! dp-f
+          (eval
+            '(lambda (x)
+               (import (dp l1))
+               (printf "~s ~s ~s ~s\n"
+                 (get-property x spam)
+                 (get-property x frob)
+                 (get-property x rats)
+                 (qq)))))))
+    "\"x-spam\" \"x-frob\" #f 444\n")
+  (equal?
+    (with-output-to-string
+      (lambda ()
+        (dp-f 0)))
+    "#f #f #f 77\n")
+  (begin
+    (module (dp-a)
+      (module (dp-a)
+        (define-syntax dp-a (identifier-syntax 3)))
+      (define-property dp-a spam 55))
+    (and (eqv? dp-a 3)
+         (eqv? (get-property dp-a spam) 55)))
+  (begin
+    (module (dp-b)
+      (module ((dp-b q))
+        (define q 3)
+        (define-syntax dp-b (identifier-syntax q)))
+      (define-property dp-b spam 55))
+    (and (eqv? dp-b 3)
+         (eqv? (get-property dp-b spam) 55)))
+  (let ()
+    (module (dp-c)
+      (module (dp-c)
+        (define-syntax dp-c (identifier-syntax 3)))
+      (define-property dp-c spam 55))
+    (and (eqv? dp-c 3)
+         (eqv? (get-property dp-c spam) 55)))
+  (let ()
+    (module (dp-c)
+      (module ((dp-c q))
+        (define q 3)
+        (define-syntax dp-c (identifier-syntax q)))
+      (define-property dp-c spam 55))
+    (and (eqv? dp-c 3)
+         (eqv? (get-property dp-c spam) 55)))
+  (begin
+    (library (dp l2) (export dp-d dp-e spam) (import (scheme))
+      (define spam)
+      (module (dp-d)
+        (module (dp-d)
+          (define-syntax dp-d (identifier-syntax 3)))
+        (define-property dp-d spam 55))
+      (module (dp-e)
+        (module ((dp-e q))
+          (define q 13)
+          (define-syntax dp-e (identifier-syntax q)))
+        (define-property dp-e spam 155)))
+    (let ()
+      (import (dp l2))
+      (and (eqv? dp-d 3)
+           (eqv? (get-property dp-d spam) 55)
+           (eqv? dp-e 13)
+           (eqv? (get-property dp-e spam) 155))))
+  (begin
+    (import (dp l2))
+    (and (eqv? dp-d 3)
+         (eqv? (get-property dp-d spam) 55)
+         (eqv? dp-e 13)
+         (eqv? (get-property dp-e spam) 155)))
+  (begin
+    (with-output-to-file "testfile-dp0.ss"
+      (lambda ()
+        (pretty-print '(define $dp0-x "dp0-x"))
+        (pretty-print '(define-property $dp0-x dp0 17)))
+      'replace)
+    (with-output-to-file "testfile-dp1.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp1)
+             (export cons a b spud)
+             (import (scheme))
+             (define spud)
+             (define a "a")
+             (define b "b")
+             (define-property cons spud "spud-cons")
+             (define-property a spud "spud-a")
+             (define-property b spud "spud-b"))))
+      'replace)
+    (with-output-to-file "testfile-dp2.ss"
+      (lambda ()
+        (pretty-print
+          '(module dp2 (cons a b putz)
+             (import (scheme))
+             (define putz)
+             (define a "a")
+             (define b "b")
+             (define-property cons putz "putz-cons")
+             (define-property a putz "putz-a")
+             (define-property b putz "putz-b"))))
+      'replace)
+    (for-each separate-compile '(dp0 dp1 dp2))
+    #t)
+  (begin (load "testfile-dp0.so") #t)
+  (equal? $dp0-x "dp0-x")
+  (equal? (get-property $dp0-x dp0) 17)
+  (equal?
+    (let ()
+      (import (testfile-dp1))
+      (list (cons a b) (get-property cons spud) (get-property a spud) (get-property b spud)))
+    '(("a" . "b") "spud-cons" "spud-a" "spud-b"))
+  (begin (load "testfile-dp2.so") #t)
+  (equal?
+    (let ()
+      (import dp2)
+      (list (cons a b) (get-property cons putz) (get-property a putz) (get-property b putz)))
+    '(("a" . "b") "putz-cons" "putz-a" "putz-b"))
+ ; illustrate use of define-property for storing parent record info,
+ ; while still allowing the record name to be a variable whose value
+ ; is the record type descriptor
+  (equal?
+    (let ()
+      (module (drt)
+        (define drt-key)
+        (define-syntax drt
+          (lambda (x)
+            (define construct-name
+              (lambda (template-identifier . args)
+                (datum->syntax template-identifier
+                  (string->symbol
+                    (apply string-append
+                      (map (lambda (x)
+                             (if (string? x)
+                                 x
+                                 (symbol->string (syntax->datum x))))
+                           args))))))
+            (define do-drt
+              (lambda (rname fname* prtd)
+                (with-syntax ([rname rname]
+                              [rtd (make-record-type-descriptor
+                                     (syntax->datum rname) prtd #f #f #f
+                                     (list->vector (map (lambda (fname) `(immutable ,(syntax->datum fname))) fname*)))]
+                              [make-rname (construct-name rname "make-" rname)]
+                              [rname? (construct-name rname rname "?")]
+                              [(rname-fname ...)
+                               (map (lambda (fname) (construct-name fname rname "-" fname))
+                                    fname*)]
+                              [(i ...) (enumerate fname*)])
+                  #'(begin
+                      (define rname 'rtd)
+                      (define rcd (make-record-constructor-descriptor 'rtd #f #f))
+                      (define-property rname drt-key 'rtd)
+                      (define make-rname (record-constructor rcd))
+                      (define rname? (record-predicate 'rtd))
+                      (define rname-fname (record-accessor 'rtd i))
+                      ...))))
+            (syntax-case x (parent)
+              [(_ rname fname ...)
+               (for-all identifier? #'(rname fname ...))
+               (do-drt #'rname #'(fname ...) #f)]
+              [(_ rname (parent pname) fname ...)
+               (for-all identifier? #'(rname pname fname ...))
+               (let ([prtd (property-value #'pname #'drt-key)])
+                 (unless prtd (syntax-error #'pname "unrecognized parent record typd"))
+                 (do-drt #'rname #'(fname ...) prtd))]))))
+      (drt foo x y)
+      (drt bar (parent foo) z)
+      (let ([b (make-bar 1 2 3)])
+        (list
+          (record-type-descriptor? foo)
+          (record-type-descriptor? bar)
+          (foo? b) (bar? b)
+          (foo-x b)
+          (foo-y b)
+          (bar-z b))))
+    '(#t #t #t #t 1 2 3))
+ ; on no!
+  (equal?
+    (let ()
+      (define type-key)
+      (define-syntax declare
+        (syntax-rules ()
+          [(_ type id)
+           (identifier? #'id)
+           (define-property id type-key #'type)]))
+      (define-syntax type-of
+        (lambda (x)
+          (syntax-case x ()
+            [(_ id)
+             (identifier? #'id)
+             #`'#,(property-value #'id #'type-key)])))
+      (let ([x 3])
+        (define p (lambda (x) x))
+        (declare fixnum? x)
+        (declare procedure? p)
+        (list (type-of x) (type-of p))))
+    '(fixnum? procedure?))
+ ; make sure library is visited and invoked when needed by
+ ; top-level-xxx procedures, even when properties are defined
+  (begin
+    (with-output-to-file "testfile-dp3.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp3) (export dp3-x frop) (import (chezscheme))
+             (define frop)
+             (define dp3-x 3)
+             (define-property dp3-x frop "blob"))))
+      'replace)
+    (for-each separate-compile '(dp3))
+    #t)
+  (begin (import (testfile-dp3)) #t)
+  (top-level-bound? 'dp3-x)
+  (equal? (get-property dp3-x frop) "blob")
+  (begin
+    (with-output-to-file "testfile-dp4.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp4) (export dp4-x frop) (import (chezscheme))
+             (define frop)
+             (define dp4-x 3)
+             (define-property dp4-x frop "blob"))))
+      'replace)
+    (for-each separate-compile '(dp4))
+    #t)
+  (begin (import (testfile-dp4)) #t)
+  (eqv? (top-level-value 'dp4-x) 3)
+  (equal? (get-property dp4-x frop) "blob")
+  (begin
+    (with-output-to-file "testfile-dp5.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp5) (export dp5-x frop) (import (chezscheme))
+             (define frop)
+             (define dp5-x 3)
+             (define-property dp5-x frop "blob"))))
+      'replace)
+    (for-each separate-compile '(dp5))
+    #t)
+  (begin (import (testfile-dp5)) #t)
+ ; same as last, but reverse order of checks
+  (equal? (get-property dp5-x frop) "blob")
+  (eqv? (top-level-value 'dp5-x) 3)
+  (begin
+    (with-output-to-file "testfile-dp6.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp6) (export dp6-x frop) (import (chezscheme))
+             (define frop)
+             (define-syntax dp6-x (identifier-syntax 3))
+             (define-property dp6-x frop "blob"))))
+      'replace)
+    (for-each separate-compile '(dp6))
+    #t)
+  (begin (import (testfile-dp6)) #t)
+  (top-level-syntax? 'dp6-x)
+  (equal? (get-property dp6-x frop) "blob")
+  (begin
+    (with-output-to-file "testfile-dp7.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp7) (export dp7-x frop) (import (chezscheme))
+             (define frop)
+             (define-syntax dp7-x (identifier-syntax 3))
+             (define-property dp7-x frop "blob"))))
+      'replace)
+    (for-each separate-compile '(dp7))
+    #t)
+  (begin (import (testfile-dp7)) #t)
+ ; same as last, but reverse order of checks
+  (equal? (get-property dp7-x frop) "blob")
+  (top-level-syntax? 'dp7-x)
+  (begin
+    (with-output-to-file "testfile-dp8.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp8) (export dp8-x frop) (import (chezscheme))
+             (define frop)
+             (define-syntax dp8-x (identifier-syntax 3))
+             (define-property dp8-x frop "blob"))))
+      'replace)
+    (for-each separate-compile '(dp8))
+    #t)
+  (begin (import (testfile-dp8)) #t)
+ ; same as last, but reverse order of checks
+  (procedure? (top-level-syntax 'dp8-x))
+  (equal? (get-property dp8-x frop) "blob")
+  (begin
+    (with-output-to-file "testfile-dp9.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp9) (export dp9-x frop) (import (chezscheme))
+             (define frop)
+             (define-syntax dp9-x (identifier-syntax 3))
+             (define-property dp9-x frop "blob"))))
+      'replace)
+    (for-each separate-compile '(dp9))
+    #t)
+  (begin (import (testfile-dp9)) #t)
+  (error? ; not a variable
+    (set-top-level-value! 'dp9-x 11))
+  (equal? (get-property dp9-x frop) "blob")
+  (begin
+    (with-output-to-file "testfile-dp10.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp10) (export dp10-x frop) (import (chezscheme))
+             (define frop)
+             (define dp10-x 3)
+             (define-property dp10-x frop "blob"))))
+      'replace)
+    (for-each separate-compile '(dp10))
+    #t)
+  (begin (import (testfile-dp10)) #t)
+  (error? ; immutable
+    (set-top-level-value! 'dp10-x 11))
+  (equal? (get-property dp10-x frop) "blob")
+  (begin
+    (with-output-to-file "testfile-dp11.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp11) (export dp11-x frop) (import (chezscheme))
+             (define frop)
+             (define dp11-x 3)
+             (define-property dp11-x frop "blob"))))
+      'replace)
+    (for-each separate-compile '(dp11))
+    #t)
+  (begin (import (testfile-dp11)) #t)
+  (not (top-level-mutable? 'dp11-x))
+  (equal? (get-property dp11-x frop) "blob")
+  (equal?
+    (syntax-case '(a b c) ()
+      [(_ . x)
+       (let ()
+         (define-property x goofy 'stuff)
+         (define-property x amazingly 'unlikely)
+         (list (get-property x goofy)
+               (get-property x amazingly)
+               #'x))])
+    '(stuff unlikely (b c)))
+ (begin
+   (library (docstring)
+     (export define-docstring get-docstring)
+     (import (chezscheme))
+     (define check-docstring
+       (lambda (x s)
+         (unless (string? s)
+           (syntax-error x "invalid docstring definition"))
+         s))
+     (define-syntax define-docstring
+       (lambda (x)
+         (syntax-case x ()
+           [(_ id expr)
+            #`(define-property id check-docstring
+                (check-docstring #'#,x expr))])))
+     (define-syntax get-docstring
+       (lambda (x)
+         (syntax-case x ()
+           [(_ id)
+            (property-value #'id #'check-docstring "no documentation available")]))))
+   #t)
+  (equal?
+    (let ()
+      (import (docstring))
+      (define-docstring cons "cons takes three arguments")
+      (get-docstring cons))
+    "cons takes three arguments")
+  (equal?
+    (let ()
+      (import (docstring))
+      (define-docstring else "else is cool")
+      (cond [else (get-docstring else)]))
+    "else is cool")
+  ((lambda (x ls) (and (member x ls) #t))
+   (parameterize ([#%$suppress-primitive-inlining #f])
+     (expand
+       '(let ()
+          (import scheme)
+          (define-property cons car 3)
+          cons)))
+   `(#%cons #2%cons #3%cons))
+  (begin
+    (define dp-x #f)
+    (define dp-y #f)
+    (define-property dp-x dp-y "xy")
+    (define-syntax a
+      (lambda (z)
+        (define-property dp-x z "xz")
+        #'(get-property dp-x dp-y)))
+    (equal? a "xy"))
+  (begin
+    (define dp-x #f)
+    (define dp-y #f)
+    (define-property dp-x dp-y "outer")
+    (define-syntax a
+      (lambda (z)
+        (define-property dp-x dp-y "inner")
+        #'(get-property dp-x dp-y)))
+    (not a))
+  (equal?
+    (let ([x #f] [y #f])
+      (define-property x y "xy")
+      (define-syntax a
+        (lambda (z)
+          (define-property x z "xz")
+          #'(get-property x y)))
+      a)
+    "xy")
+  (eq?
+    (let ([x #f] [y #f])
+      (define-property x y "outer")
+      (define-syntax a
+        (lambda (z)
+          (define-property x y "inner")
+          #'(get-property x y)))
+      a)
+    #f)
+  (eq?
+    (let ([x #f])
+      (define-syntax a
+        (syntax-rules (x)
+          [(_ x) 'yes]
+          [(_ y) 'no]))
+      (let ()
+        (define-property x q 0)
+        (a x)))
+    'yes)
+  (begin
+    (library (dp l3) (export x)
+      (import (chezscheme))
+      (define x 5)
+      (define-property x car 17))
+    (import (dp l3))
+    (and (eqv? x 5) (eqv? (let () (import (chezscheme)) (get-property x car)) 17)))
+  (begin
+    (library (dp l4) (export sort)
+      (import (chezscheme))
+      (define-property sort car 53))
+    (library (dp l5) (export sort)
+      (import (chezscheme))
+      (define-property sort cdr 87))
+    (import (dp l4))
+    (import (dp l5))
+    (and (procedure? sort)
+         (eq? sort #%sort)
+         (eqv? (let () (import (only (chezscheme) car)) (get-property sort car)) 53)
+         (eqv? (let () (import (only (chezscheme) cdr)) (get-property sort cdr)) 87)))
+  (begin
+    (with-output-to-file "testfile-dp12.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-dp12) (export dp12-dq) (import (chezscheme))
+             (define-syntax dp12-dq (identifier-syntax "dq"))
+             (define-property dp12-dq car "dqp"))))
+      'replace)
+    (for-each separate-compile '(dp12))
+    #t)
+  (begin (import (testfile-dp12)) #t)
+  (equal? (list dp12-dq (let () (import (chezscheme)) (get-property dp12-dq car))) '("dq" "dqp"))
+  (equal?
+    (let ()
+      (define x 0)
+      (module m1 (x) (define-property x car "xcar"))
+      (module m2 (x) (define-property x cdr "xcdr"))
+      (let ([q1 (let () (import m1) (list x (get-property x car) (get-property x cdr)))]
+            [q2 (let () (import m2) (list x (get-property x car) (get-property x cdr)))]
+            [q3 (let () (import m1) (import m2) (list x (get-property x car) (get-property x cdr)))]
+            [q4 (let () (import m2) (import m1) (list x (get-property x car) (get-property x cdr)))])
+        (list x q1 q2 q3 q4 (get-property x car) (get-property x cdr))))
+    '(0 (0 "xcar" #f) (0 #f "xcdr") (0 "xcar" "xcdr") (0 "xcar" "xcdr") #f #f))
+  (equal?
+    (let ()
+      (define x 0)
+      (module m1 (x) (define-property x car "xcar"))
+      (import m1)
+      (module m2 (x) (define-property x cdr "xcdr"))
+      (import m2)
+      (list x (get-property x car) (get-property x cdr)))
+    '(0 "xcar" "xcdr"))
+  (begin
+    (module $dp13 (foo)
+      (define foo 17)
+      (module ((foo bar))
+        (define-property foo cons #'bar)
+        (define bar 35)))
+    #t)
+  (eqv?
+    (let ()
+      (import $dp13)
+      (define-syntax a
+        (lambda (x)
+          (syntax-case x ()
+            [(_ id) (property-value #'id #'cons)])))
+      (a foo))
+    35)
+  (eqv?
+    (let ()
+      (module m (x) (define x 3) (define-property x x 4))
+      (import m)
+      (get-property x x))
+    4)
+  (eqv?
+    (let ()
+      (module m (x) (define x 3) (define-property x x 4))
+      (import (alias m (x y)))
+      (get-property x x))
+    4)
+  (eqv?
+    (let ()
+      (module m (x) (define x 3) (define-property x x 4))
+      (import (alias m (x y)))
+      (get-property x y))
+    4)
+  (eqv?
+    (let ()
+      (module m (x) (define x 3) (define-property x x 4))
+      (import (alias m (x y)))
+      (get-property y x))
+    4)
+  (eqv?
+    (let ()
+      (module m (x) (define x 3) (define-property x x 4))
+      (import (alias m (x y)))
+      (get-property y y))
+    4)
+  (eqv?
+    (let ()
+      (module m (x) (define x 3) (define-property x x 4))
+      (import (rename m (x y)))
+      (get-property y y))
+    4)
+  (begin
+    (module $dp14 (x) (define x 3) (define-property x x 4))
+    #t)
+  (eqv?
+    (let ()
+      (import $dp14)
+      (get-property x x))
+    4)
+  (eqv?
+    (let ()
+      (import (alias $dp14 (x y)))
+      (get-property x x))
+    4)
+  (eqv?
+    (let ()
+      (import (alias $dp14 (x y)))
+      (get-property x y))
+    4)
+  (eqv?
+    (let ()
+      (import (alias $dp14 (x y)))
+      (get-property y x))
+    4)
+  (eqv?
+    (let ()
+      (import (alias $dp14 (x y)))
+      (get-property y y))
+    4)
+  (eqv?
+    (let ()
+      (import (rename $dp14 (x y)))
+      (get-property y y))
+    4)
+  (equal?
+    (let ([y 14])
+      (define k1)
+      (define k2)
+      (module ()
+        (export x (rename (y x)))
+        (define x 3)
+        (define-property x k1 4)
+        (define-property x k2 5)
+        (alias y x))
+      (list x y (get-property x k1) (get-property x k2) (get-property y k1) (get-property y k2)))
+    '(3 14 4 5 #f #f))
+  (error? ; attempt to export different bindings for x
+    (let ([y 14])
+      (define k1)
+      (define k2)
+      (module ()
+        (export x (rename (y x)))
+        (define x 3)
+        (define-property x k1 4)
+        (alias y x)
+        (define-property x k2 5))
+      (list x y (get-property x k1) (get-property y k2))))
+  (begin
+    (with-output-to-file "testfile-A.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-A)
+             (export $testfile-A-x $testfile-A-prop-id)
+             (import (scheme))
+             (define $testfile-A-x (cons 'a 'b))
+             (define $testfile-A-prop-id)
+             (define-property $testfile-A-x $testfile-A-prop-id (cons 'c 'd)))))
+      'replace)
+    (with-output-to-file "testfile-B.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-B)
+             (export)
+             (import (scheme) (testfile-A))
+             (export (import (testfile-A))))))
+      'replace)
+    (with-output-to-file "testfile-C.ss"
+      (lambda ()
+        (pretty-print
+          '(library (testfile-C)
+             (export)
+             (import (scheme) (testfile-A) (testfile-B))
+             (export (import (testfile-A)) (import (testfile-B))))))
+      'replace)
+    (for-each separate-compile '(A B C))
+    #t)
+  (equal?
+    (let ()
+      (import (testfile-C))
+      (list $testfile-A-x (get-property $testfile-A-x $testfile-A-prop-id)))
+    '((a . b) (c . d)))
+)
+
 (mat library1
   (error? (compile-library "/file/not/there"))
   (error? (load-library "/file/not/there"))
-  (error? ; abc is not a string
+  (error?                               ; abc is not a string
     (load-library 'abc))
-  (error? ; xxx is not a procedure
+  (error?                               ; xxx is not a procedure
     (load-library "/file/not/there" 'xxx))
-  (error? ; 3 is not a string
+  (error?                               ; 3 is not a string
     (parameterize ([source-directories '("/tmp" ".")]) (load-library 3)))
-  (error? ; 3 is not a string
+  (error?                               ; 3 is not a string
     (parameterize ([source-directories '("/tmp" ".")]) (load-library 3 values)))
   (begin
     (library ($l1-a) (export $l1-x) (import (scheme))
-      (module $l1-x (($l1-a $l1-b) $l1-c $l1-e)
-        (define $l1-d 4)
-        (define-syntax $l1-a (identifier-syntax (cons $l1-b $l1-y)))
-        (define $l1-b 55)
-        (define $l1-c (lambda () (* $l1-d $l1-y)))
-        (define $l1-f 44)
-        (define-syntax $l1-e (identifier-syntax $l1-f)))
-      (define $l1-y 14))
+             (module $l1-x (($l1-a $l1-b) $l1-c $l1-e)
+               (define $l1-d 4)
+               (define-syntax $l1-a (identifier-syntax (cons $l1-b $l1-y)))
+               (define $l1-b 55)
+               (define $l1-c (lambda () (* $l1-d $l1-y)))
+               (define $l1-f 44)
+               (define-syntax $l1-e (identifier-syntax $l1-f)))
+             (define $l1-y 14))
     #t)
   (equal?
     (let () (import ($l1-a)) (import $l1-x) (list $l1-a ($l1-c)))
@@ -7406,29 +8387,29 @@
     #t)
   (equal? $l1-a '(55 . 14))
   (equal? ($l1-c) 56)
-  (error? ; unbound variable $l1-b
+  (error?                               ; unbound variable $l1-b
     $l1-b)
-  (error? ; unbound variable $l1-d
+  (error?                               ; unbound variable $l1-d
     $l1-d)
-  (error? ; unbound variable $l1-y
+  (error?                               ; unbound variable $l1-y
     $l1-y)
-  (error? ; unexported identifier $l1-f
+  (error?                               ; unexported identifier $l1-f
     $l1-e)
-  (error? ; unbound variable $l1-f
+  (error?                               ; unbound variable $l1-f
     $l1-f)
   (equal?
     (let () (import ($l1-a)) (import $l1-x) (list $l1-a ($l1-c)))
     '((55 . 14) 56))
   (begin
     (library ($l1-b) (export $l1-x) (import (scheme))
-      (module $l1-x ($l1-a $l1-c $l1-e)
-        (define $l1-d 4)
-        (define $l1-a (lambda () (cons $l1-b $l1-y)))
-        (define $l1-b 55)
-        (define $l1-c (lambda () (* $l1-d $l1-y)))
-        (define $l1-f 44)
-        (define $l1-e (lambda () $l1-f)))
-      (define $l1-y 14))
+             (module $l1-x ($l1-a $l1-c $l1-e)
+               (define $l1-d 4)
+               (define $l1-a (lambda () (cons $l1-b $l1-y)))
+               (define $l1-b 55)
+               (define $l1-c (lambda () (* $l1-d $l1-y)))
+               (define $l1-f 44)
+               (define $l1-e (lambda () $l1-f)))
+             (define $l1-y 14))
     #t)
   (equal?
     (let () (import ($l1-b)) (import $l1-x) (vector ($l1-a) ($l1-c) ($l1-e)))
@@ -7442,24 +8423,24 @@
   (equal? ($l1-a) '(55 . 14))
   (equal? ($l1-c) 56)
   (equal? ($l1-e) 44)
-  (error? ; unbound variable $l1-b
+  (error?                               ; unbound variable $l1-b
     $l1-b)
-  (error? ; unbound variable $l1-d
+  (error?                               ; unbound variable $l1-d
     $l1-d)
-  (error? ; unbound variable $l1-y
+  (error?                               ; unbound variable $l1-y
     $l1-y)
-  (error? ; unbound variable $l1-f
+  (error?                               ; unbound variable $l1-f
     $l1-f)
   (equal?
     (let () (import ($l1-b)) (import $l1-x) (vector ($l1-a) ($l1-c) ($l1-e)))
     '#((55 . 14) 56 44))
   (begin
     (library ($l1-c) (export (rename (q $l1-q) (a:x $l1-x)) $l1-p)
-      (import (scheme) (rename ($l1-a) ($l1-x a:x)) (rename ($l1-b) ($l1-x b:x)))
-      (import (drop-prefix a:x $l1-) (prefix (drop-prefix b:x $l1-) b:))
-      (define-syntax q (identifier-syntax (list a (c) (b:a) (b:c) ($l1-p) (r))))
-      (define $l1-p (lambda () (vector a (c) (b:a) (b:c))))
-      (define r (lambda () (cons* a (c) (b:a) (b:c)))))
+             (import (scheme) (rename ($l1-a) ($l1-x a:x)) (rename ($l1-b) ($l1-x b:x)))
+             (import (drop-prefix a:x $l1-) (prefix (drop-prefix b:x $l1-) b:))
+             (define-syntax q (identifier-syntax (list a (c) (b:a) (b:c) ($l1-p) (r))))
+             (define $l1-p (lambda () (vector a (c) (b:a) (b:c))))
+             (define r (lambda () (cons* a (c) (b:a) (b:c)))))
     #t)
   (equal?
     (let () (import ($l1-c)) $l1-q)
@@ -7475,21 +8456,21 @@
 
   (begin
     (library ($l1-d) (export $l1-x $l1-getx $l1-setx!) (import (scheme))
-      (define x 0)
-      (define-syntax $l1-x (identifier-syntax x))
-      (define $l1-getx (lambda () x))
-      (define $l1-setx! (lambda (v) (set! x v))))
+             (define x 0)
+             (define-syntax $l1-x (identifier-syntax x))
+             (define $l1-getx (lambda () x))
+             (define $l1-setx! (lambda (v) (set! x v))))
     #t)
   (eqv?
     (let () (import ($l1-d)) ($l1-setx! 'hello) ($l1-getx))
     'hello)
-  (error? ; unexported identifier x
+  (error?                               ; unexported identifier x
     (let () (import ($l1-d)) $l1-x))
-  (error? ; unexported identifier x
+  (error?                               ; unexported identifier x
     (expand '(let () (import ($l1-d)) $l1-x)))
-  (error? ; immutable variable $l1-x
+  (error?                               ; immutable variable $l1-x
     (let () (import ($l1-d)) (set! $l1-getx void)))
-  (error? ; immutable variable $l1-x
+  (error?                               ; immutable variable $l1-x
     (expand '(let () (import ($l1-d)) (set! $l1-getx void))))
   (begin
     (import ($l1-d))
@@ -7497,63 +8478,63 @@
   (eqv?
     (begin ($l1-setx! 'hello) ($l1-getx))
     'hello)
-  (error? ; unexported identifier x
+  (error?                               ; unexported identifier x
     $l1-x)
-  (error? ; unexported identifier x
+  (error?                               ; unexported identifier x
     (expand '$l1-x))
-  (error? ; immutable variable $l1-x
+  (error?                               ; immutable variable $l1-x
     (set! $l1-getx void))
-  (error? ; immutable variable $l1-x
+  (error?                               ; immutable variable $l1-x
     (expand '(set! $l1-getx void)))
 
   (error?
     (library ($l1-e) (export $l1-x) (import (scheme))
-      (define $l1-x 0)
-      (set! $l1-x 1)))
+             (define $l1-x 0)
+             (set! $l1-x 1)))
   (error?
     (expand
       '(library ($l1-e) (export $l1-x) (import (scheme))
-         (define $l1-x 0)
-         (set! $l1-x 1))))
+                (define $l1-x 0)
+                (set! $l1-x 1))))
 
   (begin
     (with-output-to-file "testfile.ss"
       (lambda ()
         (pretty-print
           '(library ($l1-f) (export $l1-x $l1-y) (import (scheme))
-             (define-syntax $l1-x (identifier-syntax q))
-             (define-syntax q
-               (begin
-                 (printf "An expand-time greeting from $l1-f\n")
-                 (lambda (x) 77)))
-             (define $l1-y (lambda () (* q 2)))
-             (printf "A run-time greeting from $l1-f\n")))
+                    (define-syntax $l1-x (identifier-syntax q))
+                    (define-syntax q
+                      (begin
+                        (printf "An expand-time greeting from $l1-f\n")
+                        (lambda (x) 77)))
+                    (define $l1-y (lambda () (* q 2)))
+                    (printf "A run-time greeting from $l1-f\n")))
         (pretty-print
           '(library ($l1-g) (export $l1-x $l1-z $l1-w) (import (scheme) ($l1-f))
-             (define-syntax $l1-z
-               (begin
-                 (printf "An expand-time greeting from $l1-g\n")
-                 (lambda (x) ($l1-y))))
-             (define $l1-w
-               (begin
-                 (printf "A run-time greeting from $l1-g\n")
-                 (lambda (x) (cons* x $l1-x ($l1-y)))))))
+                    (define-syntax $l1-z
+                      (begin
+                        (printf "An expand-time greeting from $l1-g\n")
+                        (lambda (x) ($l1-y))))
+                    (define $l1-w
+                      (begin
+                        (printf "A run-time greeting from $l1-g\n")
+                        (lambda (x) (cons* x $l1-x ($l1-y)))))))
         (pretty-print
           '(library ($l1-h) (export $l1-x $l1-y $l1-v) (import (scheme) ($l1-f) ($l1-g))
-             (define $l1-v (list $l1-x ($l1-y) $l1-z ($l1-w 13)))
-             (printf "A run-time greeting from $l1-h\n"))))
+                    (define $l1-v (list $l1-x ($l1-y) $l1-z ($l1-w 13)))
+                    (printf "A run-time greeting from $l1-h\n"))))
       'replace)
     (compile-file "testfile")
     #t)
- ; look, ma, no need to load...
+                                        ; look, ma, no need to load...
   (equal?
     (let () (import ($l1-h)) $l1-v)
     '(77 154 154 (13 77 . 154)))
   (begin
     (library ($l1-h) (export $l1-x $l1-y $l1-v) (import (scheme))
-      (define $l1-x "these aren't")
-      (define $l1-y "the exports")
-      (define $l1-v "you're looking for"))
+             (define $l1-x "these aren't")
+             (define $l1-y "the exports")
+             (define $l1-v "you're looking for"))
     #t)
   (begin (load "testfile.so") #t)
   (equal?
@@ -7565,46 +8546,46 @@
       (lambda ()
         (pretty-print
           '(library ($l1-f) (export $l1-x $l1-y) (import (scheme))
-             (define-syntax $l1-x (identifier-syntax q))
-             (define-syntax q
-               (begin
-                 (printf "An expand-time greeting from $l1-f\n")
-                 (lambda (x) 77)))
-             (define $l1-y (lambda () (* q 2)))
-             (printf "A run-time greeting from $l1-f\n")))
+                    (define-syntax $l1-x (identifier-syntax q))
+                    (define-syntax q
+                      (begin
+                        (printf "An expand-time greeting from $l1-f\n")
+                        (lambda (x) 77)))
+                    (define $l1-y (lambda () (* q 2)))
+                    (printf "A run-time greeting from $l1-f\n")))
         (pretty-print
           '(library ($l1-g) (export $l1-x $l1-z $l1-w) (import (scheme) ($l1-f))
-             (define-syntax $l1-z
-               (begin
-                 (printf "An expand-time greeting from $l1-g\n")
-                 (lambda (x) ($l1-y))))
-             (define $l1-w
-               (begin
-                 (printf "A run-time greeting from $l1-g\n")
-                 (lambda (x) (cons* x $l1-z $l1-x ($l1-y)))))))
+                    (define-syntax $l1-z
+                      (begin
+                        (printf "An expand-time greeting from $l1-g\n")
+                        (lambda (x) ($l1-y))))
+                    (define $l1-w
+                      (begin
+                        (printf "A run-time greeting from $l1-g\n")
+                        (lambda (x) (cons* x $l1-z $l1-x ($l1-y)))))))
         (pretty-print
           '(library ($l1-h) (export $l1-x $l1-y $l1-v) (import (scheme) ($l1-f) ($l1-g))
-             (define $l1-v (list $l1-x ($l1-y) $l1-z ($l1-w 13)))
-             (printf "A run-time greeting from $l1-h\n"))))
+                    (define $l1-v (list $l1-x ($l1-y) $l1-z ($l1-w 13)))
+                    (printf "A run-time greeting from $l1-h\n"))))
       'replace)
     (compile-file "testfile")
     #t)
- ; look, ma, no need to load...
+                                        ; look, ma, no need to load...
   (equal?
     (let () (import ($l1-h)) $l1-v)
     '(77 154 154 (13 154 77 . 154)))
   (begin
     (library ($l1-h) (export $l1-x $l1-y $l1-v) (import (scheme))
-      (define $l1-x "these aren't")
-      (define $l1-y "the exports")
-      (define $l1-v "you're looking for"))
+             (define $l1-x "these aren't")
+             (define $l1-y "the exports")
+             (define $l1-v "you're looking for"))
     #t)
   (begin (load "testfile.so") #t)
   (equal?
     (let () (import ($l1-h)) $l1-v)
     '(77 154 154 (13 154 77 . 154)))
 
-  (error? ; unknown library ($l1-ham)
+  (error?                               ; unknown library ($l1-ham)
     (begin
       (library ($l1-spam) (export) (import ($l1-ham)))
       (library ($l1-ham) (export) (import ($l1-spam)))))
@@ -7614,15 +8595,15 @@
       (lambda ()
         (pretty-print
           '(library ($l1-i) (export $l1-x $l1-y) (import (scheme))
-             (define $l1-x 'i-am-x)
-             (define-syntax $l1-y (identifier-syntax 'i-am-y))))
+                    (define $l1-x 'i-am-x)
+                    (define-syntax $l1-y (identifier-syntax 'i-am-y))))
         (pretty-print
           '(library ($l1-j) (export $l1-x $l1-y)
-             (import ($l1-i) (only (scheme) errorf))
-             (errorf #f "this error shouldn't happen")))
+                    (import ($l1-i) (only (scheme) errorf))
+                    (errorf #f "this error shouldn't happen")))
         (pretty-print
           '(library ($l1-k) (export $l1-z) (import (scheme) ($l1-j))
-             (define $l1-z (list 'i-am-z $l1-x $l1-y)))))
+                    (define $l1-z (list 'i-am-z $l1-x $l1-y)))))
       'replace)
     (compile-file "testfile")
     #t)
@@ -7636,7 +8617,7 @@
 
   (begin
     (library ($l1-l) (export $l1-x) (import (scheme))
-      (define $l1-x 'i-am-$l1-l.$l1-x))
+             (define $l1-x 'i-am-$l1-l.$l1-x))
     #t)
   (eq?
     (let ()
@@ -7744,14 +8725,14 @@
       'replace)
     (for-each separate-compile '(a2 b2 c2 d2 a2))
     #t)
-  (error? ; expected different compilation instance
-          ; program complains about b2 rather than b2 about a2
-          ;   now that load-library reloads source when dependency changes
-          ;   would be nice if program were reloaded from source as well
+  (error?         ; expected different compilation instance
+                                        ; program complains about b2 rather than b2 about a2
+                                        ;   now that load-library reloads source when dependency changes
+                                        ;   would be nice if program were reloaded from source as well
     (load "testfile-d2.so"))
-  ; no longer fails now that load-library reloads source when dependency changes
+                                        ; no longer fails now that load-library reloads source when dependency changes
   #;(error? ; expected different compilation instance
-    (import (testfile-c2)))
+  (import (testfile-c2)))
   (begin
     (library ($l1-m) (export $l1-x) (import (scheme)) (define $l1-x 333))
     (library ($l1-n) (export $l1-x) (import (scheme)) (import ($l1-m)))
@@ -7777,37 +8758,37 @@
              (let ([t id])
                (if (eq? t z) (errorf 'from "~s undefined" 'id) t))))]))
     (library ($frappe) (export wire whip) (import (scheme))
-      (define wire 3)
-      (define-syntax whip (identifier-syntax egg))
-      (define egg 'whites))
+             (define wire 3)
+             (define-syntax whip (identifier-syntax egg))
+             (define egg 'whites))
     (equal?
       (list (cons ($from1 ($frappe) wire) ($from1 ($frappe) whip))
-            (cons ($from2 ($frappe) wire) ($from2 ($frappe) whip))
-            (cons ($from3 ($frappe) wire) ($from3 ($frappe) whip)))
+        (cons ($from2 ($frappe) wire) ($from2 ($frappe) whip))
+        (cons ($from3 ($frappe) wire) ($from3 ($frappe) whip)))
       '((3 . whites) (3 . whites) (3 . whites))))
   (begin
     (library ($q) (export m from) (import (scheme))
-      (module m (f) (define f "this is f"))
-      (define-syntax from
-        (syntax-rules () [(_ m id) (let () (import-only m) id)])))
+             (module m (f) (define f "this is f"))
+             (define-syntax from
+               (syntax-rules () [(_ m id) (let () (import-only m) id)])))
     (equal? (let () (import-only ($q)) (from m f)) "this is f"))
   (begin
     (library ($p) (export d f) (import (scheme))
-      (define-syntax d
-        (syntax-rules ()
-          ((_ e) (m (lambda () e)))))
-      (define m (lambda (x) x))
-      (define f (lambda (th) (th))))
+             (define-syntax d
+               (syntax-rules ()
+                 ((_ e) (m (lambda () e)))))
+             (define m (lambda (x) x))
+             (define f (lambda (th) (th))))
     (eqv? (let () (import-only ($p)) (f (d 2))) 2))
- ; this works for libraries because m is implicitly exported
+                                        ; this works for libraries because m is implicitly exported
   (eqv? (let () (import-only ($p)) (f (d 1/3))) 1/3)
-  (error? ; cons undefined
+  (error?                               ; cons undefined
     (let () (import-only ($p)) (f (d cons))))
-  (error? ; invalid syntax
+  (error?                               ; invalid syntax
     (library (a) (export x:eval) (import (add-prefix (rnrs eval) x))))
-  (error? ; invalid syntax
+  (error?                               ; invalid syntax
     (library (a) (export val) (import (drop-prefix (rnrs eval) x))))
-  (error? ; invalid syntax
+  (error?                               ; invalid syntax
     (library (a) (export meaning) (import (alias (rnrs eval) [eval meaning]))))
   (begin
     (define $l1-q1)
@@ -7817,36 +8798,36 @@
         [(_ name (export ex ...) (import im ...) body ...)
          (begin
            (library name (export ex ... q)
-             (import im ... (rename (only (rnrs) cons) (cons list)))
-             (define q list) body ...)
+                    (import im ... (rename (only (rnrs) cons) (cons list)))
+                    (define q list) body ...)
            (let () (import name) (set! $l1-q1 q)))]))
     ($l1-qlib ($l1-libfoo) (export q) (import (rnrs)) (define q list))
     (let () (import ($l1-libfoo)) (set! $l1-q2 q))
     (equal? (list $l1-q1 $l1-q2) (list cons list)))
- ; check for existence of chezscheme library
+                                        ; check for existence of chezscheme library
   (begin
     (library ($l1-r1) (export $l1-x) (import (chezscheme))
-      (define $l1-x (sort < '(1 3 2 0 5))))
+             (define $l1-x (sort < '(1 3 2 0 5))))
     (library ($l1-r2) (export $l1-y) (import (chezscheme) ($l1-r1))
-      (define $l1-y (cons $l1-x (void))))
+             (define $l1-y (cons $l1-x (void))))
     (equal? (let () (import ($l1-r2)) $l1-y) `((0 1 2 3 5) . ,(void))))
-  (error? ; invalid context for library form
+  (error?                           ; invalid context for library form
     (module (a) (library (a) (export) (import))))
-  (error? ; invalid syntax for library form
+  (error?                            ; invalid syntax for library form
     (module (a) (library a (import) (export x) (define x 3)) (import a) x))
-  (error? ; invalid context for top-level-program form
+  (error?                 ; invalid context for top-level-program form
     (module (a) (top-level-program (import))))
-  (error? ; invalid syntax for top-level-program form
+  (error?                  ; invalid syntax for top-level-program form
     (module (a) (top-level-program (display "hello"))))
-  (error? ; invalid context for library form
+  (error?                           ; invalid context for library form
     (lambda () (library (a) (export) (import))))
-  (error? ; invalid syntax for library form
+  (error?                            ; invalid syntax for library form
     (lambda () (library a (import) (export x) (define x 3)) (import a) x))
-  (error? ; invalid context for top-level-program form
+  (error?                 ; invalid context for top-level-program form
     (lambda () (top-level-program (import))))
-  (error? ; invalid syntax for top-level-program form
+  (error?                  ; invalid syntax for top-level-program form
     (lambda () (top-level-program (display "hello"))))
-  (error? ; defnie not defined
+  (error?                               ; defnie not defined
     (library ($l1-s) (export y) (import (rnrs)) (defnie x 3) (define y 4)))
 
   (begin
@@ -7857,17 +8838,17 @@
         (define x 0)
         (define set-x! (lambda () (set! x 1)))))
     #t)
-  (error? ; attempt to reference assigned hence unexported
+  (error?             ; attempt to reference assigned hence unexported
     (let () (import ($l1-s)) (import m) x))
-  (error? ; attempt to reference assigned hence unexported
+  (error?             ; attempt to reference assigned hence unexported
     (let () (import ($l1-s)) (import m) (set! x 2)))
-  (error? ; invalid version
+  (error?                               ; invalid version
     (let () (import-only (chezscheme csv7 (6))) record-field-mutator))
   (equal?
     (let () (import-only (chezscheme csv7)) record-field-mutator)
     csv7:record-field-mutator)
 
- ; test macros generating libraries
+                                        ; test macros generating libraries
   (begin
     (let-syntax ([make-A (syntax-rules ()
                            [(_) (library (A)
@@ -7876,7 +8857,7 @@
                                   (define $library-x 3))])])
       (make-A))
     #t)
-  (error? ; out-of-context library reference (A)
+  (error?                       ; out-of-context library reference (A)
     (equal? (let () (import (A)) $library-x) 3))
   (begin
     (let-syntax ([make-A (lambda (x)
@@ -7888,7 +8869,7 @@
                                         (define $library-x 3)))]))])
       (make-A))
     #t)
-  (error? ; unbound $library-x
+  (error?                               ; unbound $library-x
     (equal? (let () (import (A)) $library-x) 3))
   (begin
     (let-syntax ([make-A (lambda (x)
@@ -7910,7 +8891,7 @@
                                   (import (chezscheme))
                                   (define x 3))
                                 (let () (import (A))
-                                  (eqv? x 3)))])])
+                                     (eqv? x 3)))])])
     (make-A))
   (let-syntax ([make-A (syntax-rules ()
                          [(_) (begin
@@ -7931,15 +8912,15 @@
       (lambda ()
         (pretty-print
           '(library (testfile-a14) (export f) (import (chezscheme))
-             (define f (lambda (n) (if (fx= n 0) 1 (fx* n (f (fx- n 1))))))
-             (printf "invoked a\n"))))
+                    (define f (lambda (n) (if (fx= n 0) 1 (fx* n (f (fx- n 1))))))
+                    (printf "invoked a\n"))))
       'replace)
     (with-output-to-file "testfile-b14.ss"
       (lambda ()
         (pretty-print
           '(library (testfile-b14) (export g) (import (chezscheme) (testfile-a14))
-             (define g (lambda (n) (f n)))
-             (printf "invoked b\n"))))
+                    (define g (lambda (n) (f n)))
+                    (printf "invoked b\n"))))
       'replace)
     (with-output-to-file "testfile-c14.ss"
       (lambda ()
@@ -7951,48 +8932,48 @@
     (with-output-to-string
       (lambda () (load "testfile-c14.ss")))
     "invoked a\ninvoked b\n3628800\n")
-  ; test for proper propagation and non-propagation of constants across library boundaries
+                                        ; test for proper propagation and non-propagation of constants across library boundaries
   (begin
     (with-output-to-file "testfile-a15.ss"
       (lambda ()
         (pretty-print
           '(library (testfile-a15) (export a b c d e f g fa fb fc fd fe ff fg)
-             (import (chezscheme))
-             (define-record-type foo (nongenerative) (fields x))
-             (define a '())
-             (define b 'sym)
-             (define c 3/4)
-             (define d '(x . y))
-             (define e (record-type-descriptor foo))
-             (define f (make-foo 3))
-             (define g "hello!")
-             (define fa (lambda () a))
-             (define fb (lambda () b))
-             (define fc (lambda () c))
-             (define fd (lambda () d))
-             (define fe (lambda () e))
-             (define ff (lambda () f))
-             (define fg (lambda () g)))))
+                    (import (chezscheme))
+                    (define-record-type foo (nongenerative) (fields x))
+                    (define a '())
+                    (define b 'sym)
+                    (define c 3/4)
+                    (define d '(x . y))
+                    (define e (record-type-descriptor foo))
+                    (define f (make-foo 3))
+                    (define g "hello!")
+                    (define fa (lambda () a))
+                    (define fb (lambda () b))
+                    (define fc (lambda () c))
+                    (define fd (lambda () d))
+                    (define fe (lambda () e))
+                    (define ff (lambda () f))
+                    (define fg (lambda () g)))))
       'replace)
     (with-output-to-file "testfile-b15.ss"
       (lambda ()
         (pretty-print
           '(library (testfile-b15) (export a b c d e f g fa fb fc fd fe ff fg)
-             (import (chezscheme) (prefix (testfile-a15) %))
-             (define a %a)
-             (define b %b)
-             (define c %c)
-             (define d %d)
-             (define e %e)
-             (define f %f)
-             (define g %g)
-             (define fa (lambda () (%fa)))
-             (define fb (lambda () (%fb)))
-             (define fc (lambda () (%fc)))
-             (define fd (lambda () (%fd)))
-             (define fe (lambda () (%fe)))
-             (define ff (lambda () (%ff)))
-             (define fg (lambda () (%fg))))))
+                    (import (chezscheme) (prefix (testfile-a15) %))
+                    (define a %a)
+                    (define b %b)
+                    (define c %c)
+                    (define d %d)
+                    (define e %e)
+                    (define f %f)
+                    (define g %g)
+                    (define fa (lambda () (%fa)))
+                    (define fb (lambda () (%fb)))
+                    (define fc (lambda () (%fc)))
+                    (define fd (lambda () (%fd)))
+                    (define fe (lambda () (%fe)))
+                    (define ff (lambda () (%ff)))
+                    (define fg (lambda () (%fg))))))
       'replace)
     (with-output-to-file "testfile-c15.ss"
       (lambda ()
@@ -8011,10 +8992,10 @@
     (for-each separate-compile '(a15 b15 c15))
     #t)
   ((lambda (x ls) (and (member x ls) #t))
-    (with-output-to-string
-      (lambda () (load "testfile-c15.so")))
-    '("(#t #t #f #t #t #t #t #t #t #f #t #t #t #t)\n(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n"
-      "(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n"))
+   (with-output-to-string
+     (lambda () (load "testfile-c15.so")))
+   '("(#t #t #f #t #t #t #t #t #t #f #t #t #t #t)\n(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n"
+     "(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n(#t #t #t #t #t #t #t #t #t #t #t #t #t #t)\n"))
   (begin
     (library ($l3) (export f) (import (chezscheme)) (define (f x) x))
     #t)
@@ -8034,7 +9015,7 @@
     ;; (export import-spec ...) multiple imports case
     (library ($l4-C) (export) (import (chezscheme)) (export (import ($l4-A) ($l4-B))))
     (equal? '(1 2) (let () (import ($l4-C)) (list a b))))
- )
+  )
 
 (mat library2
   ; test to make sure that libraries needed by the transformers of local
@@ -9588,9 +10569,8 @@
       '(let ()
          (define-syntax ref-prop
            (lambda (x)
-             (lambda (r)
-               (syntax-case x ()
-                 [(_ id key) (r #'id #'key)]))))
+             (syntax-case x ()
+               [(_ id key) (property-value #'id #'key)])))
          (ref-prop q5 q5)))
     "ct\n3\n")
   (begin
@@ -9606,9 +10586,8 @@
       '(let ()
          (define-syntax ref-prop
            (lambda (x)
-             (lambda (r)
-               (syntax-case x ()
-                 [(_ id key) (r #'id #'key)]))))
+             (syntax-case x ()
+               [(_ id key) (property-value #'id #'key)])))
          (ref-prop q6 q6)))
     "rt\n4\n")
   (begin
@@ -9630,9 +10609,8 @@
       '(let ()
          (define-syntax ref-prop
            (lambda (x)
-             (lambda (r)
-               (syntax-case x ()
-                 [(_ id key) (r #'id #'key)]))))
+             (syntax-case x ()
+               [(_ id key) (property-value #'id #'key)])))
          (ref-prop q5 q5)))
     "ct\n33\n")
   (equal?
@@ -9640,9 +10618,8 @@
       '(let ()
          (define-syntax ref-prop
            (lambda (x)
-             (lambda (r)
-               (syntax-case x ()
-                 [(_ id key) (r #'id #'key)]))))
+             (syntax-case x ()
+               [(_ id key) (property-value #'id #'key)])))
          (ref-prop q6 q6)))
     "rt\n44\n")
   ; --------

--- a/mats/patch-compile-0-f-f-t
+++ b/mats/patch-compile-0-f-f-t
@@ -1,7 +1,7 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Fri Feb 24 19:33:45 2023
---- output-compile-0-f-f-t-experr/errors-compile-0-f-f-t	Fri Feb 24 19:33:41 2023
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2025-04-28 11:23:44.687579691 +0200
+--- output-compile-0-f-f-t-experr/errors-compile-0-f-f-t	2025-04-28 11:23:32.378650435 +0200
 ***************
-*** 4052,4058 ****
+*** 4069,4075 ****
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation "static"".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: 17 is not a procedure".
@@ -9,7 +9,7 @@
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation oldgen".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation -1".
   misc.mo:Expected error in mat make-object-finder: "incorrect number of arguments 1 to #<procedure find-next>".
---- 4052,4058 ----
+--- 4069,4075 ----
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation "static"".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: 17 is not a procedure".
@@ -18,7 +18,7 @@
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation -1".
   misc.mo:Expected error in mat make-object-finder: "incorrect number of arguments 1 to #<procedure find-next>".
 ***************
-*** 7881,7891 ****
+*** 8023,8033 ****
   7.mo:Expected error in mat sstats: "set-sstats-gc-bytes!: twelve is not an exact integer".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation yuk".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation -1".
@@ -30,7 +30,7 @@
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
---- 7881,7891 ----
+--- 8023,8033 ----
   7.mo:Expected error in mat sstats: "set-sstats-gc-bytes!: twelve is not an exact integer".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation yuk".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation -1".
@@ -43,7 +43,7 @@
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
 ***************
-*** 9412,9424 ****
+*** 9577,9589 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -57,7 +57,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9412,9424 ----
+--- 9577,9589 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".

--- a/mats/patch-compile-0-f-t-f
+++ b/mats/patch-compile-0-f-t-f
@@ -1,7 +1,7 @@
-*** errors-compile-0-f-f-f	Wed Feb 12 08:37:37 2025
---- output-compile-0-f-t-f-cl3/errors-compile-0-f-t-f	Wed Feb 12 04:06:08 2025
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2025-04-28 11:23:44.687579691 +0200
+--- output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	2025-04-28 11:23:35.327633488 +0200
 ***************
-*** 212,218 ****
+*** 224,230 ****
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable c".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable m".
@@ -9,7 +9,7 @@
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable y".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
---- 212,218 ----
+--- 224,230 ----
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable c".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable m".
@@ -18,26 +18,24 @@
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
 ***************
-*** 231,238 ****
+*** 243,249 ****
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
+! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
-- 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
-  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
---- 231,238 ----
+--- 243,249 ----
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
-+ 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
+! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
-  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
 ***************
-*** 278,287 ****
+*** 290,299 ****
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 0 values to single value return context".
@@ -48,7 +46,7 @@
   3.mo:Expected error in mat mrvs: "variable $mrvs-foo is not bound".
   3.mo:Expected error in mat mrvs: "attempt to apply non-procedure 17".
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
---- 278,287 ----
+--- 290,299 ----
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 0 values to single value return context".
@@ -60,7 +58,7 @@
   3.mo:Expected error in mat mrvs: "attempt to apply non-procedure 17".
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
 ***************
-*** 4101,4107 ****
+*** 4113,4119 ****
   misc.mo:Expected error in mat cpletrec: "foreign-procedure: no entry for "foo"".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable q".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable bar".
@@ -68,7 +66,7 @@
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable a".
---- 4101,4107 ----
+--- 4113,4119 ----
   misc.mo:Expected error in mat cpletrec: "foreign-procedure: no entry for "foo"".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable q".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable bar".
@@ -77,7 +75,7 @@
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable a".
 ***************
-*** 7963,7970 ****
+*** 8033,8040 ****
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -86,7 +84,7 @@
   record.mo:Expected error in mat record2: "invalid value 3 for foreign type double-float".
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
---- 7963,7970 ----
+--- 8033,8040 ----
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -96,7 +94,7 @@
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
 ***************
-*** 7972,7986 ****
+*** 8042,8056 ****
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -112,7 +110,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid input #f".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
---- 7972,7986 ----
+--- 8042,8056 ----
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -129,7 +127,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
 ***************
-*** 7993,8018 ****
+*** 8063,8088 ****
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -156,7 +154,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: 0 is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
---- 7993,8018 ----
+--- 8063,8088 ----
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -184,7 +182,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
 ***************
-*** 8148,8186 ****
+*** 8225,8263 ****
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -224,7 +222,7 @@
   record.mo:Expected error in mat record?: "record?: 4 is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
---- 8148,8186 ----
+--- 8225,8263 ----
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -265,7 +263,7 @@
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
 ***************
-*** 8197,8254 ****
+*** 8274,8331 ****
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: invalid protocol flimflam".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure not-a-procedure".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure spam".
@@ -324,7 +322,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "cannot extend define-record-type parent fratrat".
---- 8197,8254 ----
+--- 8274,8331 ----
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: invalid protocol flimflam".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure not-a-procedure".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure spam".

--- a/mats/patch-compile-0-f-t-t
+++ b/mats/patch-compile-0-f-t-t
@@ -1,7 +1,7 @@
-*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	Fri Feb 24 19:33:42 2023
---- output-compile-0-f-t-t-experr/errors-compile-0-f-t-t	Fri Feb 24 19:33:36 2023
+*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	2025-04-28 11:23:35.327633488 +0200
+--- output-compile-0-f-t-t-experr/errors-compile-0-f-t-t	2025-04-28 11:23:23.503701427 +0200
 ***************
-*** 9412,9424 ****
+*** 9577,9589 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -15,7 +15,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9412,9424 ----
+--- 9577,9589 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".

--- a/mats/patch-compile-0-t-f-f
+++ b/mats/patch-compile-0-t-f-f
@@ -1,7 +1,7 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Wed Mar 26 16:42:58 2025
---- output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Wed Mar 26 16:47:08 2025
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2025-04-28 11:23:44.687579691 +0200
+--- output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2025-04-28 11:24:00.793487089 +0200
 ***************
-*** 180,186 ****
+*** 192,198 ****
   3.mo:Expected error in mat case-lambda: "incorrect number of arguments 2 to #<procedure foo>".
   3.mo:Expected error in mat case-lambda: "incorrect number of arguments 4 to #<procedure foo>".
   3.mo:Expected error in mat case-lambda: "incorrect number of arguments 2 to #<procedure foo>".
@@ -9,7 +9,7 @@
   3.mo:Expected error in mat letrec: "variable f is not bound".
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat letrec: "attempt to assign undefined variable b".
---- 180,186 ----
+--- 192,198 ----
   3.mo:Expected error in mat case-lambda: "incorrect number of arguments 2 to #<procedure foo>".
   3.mo:Expected error in mat case-lambda: "incorrect number of arguments 4 to #<procedure foo>".
   3.mo:Expected error in mat case-lambda: "incorrect number of arguments 2 to #<procedure foo>".
@@ -18,7 +18,7 @@
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat letrec: "attempt to assign undefined variable b".
 ***************
-*** 278,289 ****
+*** 290,301 ****
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 0 values to single value return context".
@@ -31,7 +31,7 @@
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
   3.mo:Expected error in mat mrvs: "cdr: a is not a pair".
---- 278,289 ----
+--- 290,301 ----
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 0 values to single value return context".
@@ -45,7 +45,7 @@
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
   3.mo:Expected error in mat mrvs: "cdr: a is not a pair".
 ***************
-*** 320,327 ****
+*** 332,339 ****
   3.mo:Expected error in mat let*-values: "let*-values: incorrect number of values from rhs 1".
   3.mo:Expected error in mat let*-values: "let*-values: incorrect number of values from rhs 1".
   3.mo:Expected error in mat let*-values: "let-values: duplicate bound identifier x in (let*-values (((...) (...))) (list x w))".
@@ -54,7 +54,7 @@
   4.mo:Expected error in mat apply: "apply: 3 is not a proper list".
   4.mo:Expected error in mat apply: "apply: 4 is not a proper list".
   4.mo:Expected error in mat apply: "apply: (3 4 5 6 7 8 . 9) is not a proper list".
---- 320,327 ----
+--- 332,339 ----
   3.mo:Expected error in mat let*-values: "let*-values: incorrect number of values from rhs 1".
   3.mo:Expected error in mat let*-values: "let*-values: incorrect number of values from rhs 1".
   3.mo:Expected error in mat let*-values: "let-values: duplicate bound identifier x in (let*-values (((...) (...))) (list x w))".
@@ -64,7 +64,7 @@
   4.mo:Expected error in mat apply: "apply: 4 is not a proper list".
   4.mo:Expected error in mat apply: "apply: (3 4 5 6 7 8 . 9) is not a proper list".
 ***************
-*** 617,623 ****
+*** 629,635 ****
   4.mo:Expected error in mat continuation-attachments: "invalid primitive name $current-continuation-attachments".
   4.mo:Expected error in mat continuation-attachments: "incorrect argument count in call ($call-setting-continuation-attachment (quote any))".
   4.mo:Expected error in mat continuation-attachments: "$call-setting-continuation-attachment: 10 is not a procedure".
@@ -72,7 +72,7 @@
   4.mo:Expected error in mat continuation-attachments: "incorrect number of arguments 0 to #<procedure>".
   4.mo:Expected error in mat continuation-attachments: "incorrect argument count in call ($call-getting-continuation-attachment (quote none))".
   4.mo:Expected error in mat continuation-attachments: "$call-getting-continuation-attachment: 10 is not a procedure".
---- 617,623 ----
+--- 629,635 ----
   4.mo:Expected error in mat continuation-attachments: "invalid primitive name $current-continuation-attachments".
   4.mo:Expected error in mat continuation-attachments: "incorrect argument count in call ($call-setting-continuation-attachment (quote any))".
   4.mo:Expected error in mat continuation-attachments: "$call-setting-continuation-attachment: 10 is not a procedure".
@@ -81,7 +81,7 @@
   4.mo:Expected error in mat continuation-attachments: "incorrect argument count in call ($call-getting-continuation-attachment (quote none))".
   4.mo:Expected error in mat continuation-attachments: "$call-getting-continuation-attachment: 10 is not a procedure".
 ***************
-*** 637,654 ****
+*** 649,666 ****
   4.mo:Expected error in mat continuation-attachments: "attempt to apply non-procedure also-something-else".
   4.mo:Expected error in mat continuation-attachments: "attempt to apply non-procedure also-something-else".
   4.mo:Expected error in mat continuation-attachments: "attempt to apply non-procedure also-something-else".
@@ -100,7 +100,7 @@
   4.mo:Expected error in mat continuation-marks: "continuation-marks->iterator: y is not a vector".
   4.mo:Expected error in mat continuation-marks: "continuation-next-marks: oops is not a continuation".
   4.mo:Expected error in mat continuation-marks: "call-with-immediate-continuation-mark: #f is not a procedure".
---- 637,654 ----
+--- 649,666 ----
   4.mo:Expected error in mat continuation-attachments: "attempt to apply non-procedure also-something-else".
   4.mo:Expected error in mat continuation-attachments: "attempt to apply non-procedure also-something-else".
   4.mo:Expected error in mat continuation-attachments: "attempt to apply non-procedure also-something-else".
@@ -120,7 +120,7 @@
   4.mo:Expected error in mat continuation-marks: "continuation-next-marks: oops is not a continuation".
   4.mo:Expected error in mat continuation-marks: "call-with-immediate-continuation-mark: #f is not a procedure".
 ***************
-*** 658,666 ****
+*** 670,678 ****
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: #<procedure> is not a continuation".
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: #f is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: (1 2 3) is not an extension of of the attachments of #<continuation>".
@@ -130,7 +130,7 @@
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #f is not a continuation mark sequence".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: (1 2 3) is not a continuation mark sequence".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #<continuation-marks> is not an extension of the marks of #<continuation>".
---- 658,666 ----
+--- 670,678 ----
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: #<procedure> is not a continuation".
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: #f is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: (1 2 3) is not an extension of of the attachments of #<continuation>".
@@ -141,7 +141,7 @@
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: (1 2 3) is not a continuation mark sequence".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #<continuation-marks> is not an extension of the marks of #<continuation>".
 ***************
-*** 673,680 ****
+*** 685,692 ****
   4.mo:Expected error in mat $primitive: "invalid primitive name fubar".
   4.mo:Expected error in mat $primitive: "incorrect argument count in call (car (quote a) (quote b))".
   4.mo:Expected error in mat $primitive: "car: 3 is not a pair".
@@ -150,7 +150,7 @@
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
---- 673,680 ----
+--- 685,692 ----
   4.mo:Expected error in mat $primitive: "invalid primitive name fubar".
   4.mo:Expected error in mat $primitive: "incorrect argument count in call (car (quote a) (quote b))".
   4.mo:Expected error in mat $primitive: "car: 3 is not a pair".
@@ -160,7 +160,7 @@
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
 ***************
-*** 684,691 ****
+*** 696,703 ****
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
@@ -169,7 +169,7 @@
   5_1.mo:Expected error in mat symbol=?: "symbol=?: 3 is not a symbol".
   5_1.mo:Expected error in mat symbol=?: "symbol=?: 3 is not a symbol".
   5_1.mo:Expected error in mat symbol=?: "symbol=?: 3 is not a symbol".
---- 684,691 ----
+--- 696,703 ----
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
   5_1.mo:Expected error in mat boolean=?: "boolean=?: 3 is not a boolean".
@@ -179,7 +179,7 @@
   5_1.mo:Expected error in mat symbol=?: "symbol=?: 3 is not a symbol".
   5_1.mo:Expected error in mat symbol=?: "symbol=?: 3 is not a symbol".
 ***************
-*** 727,734 ****
+*** 739,746 ****
   5_2.mo:Expected error in mat c....r-errors: "cddadr: incorrect list structure (a . b)".
   5_2.mo:Expected error in mat c....r-errors: "cdddar: incorrect list structure (a . b)".
   5_2.mo:Expected error in mat c....r-errors: "cddddr: incorrect list structure (a . b)".
@@ -188,7 +188,7 @@
   5_2.mo:Expected error in mat list-ref: "list-ref: index 0 reaches a non-pair in a".
   5_2.mo:Expected error in mat list-ref: "list-ref: index 4 reaches a non-pair in (a b . c)".
   5_2.mo:Expected error in mat list-ref: "list-ref: index 4 is out of range for list (a b)".
---- 727,734 ----
+--- 739,746 ----
   5_2.mo:Expected error in mat c....r-errors: "cddadr: incorrect list structure (a . b)".
   5_2.mo:Expected error in mat c....r-errors: "cdddar: incorrect list structure (a . b)".
   5_2.mo:Expected error in mat c....r-errors: "cddddr: incorrect list structure (a . b)".
@@ -198,7 +198,7 @@
   5_2.mo:Expected error in mat list-ref: "list-ref: index 4 reaches a non-pair in (a b . c)".
   5_2.mo:Expected error in mat list-ref: "list-ref: index 4 is out of range for list (a b)".
 ***************
-*** 815,827 ****
+*** 827,839 ****
   5_2.mo:Expected error in mat append!: "append!: (b a b a b a ...) is circular".
   5_2.mo:Expected error in mat append!: "append!: (c d a b a b ...) is circular".
   5_2.mo:Expected error in mat append!: "append!: (a b . c) is not a proper list".
@@ -212,7 +212,7 @@
   5_2.mo:Expected error in mat reverse!: "reverse!: a is not a proper list".
   5_2.mo:Expected error in mat reverse!: "reverse!: (a b . c) is not a proper list".
   5_2.mo:Expected error in mat reverse!: "reverse!: (a b a b a b ...) is circular".
---- 815,827 ----
+--- 827,839 ----
   5_2.mo:Expected error in mat append!: "append!: (b a b a b a ...) is circular".
   5_2.mo:Expected error in mat append!: "append!: (c d a b a b ...) is circular".
   5_2.mo:Expected error in mat append!: "append!: (a b . c) is not a proper list".
@@ -227,7 +227,7 @@
   5_2.mo:Expected error in mat reverse!: "reverse!: (a b . c) is not a proper list".
   5_2.mo:Expected error in mat reverse!: "reverse!: (a b a b a b ...) is circular".
 ***************
-*** 834,851 ****
+*** 846,863 ****
   5_2.mo:Expected error in mat find: "find: improper list (a b . c)".
   5_2.mo:Expected error in mat find: "find: improper list (a b c . d)".
   5_2.mo:Expected error in mat find: "find: a is not a procedure".
@@ -246,7 +246,7 @@
   5_2.mo:Expected error in mat member: "member: improper list a".
   5_2.mo:Expected error in mat member: "member: cyclic list (a b a b a b ...)".
   5_2.mo:Expected error in mat member: "member: improper list (a b . c)".
---- 834,851 ----
+--- 846,863 ----
   5_2.mo:Expected error in mat find: "find: improper list (a b . c)".
   5_2.mo:Expected error in mat find: "find: improper list (a b c . d)".
   5_2.mo:Expected error in mat find: "find: a is not a procedure".
@@ -266,7 +266,7 @@
   5_2.mo:Expected error in mat member: "member: cyclic list (a b a b a b ...)".
   5_2.mo:Expected error in mat member: "member: improper list (a b . c)".
 ***************
-*** 888,897 ****
+*** 900,909 ****
   5_2.mo:Expected error in mat assv: "assv: cyclic alist ((a . 1) (b . 2) (3.2 . 3) ("a" . 4) (a . 1) (b . 2) ...)".
   5_2.mo:Expected error in mat assoc: "assoc: cyclic alist ((a . 1) (b . 2) (3.2 . 3) ("a" . 4) (a . 1) (b . 2) ...)".
   5_2.mo:Expected error in mat assoc: "assoc: cyclic alist ((a . 1) (b . 2) (3.2 . 3) ("a" . 4) (a . 1) (b . 2) ...)".
@@ -277,7 +277,7 @@
   5_2.mo:Expected error in mat sort: "sort: 3 is not a proper list".
   5_2.mo:Expected error in mat sort: "sort: #(1 2 3) is not a proper list".
   5_2.mo:Expected error in mat sort: "sort: (1 2 . 3) is not a proper list".
---- 888,897 ----
+--- 900,909 ----
   5_2.mo:Expected error in mat assv: "assv: cyclic alist ((a . 1) (b . 2) (3.2 . 3) ("a" . 4) (a . 1) (b . 2) ...)".
   5_2.mo:Expected error in mat assoc: "assoc: cyclic alist ((a . 1) (b . 2) (3.2 . 3) ("a" . 4) (a . 1) (b . 2) ...)".
   5_2.mo:Expected error in mat assoc: "assoc: cyclic alist ((a . 1) (b . 2) (3.2 . 3) ("a" . 4) (a . 1) (b . 2) ...)".
@@ -289,7 +289,7 @@
   5_2.mo:Expected error in mat sort: "sort: #(1 2 3) is not a proper list".
   5_2.mo:Expected error in mat sort: "sort: (1 2 . 3) is not a proper list".
 ***************
-*** 900,909 ****
+*** 912,921 ****
   5_2.mo:Expected error in mat sort: "sort: (q p a b a b ...) is circular".
   5_2.mo:Expected error in mat sort: "sort: (a b c) is not a procedure".
   5_2.mo:Expected error in mat sort: ">: b is not a real number".
@@ -300,7 +300,7 @@
   5_2.mo:Expected error in mat list-sort: "list-sort: 3 is not a proper list".
   5_2.mo:Expected error in mat list-sort: "list-sort: #(1 2 3) is not a proper list".
   5_2.mo:Expected error in mat list-sort: "list-sort: (1 2 . 3) is not a proper list".
---- 900,909 ----
+--- 912,921 ----
   5_2.mo:Expected error in mat sort: "sort: (q p a b a b ...) is circular".
   5_2.mo:Expected error in mat sort: "sort: (a b c) is not a procedure".
   5_2.mo:Expected error in mat sort: ">: b is not a real number".
@@ -312,7 +312,7 @@
   5_2.mo:Expected error in mat list-sort: "list-sort: #(1 2 3) is not a proper list".
   5_2.mo:Expected error in mat list-sort: "list-sort: (1 2 . 3) is not a proper list".
 ***************
-*** 912,921 ****
+*** 924,933 ****
   5_2.mo:Expected error in mat list-sort: "list-sort: (q p a b a b ...) is circular".
   5_2.mo:Expected error in mat list-sort: "list-sort: (a b c) is not a procedure".
   5_2.mo:Expected error in mat list-sort: ">: b is not a real number".
@@ -323,7 +323,7 @@
   5_2.mo:Expected error in mat sort!: "sort!: 3 is not a proper list".
   5_2.mo:Expected error in mat sort!: "sort!: #(1 2 3) is not a proper list".
   5_2.mo:Expected error in mat sort!: "sort!: (1 2 . 3) is not a proper list".
---- 912,921 ----
+--- 924,933 ----
   5_2.mo:Expected error in mat list-sort: "list-sort: (q p a b a b ...) is circular".
   5_2.mo:Expected error in mat list-sort: "list-sort: (a b c) is not a procedure".
   5_2.mo:Expected error in mat list-sort: ">: b is not a real number".
@@ -335,7 +335,7 @@
   5_2.mo:Expected error in mat sort!: "sort!: #(1 2 3) is not a proper list".
   5_2.mo:Expected error in mat sort!: "sort!: (1 2 . 3) is not a proper list".
 ***************
-*** 944,961 ****
+*** 956,973 ****
   5_2.mo:Expected error in mat iota: "iota: -1 is not a nonnegative fixnum".
   5_2.mo:Expected error in mat iota: "iota: 1000000000000000000000000000000 is not a nonnegative fixnum".
   5_2.mo:Expected error in mat iota: "iota: 3/4 is not a nonnegative fixnum".
@@ -354,7 +354,7 @@
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: a is not a string".
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: 0 is not a valid radix".
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: 37 is not a valid radix".
---- 944,961 ----
+--- 956,973 ----
   5_2.mo:Expected error in mat iota: "iota: -1 is not a nonnegative fixnum".
   5_2.mo:Expected error in mat iota: "iota: 1000000000000000000000000000000 is not a nonnegative fixnum".
   5_2.mo:Expected error in mat iota: "iota: 3/4 is not a nonnegative fixnum".
@@ -374,7 +374,7 @@
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: 0 is not a valid radix".
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: 37 is not a valid radix".
 ***************
-*** 966,972 ****
+*** 978,984 ****
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: <int> is not a valid radix".
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: 36 is not a valid radix".
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: a is not a valid radix".
@@ -382,7 +382,7 @@
   5_3.mo:Expected error in mat number->string: "number->string: a is not a number".
   5_3.mo:Expected error in mat number->string: "number->string: a is not a number".
   5_3.mo:Expected error in mat number->string: "number->string: a is not a number".
---- 966,972 ----
+--- 978,984 ----
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: <int> is not a valid radix".
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: 36 is not a valid radix".
   5_3.mo:Expected error in mat r6rs:string->number: "string->number: a is not a valid radix".
@@ -391,7 +391,7 @@
   5_3.mo:Expected error in mat number->string: "number->string: a is not a number".
   5_3.mo:Expected error in mat number->string: "number->string: a is not a number".
 ***************
-*** 1002,1008 ****
+*** 1014,1020 ****
   5_3.mo:Expected error in mat r6rs:number->string: "number->string: a precision is specified and radix 16 is not 10".
   5_3.mo:Expected error in mat exact?: "exact?: a is not a number".
   5_3.mo:Expected error in mat inexact?: "inexact?: () is not a number".
@@ -399,7 +399,7 @@
   5_3.mo:Expected error in mat =: "=: a is not a number".
   5_3.mo:Expected error in mat =: "=: a is not a number".
   5_3.mo:Expected error in mat =: "=: a is not a number".
---- 1002,1008 ----
+--- 1014,1020 ----
   5_3.mo:Expected error in mat r6rs:number->string: "number->string: a precision is specified and radix 16 is not 10".
   5_3.mo:Expected error in mat exact?: "exact?: a is not a number".
   5_3.mo:Expected error in mat inexact?: "inexact?: () is not a number".
@@ -408,7 +408,7 @@
   5_3.mo:Expected error in mat =: "=: a is not a number".
   5_3.mo:Expected error in mat =: "=: a is not a number".
 ***************
-*** 1011,1017 ****
+*** 1023,1029 ****
   5_3.mo:Expected error in mat =: "=: a is not a number".
   5_3.mo:Expected error in mat =: "=: a is not a number".
   5_3.mo:Expected error in mat =: "=: a is not a number".
@@ -416,7 +416,7 @@
   5_3.mo:Expected error in mat <: "<: a is not a real number".
   5_3.mo:Expected error in mat <: "<: a is not a real number".
   5_3.mo:Expected error in mat <: "<: a is not a real number".
---- 1011,1017 ----
+--- 1023,1029 ----
   5_3.mo:Expected error in mat =: "=: a is not a number".
   5_3.mo:Expected error in mat =: "=: a is not a number".
   5_3.mo:Expected error in mat =: "=: a is not a number".
@@ -425,7 +425,7 @@
   5_3.mo:Expected error in mat <: "<: a is not a real number".
   5_3.mo:Expected error in mat <: "<: a is not a real number".
 ***************
-*** 1031,1037 ****
+*** 1043,1049 ****
   5_3.mo:Expected error in mat <: "<: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat <: "<: 2+1i is not a real number".
   5_3.mo:Expected error in mat <: "<: 3+1i is not a real number".
@@ -433,7 +433,7 @@
   5_3.mo:Expected error in mat <=: "<=: a is not a real number".
   5_3.mo:Expected error in mat <=: "<=: a is not a real number".
   5_3.mo:Expected error in mat <=: "<=: a is not a real number".
---- 1031,1037 ----
+--- 1043,1049 ----
   5_3.mo:Expected error in mat <: "<: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat <: "<: 2+1i is not a real number".
   5_3.mo:Expected error in mat <: "<: 3+1i is not a real number".
@@ -442,7 +442,7 @@
   5_3.mo:Expected error in mat <=: "<=: a is not a real number".
   5_3.mo:Expected error in mat <=: "<=: a is not a real number".
 ***************
-*** 1051,1057 ****
+*** 1063,1069 ****
   5_3.mo:Expected error in mat <=: "<=: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat <=: "<=: 2+1i is not a real number".
   5_3.mo:Expected error in mat <=: "<=: 3+1i is not a real number".
@@ -450,7 +450,7 @@
   5_3.mo:Expected error in mat >: ">: a is not a real number".
   5_3.mo:Expected error in mat >: ">: a is not a real number".
   5_3.mo:Expected error in mat >: ">: a is not a real number".
---- 1051,1057 ----
+--- 1063,1069 ----
   5_3.mo:Expected error in mat <=: "<=: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat <=: "<=: 2+1i is not a real number".
   5_3.mo:Expected error in mat <=: "<=: 3+1i is not a real number".
@@ -459,7 +459,7 @@
   5_3.mo:Expected error in mat >: ">: a is not a real number".
   5_3.mo:Expected error in mat >: ">: a is not a real number".
 ***************
-*** 1071,1077 ****
+*** 1083,1089 ****
   5_3.mo:Expected error in mat >: ">: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat >: ">: 2+1i is not a real number".
   5_3.mo:Expected error in mat >: ">: 3+1i is not a real number".
@@ -467,7 +467,7 @@
   5_3.mo:Expected error in mat >=: ">=: a is not a real number".
   5_3.mo:Expected error in mat >=: ">=: a is not a real number".
   5_3.mo:Expected error in mat >=: ">=: a is not a real number".
---- 1071,1077 ----
+--- 1083,1089 ----
   5_3.mo:Expected error in mat >: ">: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat >: ">: 2+1i is not a real number".
   5_3.mo:Expected error in mat >: ">: 3+1i is not a real number".
@@ -476,7 +476,7 @@
   5_3.mo:Expected error in mat >=: ">=: a is not a real number".
   5_3.mo:Expected error in mat >=: ">=: a is not a real number".
 ***************
-*** 1091,1098 ****
+*** 1103,1110 ****
   5_3.mo:Expected error in mat >=: ">=: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat >=: ">=: 2+1i is not a real number".
   5_3.mo:Expected error in mat >=: ">=: 3+1i is not a real number".
@@ -485,7 +485,7 @@
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
---- 1091,1098 ----
+--- 1103,1110 ----
   5_3.mo:Expected error in mat >=: ">=: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat >=: ">=: 2+1i is not a real number".
   5_3.mo:Expected error in mat >=: ">=: 3+1i is not a real number".
@@ -495,7 +495,7 @@
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
 ***************
-*** 1100,1107 ****
+*** 1112,1119 ****
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
@@ -504,7 +504,7 @@
   5_3.mo:Expected error in mat r6rs:<: "<: a is not a real number".
   5_3.mo:Expected error in mat r6rs:<: "<: a is not a real number".
   5_3.mo:Expected error in mat r6rs:<: "<: a is not a real number".
---- 1100,1107 ----
+--- 1112,1119 ----
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
   5_3.mo:Expected error in mat r6rs:=: "=: a is not a number".
@@ -514,7 +514,7 @@
   5_3.mo:Expected error in mat r6rs:<: "<: a is not a real number".
   5_3.mo:Expected error in mat r6rs:<: "<: a is not a real number".
 ***************
-*** 1112,1119 ****
+*** 1124,1131 ****
   5_3.mo:Expected error in mat r6rs:<: "<: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat r6rs:<: "<: 2+1i is not a real number".
   5_3.mo:Expected error in mat r6rs:<: "<: 3+1i is not a real number".
@@ -523,7 +523,7 @@
   5_3.mo:Expected error in mat r6rs:<=: "<=: a is not a real number".
   5_3.mo:Expected error in mat r6rs:<=: "<=: a is not a real number".
   5_3.mo:Expected error in mat r6rs:<=: "<=: a is not a real number".
---- 1112,1119 ----
+--- 1124,1131 ----
   5_3.mo:Expected error in mat r6rs:<: "<: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat r6rs:<: "<: 2+1i is not a real number".
   5_3.mo:Expected error in mat r6rs:<: "<: 3+1i is not a real number".
@@ -533,7 +533,7 @@
   5_3.mo:Expected error in mat r6rs:<=: "<=: a is not a real number".
   5_3.mo:Expected error in mat r6rs:<=: "<=: a is not a real number".
 ***************
-*** 1124,1131 ****
+*** 1136,1143 ****
   5_3.mo:Expected error in mat r6rs:<=: "<=: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat r6rs:<=: "<=: 2+1i is not a real number".
   5_3.mo:Expected error in mat r6rs:<=: "<=: 3+1i is not a real number".
@@ -542,7 +542,7 @@
   5_3.mo:Expected error in mat r6rs:>: ">: a is not a real number".
   5_3.mo:Expected error in mat r6rs:>: ">: a is not a real number".
   5_3.mo:Expected error in mat r6rs:>: ">: a is not a real number".
---- 1124,1131 ----
+--- 1136,1143 ----
   5_3.mo:Expected error in mat r6rs:<=: "<=: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat r6rs:<=: "<=: 2+1i is not a real number".
   5_3.mo:Expected error in mat r6rs:<=: "<=: 3+1i is not a real number".
@@ -552,7 +552,7 @@
   5_3.mo:Expected error in mat r6rs:>: ">: a is not a real number".
   5_3.mo:Expected error in mat r6rs:>: ">: a is not a real number".
 ***************
-*** 1136,1143 ****
+*** 1148,1155 ****
   5_3.mo:Expected error in mat r6rs:>: ">: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat r6rs:>: ">: 2+1i is not a real number".
   5_3.mo:Expected error in mat r6rs:>: ">: 3+1i is not a real number".
@@ -561,7 +561,7 @@
   5_3.mo:Expected error in mat r6rs:>=: ">=: a is not a real number".
   5_3.mo:Expected error in mat r6rs:>=: ">=: a is not a real number".
   5_3.mo:Expected error in mat r6rs:>=: ">=: a is not a real number".
---- 1136,1143 ----
+--- 1148,1155 ----
   5_3.mo:Expected error in mat r6rs:>: ">: 2.0+1.0i is not a real number".
   5_3.mo:Expected error in mat r6rs:>: ">: 2+1i is not a real number".
   5_3.mo:Expected error in mat r6rs:>: ">: 3+1i is not a real number".
@@ -571,7 +571,7 @@
   5_3.mo:Expected error in mat r6rs:>=: ">=: a is not a real number".
   5_3.mo:Expected error in mat r6rs:>=: ">=: a is not a real number".
 ***************
-*** 1157,1163 ****
+*** 1169,1175 ****
   5_3.mo:Expected error in mat +: "oops".
   5_3.mo:Expected error in mat +: "+: #f is not a number".
   5_3.mo:Expected error in mat +: "+: #f is not a number".
@@ -579,7 +579,7 @@
   5_3.mo:Expected error in mat -: "-: a is not a number".
   5_3.mo:Expected error in mat -: "-: a is not a number".
   5_3.mo:Expected error in mat -: "-: a is not a number".
---- 1157,1163 ----
+--- 1169,1175 ----
   5_3.mo:Expected error in mat +: "oops".
   5_3.mo:Expected error in mat +: "+: #f is not a number".
   5_3.mo:Expected error in mat +: "+: #f is not a number".
@@ -588,7 +588,7 @@
   5_3.mo:Expected error in mat -: "-: a is not a number".
   5_3.mo:Expected error in mat -: "-: a is not a number".
 ***************
-*** 1170,1176 ****
+*** 1182,1188 ****
   5_3.mo:Expected error in mat *: "*: a is not a number".
   5_3.mo:Expected error in mat *: "*: #f is not a number".
   5_3.mo:Expected error in mat *: "*: #f is not a number".
@@ -596,7 +596,7 @@
   5_3.mo:Expected error in mat /: "/: a is not a number".
   5_3.mo:Expected error in mat /: "/: a is not a number".
   5_3.mo:Expected error in mat /: "/: a is not a number".
---- 1170,1176 ----
+--- 1182,1188 ----
   5_3.mo:Expected error in mat *: "*: a is not a number".
   5_3.mo:Expected error in mat *: "*: #f is not a number".
   5_3.mo:Expected error in mat *: "*: #f is not a number".
@@ -605,7 +605,7 @@
   5_3.mo:Expected error in mat /: "/: a is not a number".
   5_3.mo:Expected error in mat /: "/: a is not a number".
 ***************
-*** 1187,1254 ****
+*** 1199,1266 ****
   5_3.mo:Expected error in mat infinite?: "infinite?: a is not a real number".
   5_3.mo:Expected error in mat infinite?: "infinite?: 3+4i is not a real number".
   5_3.mo:Expected error in mat infinite?: "infinite?: 3.0-0.0i is not a real number".
@@ -674,7 +674,7 @@
   5_3.mo:Expected error in mat quotient: "quotient: a is not an integer".
   5_3.mo:Expected error in mat quotient: "quotient: a is not an integer".
   5_3.mo:Expected error in mat quotient: "quotient: 2/5 is not an integer".
---- 1187,1254 ----
+--- 1199,1266 ----
   5_3.mo:Expected error in mat infinite?: "infinite?: a is not a real number".
   5_3.mo:Expected error in mat infinite?: "infinite?: 3+4i is not a real number".
   5_3.mo:Expected error in mat infinite?: "infinite?: 3.0-0.0i is not a real number".
@@ -744,7 +744,7 @@
   5_3.mo:Expected error in mat quotient: "quotient: a is not an integer".
   5_3.mo:Expected error in mat quotient: "quotient: 2/5 is not an integer".
 ***************
-*** 1261,1270 ****
+*** 1273,1282 ****
   5_3.mo:Expected error in mat quotient: "quotient: 2+1i is not an integer".
   5_3.mo:Expected error in mat quotient: "quotient: 2+1i is not an integer".
   5_3.mo:Expected error in mat quotient: "quotient: 2.0+1.0i is not an integer".
@@ -755,7 +755,7 @@
   5_3.mo:Expected error in mat remainder: "remainder: a is not an integer".
   5_3.mo:Expected error in mat remainder: "remainder: a is not an integer".
   5_3.mo:Expected error in mat remainder: "remainder: 2/5 is not an integer".
---- 1261,1270 ----
+--- 1273,1282 ----
   5_3.mo:Expected error in mat quotient: "quotient: 2+1i is not an integer".
   5_3.mo:Expected error in mat quotient: "quotient: 2+1i is not an integer".
   5_3.mo:Expected error in mat quotient: "quotient: 2.0+1.0i is not an integer".
@@ -767,7 +767,7 @@
   5_3.mo:Expected error in mat remainder: "remainder: a is not an integer".
   5_3.mo:Expected error in mat remainder: "remainder: 2/5 is not an integer".
 ***************
-*** 1275,1283 ****
+*** 1287,1295 ****
   5_3.mo:Expected error in mat remainder: "remainder: 2.5 is not an integer".
   5_3.mo:Expected error in mat remainder: "remainder: 2.5 is not an integer".
   5_3.mo:Expected error in mat remainder: "remainder: -3+2i is not an integer".
@@ -777,7 +777,7 @@
   5_3.mo:Expected error in mat modulo: "modulo: a is not an integer".
   5_3.mo:Expected error in mat modulo: "modulo: a is not an integer".
   5_3.mo:Expected error in mat modulo: "modulo: 3/5 is not an integer".
---- 1275,1283 ----
+--- 1287,1295 ----
   5_3.mo:Expected error in mat remainder: "remainder: 2.5 is not an integer".
   5_3.mo:Expected error in mat remainder: "remainder: 2.5 is not an integer".
   5_3.mo:Expected error in mat remainder: "remainder: -3+2i is not an integer".
@@ -788,7 +788,7 @@
   5_3.mo:Expected error in mat modulo: "modulo: a is not an integer".
   5_3.mo:Expected error in mat modulo: "modulo: 3/5 is not an integer".
 ***************
-*** 1287,1332 ****
+*** 1299,1344 ****
   5_3.mo:Expected error in mat modulo: "modulo: 3.2 is not an integer".
   5_3.mo:Expected error in mat modulo: "modulo: -3.2 is not an integer".
   5_3.mo:Expected error in mat modulo: "modulo: -3+2i is not an integer".
@@ -835,7 +835,7 @@
   5_3.mo:Expected error in mat min: "min: a is not a real number".
   5_3.mo:Expected error in mat min: "min: a is not a real number".
   5_3.mo:Expected error in mat min: "min: a is not a real number".
---- 1287,1332 ----
+--- 1299,1344 ----
   5_3.mo:Expected error in mat modulo: "modulo: 3.2 is not an integer".
   5_3.mo:Expected error in mat modulo: "modulo: -3.2 is not an integer".
   5_3.mo:Expected error in mat modulo: "modulo: -3+2i is not an integer".
@@ -883,7 +883,7 @@
   5_3.mo:Expected error in mat min: "min: a is not a real number".
   5_3.mo:Expected error in mat min: "min: a is not a real number".
 ***************
-*** 1385,1393 ****
+*** 1397,1405 ****
   5_3.mo:Expected error in mat lcm: "lcm: +nan.0 is not an integer".
   5_3.mo:Expected error in mat lcm: "lcm: +nan.0 is not an integer".
   5_3.mo:Expected error in mat lcm: "lcm: +nan.0 is not an integer".
@@ -893,7 +893,7 @@
   5_3.mo:Expected error in mat expt: "expt: a is not a number".
   5_3.mo:Expected error in mat expt: "expt: a is not a number".
   5_3.mo:Expected error in mat expt: "expt: undefined for values 0 and -1".
---- 1385,1393 ----
+--- 1397,1405 ----
   5_3.mo:Expected error in mat lcm: "lcm: +nan.0 is not an integer".
   5_3.mo:Expected error in mat lcm: "lcm: +nan.0 is not an integer".
   5_3.mo:Expected error in mat lcm: "lcm: +nan.0 is not an integer".
@@ -904,7 +904,7 @@
   5_3.mo:Expected error in mat expt: "expt: a is not a number".
   5_3.mo:Expected error in mat expt: "expt: undefined for values 0 and -1".
 ***************
-*** 1400,1415 ****
+*** 1412,1427 ****
   5_3.mo:Expected error in mat expt: "expt: undefined for values 0 and +nan.0+3.0i".
   5_3.mo:Expected error in mat expt: "expt: undefined for values 0 and 0+3i".
   5_3.mo:Expected error in mat expt: "expt: undefined for values 0 and -1/2".
@@ -921,7 +921,7 @@
   5_3.mo:Expected error in mat random: "random: invalid argument a".
   5_3.mo:Expected error in mat random: "random: invalid argument -3".
   5_3.mo:Expected error in mat random: "random: invalid argument 0".
---- 1400,1415 ----
+--- 1412,1427 ----
   5_3.mo:Expected error in mat expt: "expt: undefined for values 0 and +nan.0+3.0i".
   5_3.mo:Expected error in mat expt: "expt: undefined for values 0 and 0+3i".
   5_3.mo:Expected error in mat expt: "expt: undefined for values 0 and -1/2".
@@ -939,7 +939,7 @@
   5_3.mo:Expected error in mat random: "random: invalid argument -3".
   5_3.mo:Expected error in mat random: "random: invalid argument 0".
 ***************
-*** 1442,1480 ****
+*** 1454,1492 ****
   5_3.mo:Expected error in mat pseudo-random-generator: "vector->pseudo-random-generator!: not a pseudo-random generator 0".
   5_3.mo:Expected error in mat pseudo-random-generator: "vector->pseudo-random-generator!: not a valid pseudo-random generator state vector 0".
   5_3.mo:Expected error in mat pseudo-random-generator: "vector->pseudo-random-generator!: not a valid pseudo-random generator state vector #(0 0 0 0 0 0)".
@@ -979,7 +979,7 @@
   5_3.mo:Expected error in mat imag-part: "imag-part: a is not a complex number".
   5_3.mo:Expected error in mat make-rectangular: "make-rectangular: a is not a real number".
   5_3.mo:Expected error in mat make-rectangular: "make-rectangular: b is not a real number".
---- 1442,1480 ----
+--- 1454,1492 ----
   5_3.mo:Expected error in mat pseudo-random-generator: "vector->pseudo-random-generator!: not a pseudo-random generator 0".
   5_3.mo:Expected error in mat pseudo-random-generator: "vector->pseudo-random-generator!: not a valid pseudo-random generator state vector 0".
   5_3.mo:Expected error in mat pseudo-random-generator: "vector->pseudo-random-generator!: not a valid pseudo-random generator state vector #(0 0 0 0 0 0)".
@@ -1020,7 +1020,7 @@
   5_3.mo:Expected error in mat make-rectangular: "make-rectangular: a is not a real number".
   5_3.mo:Expected error in mat make-rectangular: "make-rectangular: b is not a real number".
 ***************
-*** 1484,1560 ****
+*** 1496,1572 ****
   5_3.mo:Expected error in mat make-polar: "make-polar: b is not a real number".
   5_3.mo:Expected error in mat make-polar: "make-polar: 3.4+0.0i is not a real number".
   5_3.mo:Expected error in mat make-polar: "make-polar: 3.4+0.0i is not a real number".
@@ -1098,7 +1098,7 @@
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: 35.0 is not an exact integer".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid start index 5.0".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid end index 8.0".
---- 1484,1560 ----
+--- 1496,1572 ----
   5_3.mo:Expected error in mat make-polar: "make-polar: b is not a real number".
   5_3.mo:Expected error in mat make-polar: "make-polar: 3.4+0.0i is not a real number".
   5_3.mo:Expected error in mat make-polar: "make-polar: 3.4+0.0i is not a real number".
@@ -1177,7 +1177,7 @@
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid start index 5.0".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid end index 8.0".
 ***************
-*** 1565,1575 ****
+*** 1577,1587 ****
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid end index -8".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid end index 3".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid end index <int>".
@@ -1189,7 +1189,7 @@
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: a is not an exact integer".
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid start index 0.0".
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid end index 2.0".
---- 1565,1575 ----
+--- 1577,1587 ----
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid end index -8".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid end index 3".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-bit-field: invalid end index <int>".
@@ -1202,7 +1202,7 @@
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid start index 0.0".
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid end index 2.0".
 ***************
-*** 1582,1592 ****
+*** 1594,1604 ****
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid end index 5".
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid end index <int>".
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid end index <int>".
@@ -1214,7 +1214,7 @@
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: a is not an exact integer".
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid start index 0.0".
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid end index 2.0".
---- 1582,1592 ----
+--- 1594,1604 ----
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid end index 5".
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid end index <int>".
   5_3.mo:Expected error in mat bitwise-copy-bit-field: "bitwise-copy-bit-field: invalid end index <int>".
@@ -1227,7 +1227,7 @@
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid start index 0.0".
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid end index 2.0".
 ***************
-*** 1600,1609 ****
+*** 1612,1621 ****
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid end index 5".
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid end index <int>".
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid end index <int>".
@@ -1238,7 +1238,7 @@
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: 35.0 is not an exact integer".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: invalid start index 5.0".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: invalid end index 8.0".
---- 1600,1609 ----
+--- 1612,1621 ----
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid end index 5".
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid end index <int>".
   5_3.mo:Expected error in mat bitwise-rotate-bit-field: "bitwise-rotate-bit-field: invalid end index <int>".
@@ -1250,7 +1250,7 @@
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: invalid start index 5.0".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: invalid end index 8.0".
 ***************
-*** 1614,1637 ****
+*** 1626,1649 ****
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: invalid end index -8".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: start index 5 is greater than end index 3".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: start index <int> is greater than end index <int>".
@@ -1275,7 +1275,7 @@
   5_3.mo:Expected error in mat bitwise-first-bit-set: "bitwise-first-bit-set: 3.0 is not an exact integer".
   5_3.mo:Expected error in mat bitwise-first-bit-set: "bitwise-first-bit-set: a is not an exact integer".
   5_3.mo:Expected error in mat $quotient-remainder: "incorrect number of arguments 0 to #<procedure $quotient-remainder>".
---- 1614,1637 ----
+--- 1626,1649 ----
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: invalid end index -8".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: start index 5 is greater than end index 3".
   5_3.mo:Expected error in mat bitwise-bit-field: "bitwise-reverse-bit-field: start index <int> is greater than end index <int>".
@@ -1301,7 +1301,7 @@
   5_3.mo:Expected error in mat bitwise-first-bit-set: "bitwise-first-bit-set: a is not an exact integer".
   5_3.mo:Expected error in mat $quotient-remainder: "incorrect number of arguments 0 to #<procedure $quotient-remainder>".
 ***************
-*** 1757,1812 ****
+*** 1769,1824 ****
   5_3.mo:Expected error in mat bitwise-xor: "bitwise-xor: 3.4-2.3i is not an exact integer".
   5_3.mo:Expected error in mat bitwise-xor: "bitwise-xor: 3.4-2.3i is not an exact integer".
   5_3.mo:Expected error in mat bitwise-xor: "bitwise-xor: 3.0 is not an exact integer".
@@ -1358,7 +1358,7 @@
   5_3.mo:Expected error in mat real->flonum: "real->flonum: a is not a real number".
   5_3.mo:Expected error in mat real->flonum: "real->flonum: 3+4i is not a real number".
   5_3.mo:Expected error in mat div-and-mod: "div-and-mod: undefined for 0".
---- 1757,1812 ----
+--- 1769,1824 ----
   5_3.mo:Expected error in mat bitwise-xor: "bitwise-xor: 3.4-2.3i is not an exact integer".
   5_3.mo:Expected error in mat bitwise-xor: "bitwise-xor: 3.4-2.3i is not an exact integer".
   5_3.mo:Expected error in mat bitwise-xor: "bitwise-xor: 3.0 is not an exact integer".
@@ -1416,7 +1416,7 @@
   5_3.mo:Expected error in mat real->flonum: "real->flonum: 3+4i is not a real number".
   5_3.mo:Expected error in mat div-and-mod: "div-and-mod: undefined for 0".
 ***************
-*** 1931,2097 ****
+*** 1943,2109 ****
   5_3.mo:Expected error in mat popcount: "fxpopcount16: 1267650600228229401496703205376 is not a 16-bit fixnum".
   5_3.mo:Expected error in mat popcount: "fxpopcount16: 1048576 is not a 16-bit fixnum".
   5_3.mo:Expected error in mat popcount: "fxpopcount16: -1 is not a 16-bit fixnum".
@@ -1584,7 +1584,7 @@
   5_4.mo:Expected error in mat integer->char: "integer->char: a is not a valid unicode scalar value".
   5_4.mo:Expected error in mat integer->char: "integer->char: #f is not a valid unicode scalar value".
   5_4.mo:Expected error in mat integer->char: "integer->char: #\a is not a valid unicode scalar value".
---- 1931,2097 ----
+--- 1943,2109 ----
   5_3.mo:Expected error in mat popcount: "fxpopcount16: 1267650600228229401496703205376 is not a 16-bit fixnum".
   5_3.mo:Expected error in mat popcount: "fxpopcount16: 1048576 is not a 16-bit fixnum".
   5_3.mo:Expected error in mat popcount: "fxpopcount16: -1 is not a 16-bit fixnum".
@@ -1753,7 +1753,7 @@
   5_4.mo:Expected error in mat integer->char: "integer->char: #f is not a valid unicode scalar value".
   5_4.mo:Expected error in mat integer->char: "integer->char: #\a is not a valid unicode scalar value".
 ***************
-*** 2110,2125 ****
+*** 2122,2137 ****
   5_4.mo:Expected error in mat integer->char: "integer->char: 1114112 is not a valid unicode scalar value".
   5_4.mo:Expected error in mat integer->char: "integer->char: 1179648 is not a valid unicode scalar value".
   5_4.mo:Expected error in mat integer->char: "integer->char: <int> is not a valid unicode scalar value".
@@ -1770,7 +1770,7 @@
   5_4.mo:Expected error in mat string-for-each: "string-for-each: "" is not a procedure".
   5_4.mo:Expected error in mat string-for-each: "string-for-each: "" is not a procedure".
   5_4.mo:Expected error in mat string-for-each: "string-for-each: "" is not a procedure".
---- 2110,2125 ----
+--- 2122,2137 ----
   5_4.mo:Expected error in mat integer->char: "integer->char: 1114112 is not a valid unicode scalar value".
   5_4.mo:Expected error in mat integer->char: "integer->char: 1179648 is not a valid unicode scalar value".
   5_4.mo:Expected error in mat integer->char: "integer->char: <int> is not a valid unicode scalar value".
@@ -1788,7 +1788,7 @@
   5_4.mo:Expected error in mat string-for-each: "string-for-each: "" is not a procedure".
   5_4.mo:Expected error in mat string-for-each: "string-for-each: "" is not a procedure".
 ***************
-*** 2134,2162 ****
+*** 2146,2174 ****
   5_4.mo:Expected error in mat string-for-each: "string-for-each: lengths of input string "" and "x" differ".
   5_4.mo:Expected error in mat string-for-each: "string-for-each: lengths of input string "y" and "" differ".
   5_4.mo:Expected error in mat string-for-each: "string-for-each: lengths of input string "y" and "" differ".
@@ -1818,7 +1818,7 @@
   5_4.mo:Expected error in mat normalization-tests: "string-normalize-nfkc: ouch is not a string".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: a is not a string".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: -1 is not a valid start index for "a"".
---- 2134,2162 ----
+--- 2146,2174 ----
   5_4.mo:Expected error in mat string-for-each: "string-for-each: lengths of input string "" and "x" differ".
   5_4.mo:Expected error in mat string-for-each: "string-for-each: lengths of input string "y" and "" differ".
   5_4.mo:Expected error in mat string-for-each: "string-for-each: lengths of input string "y" and "" differ".
@@ -1849,7 +1849,7 @@
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: a is not a string".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: -1 is not a valid start index for "a"".
 ***************
-*** 2165,2171 ****
+*** 2177,2183 ****
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: 1 and 0 are not valid start/end indices for "a"".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: 0 and a are not valid start/end indices for "a"".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: 1 and 2 are not valid start/end indices for "a"".
@@ -1857,7 +1857,7 @@
   5_4.mo:Expected error in mat grapheme: "string-grapheme-span: a is not a string".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-span: -1 is not a valid start index for "a"".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-span: a is not a valid start index for "a"".
---- 2165,2171 ----
+--- 2177,2183 ----
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: 1 and 0 are not valid start/end indices for "a"".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: 0 and a are not valid start/end indices for "a"".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-count: 1 and 2 are not valid start/end indices for "a"".
@@ -1866,7 +1866,7 @@
   5_4.mo:Expected error in mat grapheme: "string-grapheme-span: -1 is not a valid start index for "a"".
   5_4.mo:Expected error in mat grapheme: "string-grapheme-span: a is not a valid start index for "a"".
 ***************
-*** 2177,2298 ****
+*** 2189,2310 ****
   5_4.mo:Expected error in mat grapheme: "char-grapheme-step: a is not a character".
   5_4.mo:Expected error in mat grapheme: "char-grapheme-step: #\a is not a grapheme cluster state".
   5_4.mo:Expected error in mat grapheme: "char-grapheme-step: 1267650600228229401496703205376 is not a grapheme cluster state".
@@ -1989,7 +1989,7 @@
   5_5.mo:Expected error in mat r6rs:string>=?/r6rs:string-ci>=?: "string-ci>=?: a is not a string".
   5_5.mo:Expected error in mat r6rs:string>=?/r6rs:string-ci>=?: "string-ci>=?: a is not a string".
   5_5.mo:Expected error in mat r6rs:string>=?/r6rs:string-ci>=?: "string-ci>=?: a is not a string".
---- 2177,2298 ----
+--- 2189,2310 ----
   5_4.mo:Expected error in mat grapheme: "char-grapheme-step: a is not a character".
   5_4.mo:Expected error in mat grapheme: "char-grapheme-step: #\a is not a grapheme cluster state".
   5_4.mo:Expected error in mat grapheme: "char-grapheme-step: 1267650600228229401496703205376 is not a grapheme cluster state".
@@ -2113,7 +2113,7 @@
   5_5.mo:Expected error in mat r6rs:string>=?/r6rs:string-ci>=?: "string-ci>=?: a is not a string".
   5_5.mo:Expected error in mat r6rs:string>=?/r6rs:string-ci>=?: "string-ci>=?: a is not a string".
 ***************
-*** 2300,2338 ****
+*** 2312,2350 ****
   5_5.mo:Expected error in mat string: "string: a is not a character".
   5_5.mo:Expected error in mat string: "string: a is not a character".
   5_5.mo:Expected error in mat string: "string: a is not a character".
@@ -2153,7 +2153,7 @@
   5_5.mo:Expected error in mat string-copy!: "string-copy!: 0 is not a string".
   5_5.mo:Expected error in mat string-copy!: "string-copy!: #vu8(1 2 3) is not a mutable string".
   5_5.mo:Expected error in mat string-copy!: "string-copy!: invalid start value -1".
---- 2300,2338 ----
+--- 2312,2350 ----
   5_5.mo:Expected error in mat string: "string: a is not a character".
   5_5.mo:Expected error in mat string: "string: a is not a character".
   5_5.mo:Expected error in mat string: "string: a is not a character".
@@ -2194,7 +2194,7 @@
   5_5.mo:Expected error in mat string-copy!: "string-copy!: #vu8(1 2 3) is not a mutable string".
   5_5.mo:Expected error in mat string-copy!: "string-copy!: invalid start value -1".
 ***************
-*** 2356,2364 ****
+*** 2368,2376 ****
   5_5.mo:Expected error in mat string-copy!: "string-copy!: index 4 + count 1 is beyond the end of "1234"".
   5_5.mo:Expected error in mat string-copy!: "string-copy!: index 0 + count 500 is beyond the end of "abcdefghi"".
   5_5.mo:Expected error in mat string-copy!: "string-copy!: index 500 + count 0 is beyond the end of "abcdefghi"".
@@ -2204,7 +2204,7 @@
   5_5.mo:Expected error in mat string-truncate!: "string-truncate!: 0 is not a mutable string".
   5_5.mo:Expected error in mat string-truncate!: "string-truncate!: #vu8(1 2 3) is not a mutable string".
   5_5.mo:Expected error in mat string-truncate!: "string-truncate!: invalid new length -1 for "abcdefghi"".
---- 2356,2364 ----
+--- 2368,2376 ----
   5_5.mo:Expected error in mat string-copy!: "string-copy!: index 4 + count 1 is beyond the end of "1234"".
   5_5.mo:Expected error in mat string-copy!: "string-copy!: index 0 + count 500 is beyond the end of "abcdefghi"".
   5_5.mo:Expected error in mat string-copy!: "string-copy!: index 500 + count 0 is beyond the end of "abcdefghi"".
@@ -2215,7 +2215,7 @@
   5_5.mo:Expected error in mat string-truncate!: "string-truncate!: #vu8(1 2 3) is not a mutable string".
   5_5.mo:Expected error in mat string-truncate!: "string-truncate!: invalid new length -1 for "abcdefghi"".
 ***************
-*** 2373,2425 ****
+*** 2385,2437 ****
   5_5.mo:Expected error in mat string-append-immutable: "string-append-immutable: a is not a string".
   5_5.mo:Expected error in mat string-append-immutable: "string-append-immutable: b is not a string".
   5_5.mo:Expected error in mat string-append-immutable: "string-append-immutable: b is not a string".
@@ -2269,7 +2269,7 @@
   bytevector.mo:Expected error in mat make-bytevector: "make-bytevector: -1 is not a valid bytevector length".
   bytevector.mo:Expected error in mat make-bytevector: "make-bytevector: -1 is not a valid bytevector length".
   bytevector.mo:Expected error in mat make-bytevector: "make-bytevector: <int> is not a valid bytevector length".
---- 2373,2425 ----
+--- 2385,2437 ----
   5_5.mo:Expected error in mat string-append-immutable: "string-append-immutable: a is not a string".
   5_5.mo:Expected error in mat string-append-immutable: "string-append-immutable: b is not a string".
   5_5.mo:Expected error in mat string-append-immutable: "string-append-immutable: b is not a string".
@@ -2324,7 +2324,7 @@
   bytevector.mo:Expected error in mat make-bytevector: "make-bytevector: -1 is not a valid bytevector length".
   bytevector.mo:Expected error in mat make-bytevector: "make-bytevector: <int> is not a valid bytevector length".
 ***************
-*** 2436,2465 ****
+*** 2448,2477 ****
   bytevector.mo:Expected error in mat bytevector: "bytevector: invalid value -500".
   bytevector.mo:Expected error in mat bytevector: "bytevector: invalid value 1e100".
   bytevector.mo:Expected error in mat bytevector: "bytevector: invalid value 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".
@@ -2355,7 +2355,7 @@
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: (3 4 5) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: (3 4 5) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: 3 is not a valid index for #vu8(3 4 5)".
---- 2436,2465 ----
+--- 2448,2477 ----
   bytevector.mo:Expected error in mat bytevector: "bytevector: invalid value -500".
   bytevector.mo:Expected error in mat bytevector: "bytevector: invalid value 1e100".
   bytevector.mo:Expected error in mat bytevector: "bytevector: invalid value 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".
@@ -2387,7 +2387,7 @@
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: (3 4 5) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: 3 is not a valid index for #vu8(3 4 5)".
 ***************
-*** 2468,2477 ****
+*** 2480,2489 ****
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: invalid value -129".
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: invalid value 128".
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: invalid value d".
@@ -2398,7 +2398,7 @@
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: (3 4 5) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: (3 4 5) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: 3 is not a valid index for #vu8(3 4 5)".
---- 2468,2477 ----
+--- 2480,2489 ----
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: invalid value -129".
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: invalid value 128".
   bytevector.mo:Expected error in mat bytevector-s8-set!: "bytevector-s8-set!: invalid value d".
@@ -2410,7 +2410,7 @@
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: (3 4 5) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: 3 is not a valid index for #vu8(3 4 5)".
 ***************
-*** 2480,2488 ****
+*** 2492,2500 ****
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: invalid value -1".
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: invalid value 256".
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: invalid value d".
@@ -2420,7 +2420,7 @@
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: invalid index -1 for bytevector #vu8(3 252 5)".
---- 2480,2488 ----
+--- 2492,2500 ----
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: invalid value -1".
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: invalid value 256".
   bytevector.mo:Expected error in mat bytevector-u8-set!: "bytevector-u8-set!: invalid value d".
@@ -2431,7 +2431,7 @@
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: invalid index -1 for bytevector #vu8(3 252 5)".
 ***************
-*** 2490,2498 ****
+*** 2502,2510 ****
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: invalid index 2 for bytevector #vu8(3 252 5)".
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: invalid index 3 for bytevector #vu8(3 252 5)".
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: invalid index 4.0 for bytevector #vu8(3 252 5)".
@@ -2441,7 +2441,7 @@
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: invalid index -1 for bytevector #vu8(3 252 5)".
---- 2490,2498 ----
+--- 2502,2510 ----
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: invalid index 2 for bytevector #vu8(3 252 5)".
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: invalid index 3 for bytevector #vu8(3 252 5)".
   bytevector.mo:Expected error in mat bytevector-s16-native-ref: "bytevector-s16-native-ref: invalid index 4.0 for bytevector #vu8(3 252 5)".
@@ -2452,7 +2452,7 @@
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: invalid index -1 for bytevector #vu8(3 252 5)".
 ***************
-*** 2500,2509 ****
+*** 2512,2521 ****
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: invalid index 2 for bytevector #vu8(3 252 5)".
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: invalid index 3 for bytevector #vu8(3 252 5)".
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: invalid index 4.0 for bytevector #vu8(3 252 5)".
@@ -2463,7 +2463,7 @@
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2500,2509 ----
+--- 2512,2521 ----
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: invalid index 2 for bytevector #vu8(3 252 5)".
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: invalid index 3 for bytevector #vu8(3 252 5)".
   bytevector.mo:Expected error in mat bytevector-u16-native-ref: "bytevector-u16-native-ref: invalid index 4.0 for bytevector #vu8(3 252 5)".
@@ -2475,7 +2475,7 @@
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2517,2526 ****
+*** 2529,2538 ****
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: invalid value 32768".
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: invalid value -32769".
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: invalid value "hello"".
@@ -2486,7 +2486,7 @@
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2517,2526 ----
+--- 2529,2538 ----
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: invalid value 32768".
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: invalid value -32769".
   bytevector.mo:Expected error in mat bytevector-s16-native-set!: "bytevector-s16-native-set!: invalid value "hello"".
@@ -2498,7 +2498,7 @@
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2534,2542 ****
+*** 2546,2554 ****
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: invalid value 65536".
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: invalid value -1".
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: invalid value "hello"".
@@ -2508,7 +2508,7 @@
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: invalid index -1 for bytevector #vu8(3 252 5)".
---- 2534,2542 ----
+--- 2546,2554 ----
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: invalid value 65536".
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: invalid value -1".
   bytevector.mo:Expected error in mat bytevector-u16-native-set!: "bytevector-u16-native-set!: invalid value "hello"".
@@ -2519,7 +2519,7 @@
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: invalid index -1 for bytevector #vu8(3 252 5)".
 ***************
-*** 2546,2554 ****
+*** 2558,2566 ****
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: unrecognized endianness #t".
@@ -2529,7 +2529,7 @@
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: invalid index -1 for bytevector #vu8(3 252 5)".
---- 2546,2554 ----
+--- 2558,2566 ----
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s16-ref: "bytevector-s16-ref: unrecognized endianness #t".
@@ -2540,7 +2540,7 @@
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: #(3 252 5) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: invalid index -1 for bytevector #vu8(3 252 5)".
 ***************
-*** 2558,2567 ****
+*** 2570,2579 ****
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: unrecognized endianness #t".
@@ -2551,7 +2551,7 @@
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2558,2567 ----
+--- 2570,2579 ----
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u16-ref: "bytevector-u16-ref: unrecognized endianness #t".
@@ -2563,7 +2563,7 @@
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2577,2586 ****
+*** 2589,2598 ****
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: unrecognized endianness #t".
@@ -2574,7 +2574,7 @@
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2577,2586 ----
+--- 2589,2598 ----
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s16-set!: "bytevector-s16-set!: unrecognized endianness #t".
@@ -2586,7 +2586,7 @@
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2596,2605 ****
+*** 2608,2617 ****
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: unrecognized endianness #t".
@@ -2597,7 +2597,7 @@
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2596,2605 ----
+--- 2608,2617 ----
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u16-set!: "bytevector-u16-set!: unrecognized endianness #t".
@@ -2609,7 +2609,7 @@
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2609,2618 ****
+*** 2621,2630 ****
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: unrecognized endianness #t".
@@ -2620,7 +2620,7 @@
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2609,2618 ----
+--- 2621,2630 ----
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s24-ref: "bytevector-s24-ref: unrecognized endianness #t".
@@ -2632,7 +2632,7 @@
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2622,2632 ****
+*** 2634,2644 ****
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: unrecognized endianness #t".
@@ -2644,7 +2644,7 @@
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2622,2632 ----
+--- 2634,2644 ----
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u24-ref: "bytevector-u24-ref: unrecognized endianness #t".
@@ -2657,7 +2657,7 @@
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2640,2650 ****
+*** 2652,2662 ****
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2669,7 +2669,7 @@
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2640,2650 ----
+--- 2652,2662 ----
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s24-set!: "bytevector-s24-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2682,7 +2682,7 @@
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2658,2666 ****
+*** 2670,2678 ****
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2692,7 +2692,7 @@
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2658,2666 ----
+--- 2670,2678 ----
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u24-set!: "bytevector-u24-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2703,7 +2703,7 @@
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2672,2680 ****
+*** 2684,2692 ****
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: invalid index 6 for bytevector #vu8(3 252 5 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: invalid index 7 for bytevector #vu8(3 252 5 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: invalid index 4.0 for bytevector #vu8(3 252 5 0 0 0 ...)".
@@ -2713,7 +2713,7 @@
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2672,2680 ----
+--- 2684,2692 ----
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: invalid index 6 for bytevector #vu8(3 252 5 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: invalid index 7 for bytevector #vu8(3 252 5 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-s32-native-ref: "bytevector-s32-native-ref: invalid index 4.0 for bytevector #vu8(3 252 5 0 0 0 ...)".
@@ -2724,7 +2724,7 @@
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2686,2695 ****
+*** 2698,2707 ****
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: invalid index 6 for bytevector #vu8(3 252 5 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: invalid index 7 for bytevector #vu8(3 252 5 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: invalid index 4.0 for bytevector #vu8(3 252 5 0 0 0 ...)".
@@ -2735,7 +2735,7 @@
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2686,2695 ----
+--- 2698,2707 ----
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: invalid index 6 for bytevector #vu8(3 252 5 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: invalid index 7 for bytevector #vu8(3 252 5 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-u32-native-ref: "bytevector-u32-native-ref: invalid index 4.0 for bytevector #vu8(3 252 5 0 0 0 ...)".
@@ -2747,7 +2747,7 @@
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2716,2725 ****
+*** 2728,2737 ****
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: invalid value <int>".
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: invalid value <-int>".
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: invalid value "hello"".
@@ -2758,7 +2758,7 @@
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2716,2725 ----
+--- 2728,2737 ----
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: invalid value <int>".
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: invalid value <-int>".
   bytevector.mo:Expected error in mat bytevector-s32-native-set!: "bytevector-s32-native-set!: invalid value "hello"".
@@ -2770,7 +2770,7 @@
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2746,2755 ****
+*** 2758,2767 ****
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: invalid value <int>".
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: invalid value -1".
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: invalid value "hello"".
@@ -2781,7 +2781,7 @@
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2746,2755 ----
+--- 2758,2767 ----
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: invalid value <int>".
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: invalid value -1".
   bytevector.mo:Expected error in mat bytevector-u32-native-set!: "bytevector-u32-native-set!: invalid value "hello"".
@@ -2793,7 +2793,7 @@
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2759,2768 ****
+*** 2771,2780 ****
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: unrecognized endianness #t".
@@ -2804,7 +2804,7 @@
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2759,2768 ----
+--- 2771,2780 ----
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s32-ref: "bytevector-s32-ref: unrecognized endianness #t".
@@ -2816,7 +2816,7 @@
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2772,2782 ****
+*** 2784,2794 ****
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: unrecognized endianness #t".
@@ -2828,7 +2828,7 @@
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2772,2782 ----
+--- 2784,2794 ----
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u32-ref: "bytevector-u32-ref: unrecognized endianness #t".
@@ -2841,7 +2841,7 @@
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2791,2801 ****
+*** 2803,2813 ****
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2853,7 +2853,7 @@
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2791,2801 ----
+--- 2803,2813 ----
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s32-set!: "bytevector-s32-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2866,7 +2866,7 @@
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2810,2819 ****
+*** 2822,2831 ****
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2877,7 +2877,7 @@
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2810,2819 ----
+--- 2822,2831 ----
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u32-set!: "bytevector-u32-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2889,7 +2889,7 @@
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2823,2832 ****
+*** 2835,2844 ****
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: unrecognized endianness #t".
@@ -2900,7 +2900,7 @@
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2823,2832 ----
+--- 2835,2844 ----
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s40-ref: "bytevector-s40-ref: unrecognized endianness #t".
@@ -2912,7 +2912,7 @@
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2836,2846 ****
+*** 2848,2858 ****
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: unrecognized endianness #t".
@@ -2924,7 +2924,7 @@
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2836,2846 ----
+--- 2848,2858 ----
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u40-ref: "bytevector-u40-ref: unrecognized endianness #t".
@@ -2937,7 +2937,7 @@
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2854,2864 ****
+*** 2866,2876 ****
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2949,7 +2949,7 @@
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2854,2864 ----
+--- 2866,2876 ----
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s40-set!: "bytevector-s40-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2962,7 +2962,7 @@
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2872,2881 ****
+*** 2884,2893 ****
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2973,7 +2973,7 @@
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2872,2881 ----
+--- 2884,2893 ----
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u40-set!: "bytevector-u40-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -2985,7 +2985,7 @@
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2885,2894 ****
+*** 2897,2906 ****
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: unrecognized endianness #t".
@@ -2996,7 +2996,7 @@
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2885,2894 ----
+--- 2897,2906 ----
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s48-ref: "bytevector-s48-ref: unrecognized endianness #t".
@@ -3008,7 +3008,7 @@
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2898,2908 ****
+*** 2910,2920 ****
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: unrecognized endianness #t".
@@ -3020,7 +3020,7 @@
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2898,2908 ----
+--- 2910,2920 ----
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u48-ref: "bytevector-u48-ref: unrecognized endianness #t".
@@ -3033,7 +3033,7 @@
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2916,2926 ****
+*** 2928,2938 ****
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -3045,7 +3045,7 @@
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2916,2926 ----
+--- 2928,2938 ----
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s48-set!: "bytevector-s48-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -3058,7 +3058,7 @@
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2934,2943 ****
+*** 2946,2955 ****
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -3069,7 +3069,7 @@
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2934,2943 ----
+--- 2946,2955 ----
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u48-set!: "bytevector-u48-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -3081,7 +3081,7 @@
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2947,2956 ****
+*** 2959,2968 ****
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: unrecognized endianness #t".
@@ -3092,7 +3092,7 @@
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
---- 2947,2956 ----
+--- 2959,2968 ----
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-s56-ref: "bytevector-s56-ref: unrecognized endianness #t".
@@ -3104,7 +3104,7 @@
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: invalid index -1 for bytevector #vu8(3 252 5 0 0 0 ...)".
 ***************
-*** 2960,2970 ****
+*** 2972,2982 ****
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: unrecognized endianness #t".
@@ -3116,7 +3116,7 @@
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2960,2970 ----
+--- 2972,2982 ----
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: unrecognized endianness bigger".
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: unrecognized endianness "little"".
   bytevector.mo:Expected error in mat bytevector-u56-ref: "bytevector-u56-ref: unrecognized endianness #t".
@@ -3129,7 +3129,7 @@
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2978,2988 ****
+*** 2990,3000 ****
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -3141,7 +3141,7 @@
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 2978,2988 ----
+--- 2990,3000 ----
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-s56-set!: "bytevector-s56-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -3154,7 +3154,7 @@
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 2996,3004 ****
+*** 3008,3016 ****
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -3164,7 +3164,7 @@
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 2996,3004 ----
+--- 3008,3016 ----
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: unrecognized endianness huge".
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: unrecognized endianness "tiny"".
   bytevector.mo:Expected error in mat bytevector-u56-set!: "bytevector-u56-set!: unrecognized endianness #vu8(173 173 173 173 173 173 ...)".
@@ -3175,7 +3175,7 @@
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3028,3036 ****
+*** 3040,3048 ****
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: invalid index 102 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: invalid index 103 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: invalid index 4.0 for bytevector #vu8(0 0 0 0 0 0 ...)".
@@ -3185,7 +3185,7 @@
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3028,3036 ----
+--- 3040,3048 ----
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: invalid index 102 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: invalid index 103 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-s64-native-ref: "bytevector-s64-native-ref: invalid index 4.0 for bytevector #vu8(0 0 0 0 0 0 ...)".
@@ -3196,7 +3196,7 @@
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3060,3069 ****
+*** 3072,3081 ****
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: invalid index 102 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: invalid index 103 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: invalid index 4.0 for bytevector #vu8(0 0 0 0 0 0 ...)".
@@ -3207,7 +3207,7 @@
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 3060,3069 ----
+--- 3072,3081 ----
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: invalid index 102 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: invalid index 103 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-u64-native-ref: "bytevector-u64-native-ref: invalid index 4.0 for bytevector #vu8(0 0 0 0 0 0 ...)".
@@ -3219,7 +3219,7 @@
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 3097,3106 ****
+*** 3109,3118 ****
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: invalid value <int>".
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: invalid value <-int>".
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: invalid value "hello"".
@@ -3230,7 +3230,7 @@
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 3097,3106 ----
+--- 3109,3118 ----
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: invalid value <int>".
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: invalid value <-int>".
   bytevector.mo:Expected error in mat bytevector-s64-native-set!: "bytevector-s64-native-set!: invalid value "hello"".
@@ -3242,7 +3242,7 @@
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 3134,3143 ****
+*** 3146,3155 ****
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: invalid value <int>".
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: invalid value -1".
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: invalid value "hello"".
@@ -3253,7 +3253,7 @@
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3134,3143 ----
+--- 3146,3155 ----
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: invalid value <int>".
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: invalid value -1".
   bytevector.mo:Expected error in mat bytevector-u64-native-set!: "bytevector-u64-native-set!: invalid value "hello"".
@@ -3265,7 +3265,7 @@
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3153,3162 ****
+*** 3165,3174 ****
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: unrecognized endianness (quote bonkers)".
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: unrecognized endianness get-real".
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: unrecognized endianness 1e23".
@@ -3276,7 +3276,7 @@
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3153,3162 ----
+--- 3165,3174 ----
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: unrecognized endianness (quote bonkers)".
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: unrecognized endianness get-real".
   bytevector.mo:Expected error in mat bytevector-s64-ref: "bytevector-s64-ref: unrecognized endianness 1e23".
@@ -3288,7 +3288,7 @@
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3172,3182 ****
+*** 3184,3194 ****
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: unrecognized endianness (quote bonkers)".
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: unrecognized endianness get-real".
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: unrecognized endianness 1e23".
@@ -3300,7 +3300,7 @@
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 3172,3182 ----
+--- 3184,3194 ----
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: unrecognized endianness (quote bonkers)".
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: unrecognized endianness get-real".
   bytevector.mo:Expected error in mat bytevector-u64-ref: "bytevector-u64-ref: unrecognized endianness 1e23".
@@ -3313,7 +3313,7 @@
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 3195,3205 ****
+*** 3207,3217 ****
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: unrecognized endianness gorgeous".
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: unrecognized endianness #(ravenous)".
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: unrecognized endianness #t".
@@ -3325,7 +3325,7 @@
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
---- 3195,3205 ----
+--- 3207,3217 ----
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: unrecognized endianness gorgeous".
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: unrecognized endianness #(ravenous)".
   bytevector.mo:Expected error in mat bytevector-s64-set!: "bytevector-s64-set!: unrecognized endianness #t".
@@ -3338,7 +3338,7 @@
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: #(0 0 0 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: invalid index -1 for bytevector #vu8(173 173 173 173 173 173 ...)".
 ***************
-*** 3218,3226 ****
+*** 3230,3238 ****
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: unrecognized endianness gorgeous".
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: unrecognized endianness #(ravenous)".
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: unrecognized endianness #t".
@@ -3348,7 +3348,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3218,3226 ----
+--- 3230,3238 ----
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: unrecognized endianness gorgeous".
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: unrecognized endianness #(ravenous)".
   bytevector.mo:Expected error in mat bytevector-u64-set!: "bytevector-u64-set!: unrecognized endianness #t".
@@ -3359,7 +3359,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3256,3264 ****
+*** 3268,3276 ****
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: invalid index 38 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: invalid index 39 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: invalid index 4.0 for bytevector #vu8(0 0 0 0 0 0 ...)".
@@ -3369,7 +3369,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3256,3264 ----
+--- 3268,3276 ----
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: invalid index 38 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: invalid index 39 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-ref: "bytevector-ieee-single-native-ref: invalid index 4.0 for bytevector #vu8(0 0 0 0 0 0 ...)".
@@ -3380,7 +3380,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3298,3307 ****
+*** 3310,3319 ****
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: invalid index 70 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: invalid index 71 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: invalid index 4.0 for bytevector #vu8(0 0 0 0 0 0 ...)".
@@ -3391,7 +3391,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: invalid index -1 for bytevector #vu8(235 235 235 235 235 235 ...)".
---- 3298,3307 ----
+--- 3310,3319 ----
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: invalid index 70 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: invalid index 71 for bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-ref: "bytevector-ieee-double-native-ref: invalid index 4.0 for bytevector #vu8(0 0 0 0 0 0 ...)".
@@ -3403,7 +3403,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: invalid index -1 for bytevector #vu8(235 235 235 235 235 235 ...)".
 ***************
-*** 3335,3344 ****
+*** 3347,3356 ****
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: 1.0+0.0i is not a real number".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: 1.0-0.0i is not a real number".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: "oops" is not a real number".
@@ -3414,7 +3414,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: invalid index -1 for bytevector #vu8(235 235 235 235 235 235 ...)".
---- 3335,3344 ----
+--- 3347,3356 ----
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: 1.0+0.0i is not a real number".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: 1.0-0.0i is not a real number".
   bytevector.mo:Expected error in mat bytevector-ieee-single-native-set!: "bytevector-ieee-single-native-set!: "oops" is not a real number".
@@ -3426,7 +3426,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: invalid index -1 for bytevector #vu8(235 235 235 235 235 235 ...)".
 ***************
-*** 3384,3393 ****
+*** 3396,3405 ****
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: 1.0+0.0i is not a real number".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: 1.0-0.0i is not a real number".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: "oops" is not a real number".
@@ -3437,7 +3437,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: invalid index -1 for bytevector #vu8(0 0 0 0 199 0 ...)".
---- 3384,3393 ----
+--- 3396,3405 ----
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: 1.0+0.0i is not a real number".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: 1.0-0.0i is not a real number".
   bytevector.mo:Expected error in mat bytevector-ieee-double-native-set!: "bytevector-ieee-double-native-set!: "oops" is not a real number".
@@ -3449,7 +3449,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: invalid index -1 for bytevector #vu8(0 0 0 0 199 0 ...)".
 ***************
-*** 3399,3408 ****
+*** 3411,3420 ****
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: unrecognized endianness "nuts"".
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: unrecognized endianness crazy".
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: unrecognized endianness 35".
@@ -3460,7 +3460,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3399,3408 ----
+--- 3411,3420 ----
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: unrecognized endianness "nuts"".
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: unrecognized endianness crazy".
   bytevector.mo:Expected error in mat bytevector-ieee-single-ref: "bytevector-ieee-single-ref: unrecognized endianness 35".
@@ -3472,7 +3472,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3418,3428 ****
+*** 3430,3440 ****
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: unrecognized endianness "nuts"".
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: unrecognized endianness crazy".
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: unrecognized endianness 35".
@@ -3484,7 +3484,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: invalid index -1 for bytevector #vu8(235 235 235 235 235 235 ...)".
---- 3418,3428 ----
+--- 3430,3440 ----
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: unrecognized endianness "nuts"".
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: unrecognized endianness crazy".
   bytevector.mo:Expected error in mat bytevector-ieee-double-ref: "bytevector-ieee-double-ref: unrecognized endianness 35".
@@ -3497,7 +3497,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: invalid index -1 for bytevector #vu8(235 235 235 235 235 235 ...)".
 ***************
-*** 3439,3449 ****
+*** 3451,3461 ****
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: unrecognized endianness "ouch"".
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: unrecognized endianness what?".
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: unrecognized endianness #\newline".
@@ -3509,7 +3509,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: invalid index -1 for bytevector #vu8(235 235 235 235 235 235 ...)".
---- 3439,3449 ----
+--- 3451,3461 ----
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: unrecognized endianness "ouch"".
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: unrecognized endianness what?".
   bytevector.mo:Expected error in mat bytevector-ieee-single-set!: "bytevector-ieee-single-set!: unrecognized endianness #\newline".
@@ -3522,7 +3522,7 @@
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: invalid index -1 for bytevector #vu8(235 235 235 235 235 235 ...)".
 ***************
-*** 3464,3474 ****
+*** 3476,3486 ****
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: unrecognized endianness "ouch"".
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: unrecognized endianness what?".
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: unrecognized endianness #\newline".
@@ -3534,7 +3534,7 @@
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3464,3474 ----
+--- 3476,3486 ----
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: unrecognized endianness "ouch"".
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: unrecognized endianness what?".
   bytevector.mo:Expected error in mat bytevector-ieee-double-set!: "bytevector-ieee-double-set!: unrecognized endianness #\newline".
@@ -3547,7 +3547,7 @@
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3503,3513 ****
+*** 3515,3525 ****
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: invalid size 0".
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: invalid size -1".
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: invalid size byte".
@@ -3559,7 +3559,7 @@
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3503,3513 ----
+--- 3515,3525 ----
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: invalid size 0".
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: invalid size -1".
   bytevector.mo:Expected error in mat bytevector-sint-ref: "bytevector-sint-ref: invalid size byte".
@@ -3572,7 +3572,7 @@
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: #(3 252 5 0 0 0 ...) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3545,3556 ****
+*** 3557,3568 ****
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: invalid size <int> for bytevector #vu8(1 2 3 4)".
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: invalid size -1".
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: invalid size byte".
@@ -3585,7 +3585,7 @@
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3545,3556 ----
+--- 3557,3568 ----
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: invalid size <int> for bytevector #vu8(1 2 3 4)".
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: invalid size -1".
   bytevector.mo:Expected error in mat bytevector-uint-ref: "bytevector-uint-ref: invalid size byte".
@@ -3599,7 +3599,7 @@
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3609,3620 ****
+*** 3621,3632 ****
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: invalid size 0".
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: invalid size -1".
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: invalid size byte".
@@ -3612,7 +3612,7 @@
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
---- 3609,3620 ----
+--- 3621,3632 ----
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: invalid size 0".
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: invalid size -1".
   bytevector.mo:Expected error in mat bytevector-sint-set!: "bytevector-sint-set!: invalid size byte".
@@ -3626,7 +3626,7 @@
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: #(3 252 5 0 0 0 ...) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: invalid index -1 for bytevector #vu8(0 0 0 0 0 0 ...)".
 ***************
-*** 3673,3688 ****
+*** 3685,3700 ****
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: invalid size 0".
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: invalid size -1".
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: invalid size byte".
@@ -3643,7 +3643,7 @@
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: 0 is not a bytevector".
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: #(1 2 3) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: invalid start value -1".
---- 3673,3688 ----
+--- 3685,3700 ----
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: invalid size 0".
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: invalid size -1".
   bytevector.mo:Expected error in mat bytevector-uint-set!: "bytevector-uint-set!: invalid size byte".
@@ -3661,7 +3661,7 @@
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: #(1 2 3) is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: invalid start value -1".
 ***************
-*** 3706,3714 ****
+*** 3718,3726 ****
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: index 4 + count 1 is beyond the end of #vu8(1 2 3 4)".
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: index 0 + count 500 is beyond the end of #vu8(255 254 253 252 251 250 ...)".
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: index 500 + count 0 is beyond the end of #vu8(255 254 253 252 251 250 ...)".
@@ -3671,7 +3671,7 @@
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: 0 is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: "abc" is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: invalid new length -1 for #vu8(1 2 3 4 5 6 ...)".
---- 3706,3714 ----
+--- 3718,3726 ----
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: index 4 + count 1 is beyond the end of #vu8(1 2 3 4)".
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: index 0 + count 500 is beyond the end of #vu8(255 254 253 252 251 250 ...)".
   bytevector.mo:Expected error in mat bytevector-copy!: "bytevector-copy!: index 500 + count 0 is beyond the end of #vu8(255 254 253 252 251 250 ...)".
@@ -3682,7 +3682,7 @@
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: "abc" is not a mutable bytevector".
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: invalid new length -1 for #vu8(1 2 3 4 5 6 ...)".
 ***************
-*** 3716,3756 ****
+*** 3728,3768 ****
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: invalid new length 1000 for #vu8(1 2 3 4 5 6 ...)".
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: invalid new length <int> for #vu8(1 2 3 4 5 6 ...)".
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: invalid new length a for #vu8(1 2 3 4 5 6 ...)".
@@ -3724,7 +3724,7 @@
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: #(a b c) is not a proper list".
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: #(a b c) is not a proper list".
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: (1 2 . 3) is not a proper list".
---- 3716,3756 ----
+--- 3728,3768 ----
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: invalid new length 1000 for #vu8(1 2 3 4 5 6 ...)".
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: invalid new length <int> for #vu8(1 2 3 4 5 6 ...)".
   bytevector.mo:Expected error in mat bytevector-truncate!: "bytevector-truncate!: invalid new length a for #vu8(1 2 3 4 5 6 ...)".
@@ -3767,7 +3767,7 @@
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: #(a b c) is not a proper list".
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: (1 2 . 3) is not a proper list".
 ***************
-*** 3789,3797 ****
+*** 3801,3809 ****
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: invalid size 0".
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: invalid size 1.0".
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: invalid size "oops"".
@@ -3777,7 +3777,7 @@
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: #(a b c) is not a proper list".
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: #(a b c) is not a proper list".
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: (1 2 . 3) is not a proper list".
---- 3789,3797 ----
+--- 3801,3809 ----
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: invalid size 0".
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: invalid size 1.0".
   bytevector.mo:Expected error in mat sint-list->bytevector: "sint-list->bytevector: invalid size "oops"".
@@ -3788,7 +3788,7 @@
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: #(a b c) is not a proper list".
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: (1 2 . 3) is not a proper list".
 ***************
-*** 3830,3838 ****
+*** 3842,3850 ****
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: invalid size 0".
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: invalid size 1.0".
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: invalid size "oops"".
@@ -3798,7 +3798,7 @@
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: #(a b c) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: #(a b c) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: unrecognized endianness spam".
---- 3830,3838 ----
+--- 3842,3850 ----
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: invalid size 0".
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: invalid size 1.0".
   bytevector.mo:Expected error in mat uint-list->bytevector: "uint-list->bytevector: invalid size "oops"".
@@ -3809,7 +3809,7 @@
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: #(a b c) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: unrecognized endianness spam".
 ***************
-*** 3852,3860 ****
+*** 3864,3872 ****
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: bytevector length 12 is not a multiple of size 10".
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: bytevector length 12 is not a multiple of size 11".
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: bytevector length 12 is not a multiple of size 50".
@@ -3819,7 +3819,7 @@
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: #(a b c) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: #(a b c) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: unrecognized endianness spam".
---- 3852,3860 ----
+--- 3864,3872 ----
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: bytevector length 12 is not a multiple of size 10".
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: bytevector length 12 is not a multiple of size 11".
   bytevector.mo:Expected error in mat bytevector->sint-list: "bytevector->sint-list: bytevector length 12 is not a multiple of size 50".
@@ -3830,7 +3830,7 @@
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: #(a b c) is not a bytevector".
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: unrecognized endianness spam".
 ***************
-*** 3874,3882 ****
+*** 3886,3894 ****
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: bytevector length 12 is not a multiple of size 10".
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: bytevector length 12 is not a multiple of size 11".
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: bytevector length 12 is not a multiple of size 50".
@@ -3840,7 +3840,7 @@
   bytevector.mo:Expected error in mat bytevector=?: "bytevector=?: a is not a bytevector".
   bytevector.mo:Expected error in mat bytevector=?: "bytevector=?: "a" is not a bytevector".
   bytevector.mo:Expected error in mat tspl/csug-examples: "invalid endianness "spam"".
---- 3874,3882 ----
+--- 3886,3894 ----
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: bytevector length 12 is not a multiple of size 10".
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: bytevector length 12 is not a multiple of size 11".
   bytevector.mo:Expected error in mat bytevector->uint-list: "bytevector->uint-list: bytevector length 12 is not a multiple of size 50".
@@ -3851,7 +3851,7 @@
   bytevector.mo:Expected error in mat bytevector=?: "bytevector=?: "a" is not a bytevector".
   bytevector.mo:Expected error in mat tspl/csug-examples: "invalid endianness "spam"".
 ***************
-*** 3982,4002 ****
+*** 3994,4014 ****
   bytevector.mo:Expected error in mat bytevector-compress: "bytevector-uncompress: invalid data in source bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-compress: "bytevector-uncompress: bytevector #vu8(255 255 255 255 255 255 ...) claims invalid uncompressed size <int>".
   profile.mo:Expected error in mat compile-profile: "compile-profile: invalid mode src [must be #f, #t, source, or block]".
@@ -3873,7 +3873,7 @@
   profile.mo:Expected error in mat compile-profile: "profile-dump-data: #t is not a string".
   profile.mo:Expected error in mat compile-profile: "profile-dump-data: invalid dump 17".
   profile.mo:Expected error in mat compile-profile: "profile-dump-data: invalid dump (17)".
---- 3982,4002 ----
+--- 3994,4014 ----
   bytevector.mo:Expected error in mat bytevector-compress: "bytevector-uncompress: invalid data in source bytevector #vu8(0 0 0 0 0 0 ...)".
   bytevector.mo:Expected error in mat bytevector-compress: "bytevector-uncompress: bytevector #vu8(255 255 255 255 255 255 ...) claims invalid uncompressed size <int>".
   profile.mo:Expected error in mat compile-profile: "compile-profile: invalid mode src [must be #f, #t, source, or block]".
@@ -3896,7 +3896,7 @@
   profile.mo:Expected error in mat compile-profile: "profile-dump-data: invalid dump 17".
   profile.mo:Expected error in mat compile-profile: "profile-dump-data: invalid dump (17)".
 ***************
-*** 4018,4029 ****
+*** 4030,4041 ****
   profile.mo:Expected error in mat profile-form: "profile subform is not a source object 3".
   misc.mo:Expected error in mat compiler1: "variable i-am-not-bound is not bound".
   misc.mo:Expected error in mat compiler1: "attempt to apply non-procedure oops".
@@ -3909,7 +3909,7 @@
   misc.mo:Expected error in mat compiler3: "incorrect argument count in call (consumer 1 2) at line 3, char 19 of testfile.ss".
   misc.mo:Expected error in mat compiler3: "incorrect argument count in call (consumer 1 2)".
   misc.mo:Expected error in mat compiler3: "variable goto is not bound".
---- 4018,4029 ----
+--- 4030,4041 ----
   profile.mo:Expected error in mat profile-form: "profile subform is not a source object 3".
   misc.mo:Expected error in mat compiler1: "variable i-am-not-bound is not bound".
   misc.mo:Expected error in mat compiler1: "attempt to apply non-procedure oops".
@@ -3923,7 +3923,7 @@
   misc.mo:Expected error in mat compiler3: "incorrect argument count in call (consumer 1 2)".
   misc.mo:Expected error in mat compiler3: "variable goto is not bound".
 ***************
-*** 4071,4078 ****
+*** 4083,4090 ****
   misc.mo:Expected error in mat eval: "attempt to reference unbound identifier sort".
   misc.mo:Expected error in mat eval: "attempt to reference unbound identifier sort".
   misc.mo:Expected error in mat eval: "attempt to reference unbound identifier sort".
@@ -3932,7 +3932,7 @@
   misc.mo:Expected error in mat eval2: "attempt to reference unbound identifier list".
   misc.mo:Expected error in mat eval2: "attempt to reference unbound identifier force".
   misc.mo:Expected error in mat eval2: "attempt to reference unbound identifier force".
---- 4071,4078 ----
+--- 4083,4090 ----
   misc.mo:Expected error in mat eval: "attempt to reference unbound identifier sort".
   misc.mo:Expected error in mat eval: "attempt to reference unbound identifier sort".
   misc.mo:Expected error in mat eval: "attempt to reference unbound identifier sort".
@@ -3942,7 +3942,7 @@
   misc.mo:Expected error in mat eval2: "attempt to reference unbound identifier force".
   misc.mo:Expected error in mat eval2: "attempt to reference unbound identifier force".
 ***************
-*** 4124,4130 ****
+*** 4136,4142 ****
   misc.mo:Expected error in mat $fasl-file-equal?: "$fasl-file-equal?: failed for probably-does-not-exist: no such file or directory".
   misc.mo:Expected error in mat $fasl-file-equal?: "$fasl-file-equal?: failed for probably-does-not-exist: no such file or directory".
   misc.mo:Expected error in mat $fasl-file-equal?: "$fasl-file-equal?: record comparison failed while comparing testfile-fatfib1.so and testfile-fatfib3.so within fasl entry 4".
@@ -3950,7 +3950,7 @@
   misc.mo:Expected error in mat cost-center: "with-cost-center: foo is not a cost center".
   misc.mo:Expected error in mat cost-center: "with-cost-center: bar is not a procedure".
   misc.mo:Expected error in mat cost-center: "cost-center-instruction-count: 5 is not a cost center".
---- 4124,4130 ----
+--- 4136,4142 ----
   misc.mo:Expected error in mat $fasl-file-equal?: "$fasl-file-equal?: failed for probably-does-not-exist: no such file or directory".
   misc.mo:Expected error in mat $fasl-file-equal?: "$fasl-file-equal?: failed for probably-does-not-exist: no such file or directory".
   misc.mo:Expected error in mat $fasl-file-equal?: "$fasl-file-equal?: record comparison failed while comparing testfile-fatfib1.so and testfile-fatfib3.so within fasl entry 4".
@@ -3959,7 +3959,7 @@
   misc.mo:Expected error in mat cost-center: "with-cost-center: bar is not a procedure".
   misc.mo:Expected error in mat cost-center: "cost-center-instruction-count: 5 is not a cost center".
 ***************
-*** 4178,4185 ****
+*** 4190,4197 ****
   misc.mo:Expected error in mat apropos: "apropos: 3 is not a symbol or string".
   misc.mo:Expected error in mat apropos: "apropos: (hit me) is not a symbol or string".
   misc.mo:Expected error in mat apropos: "apropos-list: b is not an environment".
@@ -3968,7 +3968,7 @@
   misc.mo:Expected error in mat apropos: "variable $apropos-unbound1 is not bound".
   misc.mo:Expected error in mat apropos: "variable $apropos-unbound2 is not bound".
   misc.mo:Expected error in mat simplify-if: "textual-port?: a is not a port".
---- 4178,4185 ----
+--- 4190,4197 ----
   misc.mo:Expected error in mat apropos: "apropos: 3 is not a symbol or string".
   misc.mo:Expected error in mat apropos: "apropos: (hit me) is not a symbol or string".
   misc.mo:Expected error in mat apropos: "apropos-list: b is not an environment".
@@ -3978,7 +3978,7 @@
   misc.mo:Expected error in mat apropos: "variable $apropos-unbound2 is not bound".
   misc.mo:Expected error in mat simplify-if: "textual-port?: a is not a port".
 ***************
-*** 4194,4209 ****
+*** 4206,4221 ****
   misc.mo:Expected error in mat pariah: "invalid syntax (pariah)".
   misc.mo:Expected error in mat pariah: "invalid syntax (pariah . 17)".
   misc.mo:Expected error in mat procedure-arity-mask: "procedure-arity-mask: 17 is not a procedure".
@@ -3995,7 +3995,7 @@
   misc.mo:Expected error in mat wrapper-procedure: "make-arity-wrapper-procedure: 1 is not a procedure".
   misc.mo:Expected error in mat wrapper-procedure: "make-arity-wrapper-procedure: not-a-procedure is not a procedure".
   misc.mo:Expected error in mat wrapper-procedure: "make-arity-wrapper-procedure: not-an-exact-integer is not an arity mask".
---- 4194,4209 ----
+--- 4206,4221 ----
   misc.mo:Expected error in mat pariah: "invalid syntax (pariah)".
   misc.mo:Expected error in mat pariah: "invalid syntax (pariah . 17)".
   misc.mo:Expected error in mat procedure-arity-mask: "procedure-arity-mask: 17 is not a procedure".
@@ -4013,7 +4013,7 @@
   misc.mo:Expected error in mat wrapper-procedure: "make-arity-wrapper-procedure: not-a-procedure is not a procedure".
   misc.mo:Expected error in mat wrapper-procedure: "make-arity-wrapper-procedure: not-an-exact-integer is not an arity mask".
 ***************
-*** 4213,4225 ****
+*** 4225,4237 ****
   misc.mo:Expected error in mat wrapper-procedure: "wrapper-procedure-data: 1 is not a wrapper procedure".
   misc.mo:Expected error in mat wrapper-procedure: "wrapper-procedure-data: #<procedure> is not a wrapper procedure".
   misc.mo:Expected error in mat wrapper-procedure: "wrapper-procedure-data: #<procedure> is not a wrapper procedure".
@@ -4027,7 +4027,7 @@
   misc.mo:Expected error in mat wrapper-procedure: "set-wrapper-procedure-data!: 1 is not a wrapper procedure".
   misc.mo:Expected error in mat wrapper-procedure: "set-wrapper-procedure-data!: #<procedure> is not a wrapper procedure".
   misc.mo:Expected error in mat wrapper-procedure: "set-wrapper-procedure-data!: #<procedure> is not a wrapper procedure".
---- 4213,4225 ----
+--- 4225,4237 ----
   misc.mo:Expected error in mat wrapper-procedure: "wrapper-procedure-data: 1 is not a wrapper procedure".
   misc.mo:Expected error in mat wrapper-procedure: "wrapper-procedure-data: #<procedure> is not a wrapper procedure".
   misc.mo:Expected error in mat wrapper-procedure: "wrapper-procedure-data: #<procedure> is not a wrapper procedure".
@@ -4042,7 +4042,7 @@
   misc.mo:Expected error in mat wrapper-procedure: "set-wrapper-procedure-data!: #<procedure> is not a wrapper procedure".
   misc.mo:Expected error in mat wrapper-procedure: "set-wrapper-procedure-data!: #<procedure> is not a wrapper procedure".
 ***************
-*** 4227,4245 ****
+*** 4239,4257 ****
   misc.mo:Expected error in mat phantom-bytevector: "make-phantom-bytevector: -1 is not a valid phantom bytevector length".
   misc.mo:Expected error in mat phantom-bytevector: "make-phantom-bytevector: 1267650600228229401496703205376 is not a valid phantom bytevector length".
   misc.mo:Expected error in mat phantom-bytevector: "make-phantom-bytevector: x is not a valid phantom bytevector length".
@@ -4062,7 +4062,7 @@
   cp0.mo:Expected error in mat cp0-regression: "attempt to reference undefined variable x".
   cp0.mo:Expected error in mat cp0-regression: "incorrect argument count in call (g)".
   cp0.mo:Expected error in mat cp0-regression: "incorrect argument count in call (cont0 (quote x))".
---- 4227,4245 ----
+--- 4239,4257 ----
   misc.mo:Expected error in mat phantom-bytevector: "make-phantom-bytevector: -1 is not a valid phantom bytevector length".
   misc.mo:Expected error in mat phantom-bytevector: "make-phantom-bytevector: 1267650600228229401496703205376 is not a valid phantom bytevector length".
   misc.mo:Expected error in mat phantom-bytevector: "make-phantom-bytevector: x is not a valid phantom bytevector length".
@@ -4083,7 +4083,7 @@
   cp0.mo:Expected error in mat cp0-regression: "incorrect argument count in call (g)".
   cp0.mo:Expected error in mat cp0-regression: "incorrect argument count in call (cont0 (quote x))".
 ***************
-*** 4253,4261 ****
+*** 4265,4273 ****
   cp0.mo:Expected error in mat cp0-regression: "condition: #f is not a condition".
   cp0.mo:Expected error in mat cp0-regression: "apply: 0 is not a proper list".
   cp0.mo:Expected error in mat cp0-regression: "apply: 2 is not a proper list".
@@ -4093,7 +4093,7 @@
   cp0.mo:Expected error in mat expand-output: "expand-output: #t is not a textual output port or #f".
   cp0.mo:Expected error in mat expand-output: "expand-output: #<binary output port bytevector> is not a textual output port or #f".
   cp0.mo:Expected error in mat expand/optimize-output: "expand/optimize-output: #t is not a textual output port or #f".
---- 4253,4261 ----
+--- 4265,4273 ----
   cp0.mo:Expected error in mat cp0-regression: "condition: #f is not a condition".
   cp0.mo:Expected error in mat cp0-regression: "apply: 0 is not a proper list".
   cp0.mo:Expected error in mat cp0-regression: "apply: 2 is not a proper list".
@@ -4104,7 +4104,7 @@
   cp0.mo:Expected error in mat expand-output: "expand-output: #<binary output port bytevector> is not a textual output port or #f".
   cp0.mo:Expected error in mat expand/optimize-output: "expand/optimize-output: #t is not a textual output port or #f".
 ***************
-*** 4289,4303 ****
+*** 4301,4315 ****
   5_6.mo:Expected error in mat immutable-vector-copy: "immutable-vector-copy: invalid start value -1".
   5_6.mo:Expected error in mat immutable-vector-copy: "immutable-vector-copy: index 1 + count 3 is beyond the end of #(a b c)".
   5_6.mo:Expected error in mat immutable-vector-copy: "immutable-vector-copy: invalid count -1".
@@ -4120,7 +4120,7 @@
   5_6.mo:Expected error in mat immutable-vector-set/copy: "immutable-vector-set/copy: y is not a valid index for #(a b c)".
   5_6.mo:Expected error in mat immutable-vector-set/copy: "immutable-vector-set/copy: -1 is not a valid index for #(a b c)".
   5_6.mo:Expected error in mat immutable-vector-set/copy: "immutable-vector-set/copy: 3 is not a valid index for #(a b c)".
---- 4289,4303 ----
+--- 4301,4315 ----
   5_6.mo:Expected error in mat immutable-vector-copy: "immutable-vector-copy: invalid start value -1".
   5_6.mo:Expected error in mat immutable-vector-copy: "immutable-vector-copy: index 1 + count 3 is beyond the end of #(a b c)".
   5_6.mo:Expected error in mat immutable-vector-copy: "immutable-vector-copy: invalid count -1".
@@ -4137,7 +4137,7 @@
   5_6.mo:Expected error in mat immutable-vector-set/copy: "immutable-vector-set/copy: -1 is not a valid index for #(a b c)".
   5_6.mo:Expected error in mat immutable-vector-set/copy: "immutable-vector-set/copy: 3 is not a valid index for #(a b c)".
 ***************
-*** 4346,4357 ****
+*** 4358,4369 ****
   5_6.mo:Expected error in mat fxvector-set!: "fxvector-set!: <-int> is not a fixnum".
   5_6.mo:Expected error in mat fxvector-set!: "fxvector-set!: a is not a fixnum".
   5_6.mo:Expected error in mat fxvector-copy: "fxvector-copy: (a b c) is not an fxvector".
@@ -4150,7 +4150,7 @@
   5_6.mo:Expected error in mat fxvector-copy!: "fxvector-copy!: 0 is not an fxvector".
   5_6.mo:Expected error in mat fxvector-copy!: "fxvector-copy!: #(1 2 3) is not an fxvector".
   5_6.mo:Expected error in mat fxvector-copy!: "fxvector-copy!: invalid start value -1".
---- 4346,4357 ----
+--- 4358,4369 ----
   5_6.mo:Expected error in mat fxvector-set!: "fxvector-set!: <-int> is not a fixnum".
   5_6.mo:Expected error in mat fxvector-set!: "fxvector-set!: a is not a fixnum".
   5_6.mo:Expected error in mat fxvector-copy: "fxvector-copy: (a b c) is not an fxvector".
@@ -4164,7 +4164,7 @@
   5_6.mo:Expected error in mat fxvector-copy!: "fxvector-copy!: #(1 2 3) is not an fxvector".
   5_6.mo:Expected error in mat fxvector-copy!: "fxvector-copy!: invalid start value -1".
 ***************
-*** 4410,4421 ****
+*** 4422,4433 ****
   5_6.mo:Expected error in mat flvector-set!: "flvector-set!: 1 is not a flonum".
   5_6.mo:Expected error in mat flvector-set!: "flvector-set!: a is not a flonum".
   5_6.mo:Expected error in mat flvector-copy: "flvector-copy: (a b c) is not an flvector".
@@ -4177,7 +4177,7 @@
   5_6.mo:Expected error in mat flvector-copy!: "flvector-copy!: 0 is not an flvector".
   5_6.mo:Expected error in mat flvector-copy!: "flvector-copy!: #(1 2 3) is not an flvector".
   5_6.mo:Expected error in mat flvector-copy!: "flvector-copy!: invalid start value -1".
---- 4410,4421 ----
+--- 4422,4433 ----
   5_6.mo:Expected error in mat flvector-set!: "flvector-set!: 1 is not a flonum".
   5_6.mo:Expected error in mat flvector-set!: "flvector-set!: a is not a flonum".
   5_6.mo:Expected error in mat flvector-copy: "flvector-copy: (a b c) is not an flvector".
@@ -4191,7 +4191,7 @@
   5_6.mo:Expected error in mat flvector-copy!: "flvector-copy!: #(1 2 3) is not an flvector".
   5_6.mo:Expected error in mat flvector-copy!: "flvector-copy!: invalid start value -1".
 ***************
-*** 4445,4453 ****
+*** 4457,4465 ****
   5_6.mo:Expected error in mat list->flvector: "list->flvector: (1.0 2.0 . 3.0) is not a proper list".
   5_6.mo:Expected error in mat list->flvector: "list->flvector: (1.0 2.0 3.0 2.0 3.0 2.0 ...) is circular".
   5_6.mo:Expected error in mat flvector->list: "flvector->list: (a b c) is not an flvector".
@@ -4201,7 +4201,7 @@
   5_6.mo:Expected error in mat vector-map: "vector-map: #() is not a procedure".
   5_6.mo:Expected error in mat vector-map: "vector-map: #() is not a procedure".
   5_6.mo:Expected error in mat vector-map: "vector-map: #() is not a procedure".
---- 4445,4453 ----
+--- 4457,4465 ----
   5_6.mo:Expected error in mat list->flvector: "list->flvector: (1.0 2.0 . 3.0) is not a proper list".
   5_6.mo:Expected error in mat list->flvector: "list->flvector: (1.0 2.0 3.0 2.0 3.0 2.0 ...) is circular".
   5_6.mo:Expected error in mat flvector->list: "flvector->list: (a b c) is not an flvector".
@@ -4212,7 +4212,7 @@
   5_6.mo:Expected error in mat vector-map: "vector-map: #() is not a procedure".
   5_6.mo:Expected error in mat vector-map: "vector-map: #() is not a procedure".
 ***************
-*** 4462,4470 ****
+*** 4474,4482 ****
   5_6.mo:Expected error in mat vector-map: "vector-map: lengths of input vectors #() and #(x) differ".
   5_6.mo:Expected error in mat vector-map: "vector-map: lengths of input vectors #(y) and #() differ".
   5_6.mo:Expected error in mat vector-map: "vector-map: lengths of input vectors #(y) and #() differ".
@@ -4222,7 +4222,7 @@
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: #() is not a procedure".
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: #() is not a procedure".
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: #() is not a procedure".
---- 4462,4470 ----
+--- 4474,4482 ----
   5_6.mo:Expected error in mat vector-map: "vector-map: lengths of input vectors #() and #(x) differ".
   5_6.mo:Expected error in mat vector-map: "vector-map: lengths of input vectors #(y) and #() differ".
   5_6.mo:Expected error in mat vector-map: "vector-map: lengths of input vectors #(y) and #() differ".
@@ -4233,7 +4233,7 @@
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: #() is not a procedure".
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: #() is not a procedure".
 ***************
-*** 4479,4496 ****
+*** 4491,4508 ****
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: lengths of input vectors #() and #(x) differ".
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: lengths of input vectors #(y) and #() differ".
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: lengths of input vectors #(y) and #() differ".
@@ -4252,7 +4252,7 @@
   5_6.mo:Expected error in mat vector-sort!: "vector-sort!: 3 is not a mutable vector".
   5_6.mo:Expected error in mat vector-sort!: "vector-sort!: (1 2 3) is not a mutable vector".
   5_6.mo:Expected error in mat vector-sort!: "vector-sort!: #(a b c) is not a procedure".
---- 4479,4496 ----
+--- 4491,4508 ----
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: lengths of input vectors #() and #(x) differ".
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: lengths of input vectors #(y) and #() differ".
   5_6.mo:Expected error in mat vector-for-each: "vector-for-each: lengths of input vectors #(y) and #() differ".
@@ -4272,7 +4272,7 @@
   5_6.mo:Expected error in mat vector-sort!: "vector-sort!: (1 2 3) is not a mutable vector".
   5_6.mo:Expected error in mat vector-sort!: "vector-sort!: #(a b c) is not a procedure".
 ***************
-*** 4499,4507 ****
+*** 4511,4519 ****
   5_6.mo:Expected error in mat vector->immutable-vector: "vector-set-fixnum!: #(1 2 3) is not a mutable vector".
   5_6.mo:Expected error in mat vector->immutable-vector: "vector-fill!: #(1 2 3) is not a mutable vector".
   5_6.mo:Expected error in mat vector->immutable-vector: "vector-sort!: #(1 2 3) is not a mutable vector".
@@ -4282,7 +4282,7 @@
   5_6.mo:Expected error in mat vector-cas!: "vector-cas!: 1 is not a mutable vector".
   5_6.mo:Expected error in mat vector-cas!: "vector-cas!: #(4 5 3) is not a mutable vector".
   5_6.mo:Expected error in mat vector-cas!: "vector-cas!: #(4 5 3) is not a valid index for #(4 5 3)".
---- 4499,4507 ----
+--- 4511,4519 ----
   5_6.mo:Expected error in mat vector->immutable-vector: "vector-set-fixnum!: #(1 2 3) is not a mutable vector".
   5_6.mo:Expected error in mat vector->immutable-vector: "vector-fill!: #(1 2 3) is not a mutable vector".
   5_6.mo:Expected error in mat vector->immutable-vector: "vector-sort!: #(1 2 3) is not a mutable vector".
@@ -4293,7 +4293,7 @@
   5_6.mo:Expected error in mat vector-cas!: "vector-cas!: #(4 5 3) is not a mutable vector".
   5_6.mo:Expected error in mat vector-cas!: "vector-cas!: #(4 5 3) is not a valid index for #(4 5 3)".
 ***************
-*** 4581,4588 ****
+*** 4593,4600 ****
   5_7.mo:Expected error in mat putprop-getprop: "getprop: 3 is not a symbol".
   5_7.mo:Expected error in mat putprop-getprop: "putprop: "hi" is not a symbol".
   5_7.mo:Expected error in mat putprop-getprop: "property-list: (a b c) is not a symbol".
@@ -4302,7 +4302,7 @@
   5_8.mo:Expected error in mat box-cas!: "box-cas!: 1 is not a mutable box".
   5_8.mo:Expected error in mat box-cas!: "box-cas!: #&1 is not a mutable box".
   6.mo:Expected error in mat port-operations: "open-input-file: failed for nonexistent file: no such file or directory".
---- 4581,4588 ----
+--- 4593,4600 ----
   5_7.mo:Expected error in mat putprop-getprop: "getprop: 3 is not a symbol".
   5_7.mo:Expected error in mat putprop-getprop: "putprop: "hi" is not a symbol".
   5_7.mo:Expected error in mat putprop-getprop: "property-list: (a b c) is not a symbol".
@@ -4312,7 +4312,7 @@
   5_8.mo:Expected error in mat box-cas!: "box-cas!: #&1 is not a mutable box".
   6.mo:Expected error in mat port-operations: "open-input-file: failed for nonexistent file: no such file or directory".
 ***************
-*** 4620,4641 ****
+*** 4632,4653 ****
   6.mo:Expected error in mat port-operations: "clear-output-port: not permitted on closed port #<output port testfile.ss>".
   6.mo:Expected error in mat port-operations: "current-output-port: a is not a textual output port".
   6.mo:Expected error in mat port-operations: "current-input-port: a is not a textual input port".
@@ -4335,7 +4335,7 @@
   6.mo:Expected error in mat port-operations1: "open-input-output-file: furball is not a string".
   6.mo:Expected error in mat port-operations1: "open-input-output-file: failed for /probably/not/a/good/path: no such file or directory".
   6.mo:Expected error in mat port-operations1: "open-input-output-file: invalid option compressed".
---- 4620,4641 ----
+--- 4632,4653 ----
   6.mo:Expected error in mat port-operations: "clear-output-port: not permitted on closed port #<output port testfile.ss>".
   6.mo:Expected error in mat port-operations: "current-output-port: a is not a textual output port".
   6.mo:Expected error in mat port-operations: "current-input-port: a is not a textual input port".
@@ -4359,7 +4359,7 @@
   6.mo:Expected error in mat port-operations1: "open-input-output-file: failed for /probably/not/a/good/path: no such file or directory".
   6.mo:Expected error in mat port-operations1: "open-input-output-file: invalid option compressed".
 ***************
-*** 4644,4650 ****
+*** 4656,4662 ****
   6.mo:Expected error in mat port-operations1: "truncate-file: all-the-way is not a valid length".
   6.mo:Expected error in mat port-operations1: "truncate-file: #<input port testfile.ss> is not an output port".
   6.mo:Expected error in mat port-operations1: "truncate-file: animal-crackers is not an output port".
@@ -4367,7 +4367,7 @@
   6.mo:Expected error in mat port-operations1: "truncate-file: not permitted on closed port #<input/output port testfile.ss>".
   6.mo:Expected error in mat port-operations1: "get-output-string: #<input port string> is not a string output port".
   6.mo:Expected error in mat port-operations1: "get-output-string: #<output port testfile.ss> is not a string output port".
---- 4644,4650 ----
+--- 4656,4662 ----
   6.mo:Expected error in mat port-operations1: "truncate-file: all-the-way is not a valid length".
   6.mo:Expected error in mat port-operations1: "truncate-file: #<input port testfile.ss> is not an output port".
   6.mo:Expected error in mat port-operations1: "truncate-file: animal-crackers is not an output port".
@@ -4376,7 +4376,7 @@
   6.mo:Expected error in mat port-operations1: "get-output-string: #<input port string> is not a string output port".
   6.mo:Expected error in mat port-operations1: "get-output-string: #<output port testfile.ss> is not a string output port".
 ***************
-*** 4661,4668 ****
+*** 4673,4680 ****
   6.mo:Expected error in mat string-port-file-position: "file-position: -1 is not a valid position".
   6.mo:Expected error in mat fresh-line: "fresh-line: 3 is not a textual output port".
   6.mo:Expected error in mat fresh-line: "fresh-line: #<input port string> is not a textual output port".
@@ -4385,7 +4385,7 @@
   6.mo:Expected error in mat pretty-print: "pretty-format: 3 is not a symbol".
   6.mo:Expected error in mat pretty-print: "pretty-format: invalid format (bad 0 ... ... 0 format)".
   6.mo:Expected error in mat fasl: "separate-eval: Warning in fasl-write: fasl file content is compressed internally; compressing the file (#<binary output port testfile.ss>) is redundant and can slow fasl writing and reading significantly
---- 4661,4668 ----
+--- 4673,4680 ----
   6.mo:Expected error in mat string-port-file-position: "file-position: -1 is not a valid position".
   6.mo:Expected error in mat fresh-line: "fresh-line: 3 is not a textual output port".
   6.mo:Expected error in mat fresh-line: "fresh-line: #<input port string> is not a textual output port".
@@ -4395,7 +4395,7 @@
   6.mo:Expected error in mat pretty-print: "pretty-format: invalid format (bad 0 ... ... 0 format)".
   6.mo:Expected error in mat fasl: "separate-eval: Warning in fasl-write: fasl file content is compressed internally; compressing the file (#<binary output port testfile.ss>) is redundant and can slow fasl writing and reading significantly
 ***************
-*** 7292,7323 ****
+*** 7304,7335 ****
   io.mo:Expected error in mat port-operations: "put-u8: not permitted on closed port #<binary output port testfile.ss>".
   io.mo:Expected error in mat port-operations: "put-bytevector: not permitted on closed port #<binary output port testfile.ss>".
   io.mo:Expected error in mat port-operations: "flush-output-port: not permitted on closed port #<binary output port testfile.ss>".
@@ -4428,7 +4428,7 @@
   io.mo:Expected error in mat port-operations1: "open-file-input/output-port: failed for /probably/not/a/good/path: no such file or directory".
   io.mo:Expected error in mat port-operations1: "invalid file option uncompressed".
   io.mo:Expected error in mat port-operations1: "invalid file option truncate".
---- 7292,7323 ----
+--- 7304,7335 ----
   io.mo:Expected error in mat port-operations: "put-u8: not permitted on closed port #<binary output port testfile.ss>".
   io.mo:Expected error in mat port-operations: "put-bytevector: not permitted on closed port #<binary output port testfile.ss>".
   io.mo:Expected error in mat port-operations: "flush-output-port: not permitted on closed port #<binary output port testfile.ss>".
@@ -4462,7 +4462,7 @@
   io.mo:Expected error in mat port-operations1: "invalid file option uncompressed".
   io.mo:Expected error in mat port-operations1: "invalid file option truncate".
 ***************
-*** 7328,7334 ****
+*** 7340,7346 ****
   io.mo:Expected error in mat port-operations1: "set-port-length!: all-the-way is not a valid length".
   io.mo:Expected error in mat port-operations1: "truncate-port: #<binary input port testfile.ss> is not an output port".
   io.mo:Expected error in mat port-operations1: "truncate-port: animal-crackers is not an output port".
@@ -4470,7 +4470,7 @@
   io.mo:Expected error in mat port-operations1: "truncate-port: not permitted on closed port #<binary input/output port testfile.ss>".
   io.mo:Expected error in mat port-operations3: "file-port?: "not a port" is not a port".
   io.mo:Expected error in mat port-operations3: "port-file-descriptor: oops is not a port".
---- 7328,7334 ----
+--- 7340,7346 ----
   io.mo:Expected error in mat port-operations1: "set-port-length!: all-the-way is not a valid length".
   io.mo:Expected error in mat port-operations1: "truncate-port: #<binary input port testfile.ss> is not an output port".
   io.mo:Expected error in mat port-operations1: "truncate-port: animal-crackers is not an output port".
@@ -4479,7 +4479,7 @@
   io.mo:Expected error in mat port-operations3: "file-port?: "not a port" is not a port".
   io.mo:Expected error in mat port-operations3: "port-file-descriptor: oops is not a port".
 ***************
-*** 7526,7550 ****
+*** 7538,7562 ****
   io.mo:Expected error in mat low-level-port-operations: "set-binary-port-output-size!: #vu8(1 2 3) is not a valid size for #<binary output port bytevector>".
   io.mo:Expected error in mat low-level-port-operations: "set-binary-port-output-size!: -1 is not a valid size for #<binary output port bytevector>".
   io.mo:Expected error in mat low-level-port-operations: "set-binary-port-output-size!: 6 is not a valid size for #<binary output port bytevector>".
@@ -4505,7 +4505,7 @@
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
   io.mo:Expected error in mat make-codec-buffer: "transcoded-port: make-codec-buffer #<procedure bad1> did not return a mutable bytevector of length at least four".
   io.mo:Expected error in mat make-codec-buffer: "transcoded-port: make-codec-buffer #<procedure bad2> did not return a mutable bytevector of length at least four".
---- 7526,7550 ----
+--- 7538,7562 ----
   io.mo:Expected error in mat low-level-port-operations: "set-binary-port-output-size!: #vu8(1 2 3) is not a valid size for #<binary output port bytevector>".
   io.mo:Expected error in mat low-level-port-operations: "set-binary-port-output-size!: -1 is not a valid size for #<binary output port bytevector>".
   io.mo:Expected error in mat low-level-port-operations: "set-binary-port-output-size!: 6 is not a valid size for #<binary output port bytevector>".
@@ -4532,7 +4532,7 @@
   io.mo:Expected error in mat make-codec-buffer: "transcoded-port: make-codec-buffer #<procedure bad1> did not return a mutable bytevector of length at least four".
   io.mo:Expected error in mat make-codec-buffer: "transcoded-port: make-codec-buffer #<procedure bad2> did not return a mutable bytevector of length at least four".
 ***************
-*** 7569,7584 ****
+*** 7581,7596 ****
   io.mo:Expected error in mat compression: "port-file-compressed!: cannot compress input/output port #<binary input/output port testfile.ss>".
   io.mo:Expected error in mat compression: "port-file-compressed!: #<output port string> is not a file port".
   io.mo:Expected error in mat compression: "port-file-compressed!: cannot compress input/output port #<binary input/output port testfile.ss>".
@@ -4549,7 +4549,7 @@
   io.mo:Expected error in mat custom-binary-ports: "unget-u8: cannot unget 255 on #<binary input port foo>".
   io.mo:Expected error in mat custom-binary-ports: "put-u8: #<binary input port foo> is not a binary output port".
   io.mo:Expected error in mat custom-binary-ports: "port-length: #<binary input port foo> does not support operation".
---- 7569,7584 ----
+--- 7581,7596 ----
   io.mo:Expected error in mat compression: "port-file-compressed!: cannot compress input/output port #<binary input/output port testfile.ss>".
   io.mo:Expected error in mat compression: "port-file-compressed!: #<output port string> is not a file port".
   io.mo:Expected error in mat compression: "port-file-compressed!: cannot compress input/output port #<binary input/output port testfile.ss>".
@@ -4567,7 +4567,7 @@
   io.mo:Expected error in mat custom-binary-ports: "put-u8: #<binary input port foo> is not a binary output port".
   io.mo:Expected error in mat custom-binary-ports: "port-length: #<binary input port foo> does not support operation".
 ***************
-*** 7650,7671 ****
+*** 7662,7683 ****
   io.mo:Expected error in mat current-ports: "console-output-port: #<input port string> is not a textual output port".
   io.mo:Expected error in mat current-ports: "console-error-port: #<input port string> is not a textual output port".
   io.mo:Expected error in mat current-transcoder: "current-transcoder: #<output port string> is not a transcoder".
@@ -4590,7 +4590,7 @@
   io.mo:Expected error in mat utf-16-codec: "utf-16-codec: invalid endianness #f".
   io.mo:Expected error in mat to-fold-or-not-to-fold: "get-datum: invalid character name #\newLine at char 0 of #<input port string>".
   io.mo:Expected error in mat to-fold-or-not-to-fold: "get-datum: invalid character name #\newLine at char 15 of #<input port string>".
---- 7650,7671 ----
+--- 7662,7683 ----
   io.mo:Expected error in mat current-ports: "console-output-port: #<input port string> is not a textual output port".
   io.mo:Expected error in mat current-ports: "console-error-port: #<input port string> is not a textual output port".
   io.mo:Expected error in mat current-transcoder: "current-transcoder: #<output port string> is not a transcoder".
@@ -4614,7 +4614,7 @@
   io.mo:Expected error in mat to-fold-or-not-to-fold: "get-datum: invalid character name #\newLine at char 0 of #<input port string>".
   io.mo:Expected error in mat to-fold-or-not-to-fold: "get-datum: invalid character name #\newLine at char 15 of #<input port string>".
 ***************
-*** 7841,7847 ****
+*** 7853,7859 ****
   7.mo:Expected error in mat eval-when: "invalid syntax visit-x".
   7.mo:Expected error in mat eval-when: "invalid syntax revisit-x".
   7.mo:Expected error in mat compile-whole-program: "compile-whole-program: failed for nosuchfile.wpo: no such file or directory".
@@ -4622,7 +4622,7 @@
   7.mo:Expected error in mat compile-whole-program: "separate-eval: Exception in environment: attempt to import invisible library (testfile-wpo-lib)
   7.mo:Expected error in mat compile-whole-program: "separate-eval: Exception: library (testfile-wpo-a4) not found
   7.mo:Expected error in mat compile-whole-program: "separate-eval: Exception: library (testfile-wpo-c4) not found
---- 7841,7847 ----
+--- 7853,7859 ----
   7.mo:Expected error in mat eval-when: "invalid syntax visit-x".
   7.mo:Expected error in mat eval-when: "invalid syntax revisit-x".
   7.mo:Expected error in mat compile-whole-program: "compile-whole-program: failed for nosuchfile.wpo: no such file or directory".
@@ -4631,7 +4631,7 @@
   7.mo:Expected error in mat compile-whole-program: "separate-eval: Exception: library (testfile-wpo-a4) not found
   7.mo:Expected error in mat compile-whole-program: "separate-eval: Exception: library (testfile-wpo-c4) not found
 ***************
-*** 7907,7933 ****
+*** 7919,7945 ****
   7.mo:Expected error in mat concatenate-object-files: "separate-eval: Exception in verify-loadability: cannot find object file for library (testfile-cof1A)
   7.mo:Expected error in mat concatenate-object-files: "separate-eval: Exception in verify-loadability: cannot find object file for library (testfile-cof1B)
   7.mo:Expected error in mat top-level-value-functions: "top-level-bound?: "hello" is not a symbol".
@@ -4659,7 +4659,7 @@
   7.mo:Expected error in mat top-level-value-functions: "define-top-level-value: hello is not an environment".
   7.mo:Expected error in mat top-level-value-functions: "define-top-level-value: #<environment *scheme*> is not a symbol".
   7.mo:Expected error in mat top-level-value-functions: "variable i-am-not-bound-i-hope is not bound".
---- 7907,7933 ----
+--- 7919,7945 ----
   7.mo:Expected error in mat concatenate-object-files: "separate-eval: Exception in verify-loadability: cannot find object file for library (testfile-cof1A)
   7.mo:Expected error in mat concatenate-object-files: "separate-eval: Exception in verify-loadability: cannot find object file for library (testfile-cof1B)
   7.mo:Expected error in mat top-level-value-functions: "top-level-bound?: "hello" is not a symbol".
@@ -4688,26 +4688,24 @@
   7.mo:Expected error in mat top-level-value-functions: "define-top-level-value: #<environment *scheme*> is not a symbol".
   7.mo:Expected error in mat top-level-value-functions: "variable i-am-not-bound-i-hope is not bound".
 ***************
-*** 8268,8275 ****
+*** 8280,8286 ****
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
-- record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
-  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
---- 8268,8275 ----
+--- 8280,8286 ----
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
-+ record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
-  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
 ***************
-*** 8359,8478 ****
+*** 8371,8490 ****
   hash.mo:Expected error in mat old-hash-table: "hash-table-for-each: ((a . b)) is not an eq hashtable".
   hash.mo:Expected error in mat old-hash-table: "incorrect number of arguments 2 to #<procedure>".
   hash.mo:Expected error in mat old-hash-table: "incorrect number of arguments 2 to #<procedure>".
@@ -4828,7 +4826,7 @@
   hash.mo:Expected error in mat hashtable-arguments: "hashtable-ephemeron?: (hash . table) is not a hashtable".
   hash.mo:Expected error in mat hash-return-value: "hashtable-ref: invalid hash-function #<procedure> return value "oops" for any".
   hash.mo:Expected error in mat hash-return-value: "hashtable-ref: invalid hash-function #<procedure> return value 3.5 for any".
---- 8359,8478 ----
+--- 8371,8490 ----
   hash.mo:Expected error in mat old-hash-table: "hash-table-for-each: ((a . b)) is not an eq hashtable".
   hash.mo:Expected error in mat old-hash-table: "incorrect number of arguments 2 to #<procedure>".
   hash.mo:Expected error in mat old-hash-table: "incorrect number of arguments 2 to #<procedure>".
@@ -4950,7 +4948,7 @@
   hash.mo:Expected error in mat hash-return-value: "hashtable-ref: invalid hash-function #<procedure> return value "oops" for any".
   hash.mo:Expected error in mat hash-return-value: "hashtable-ref: invalid hash-function #<procedure> return value 3.5 for any".
 ***************
-*** 8495,8623 ****
+*** 8507,8635 ****
   hash.mo:Expected error in mat hash-return-value: "hashtable-delete!: invalid hash-function #<procedure> return value "oops" for any".
   hash.mo:Expected error in mat hash-return-value: "hashtable-delete!: invalid hash-function #<procedure> return value 3.5 for any".
   hash.mo:Expected error in mat hash-return-value: "hashtable-delete!: invalid hash-function #<procedure> return value 1+2i for any".
@@ -5080,7 +5078,7 @@
   hash.mo:Expected error in mat eqv-hashtable-arguments: "make-ephemeron-eqv-hashtable: invalid size argument -1".
   hash.mo:Expected error in mat eqv-hashtable-arguments: "make-ephemeron-eqv-hashtable: invalid size argument #t".
   hash.mo:Expected error in mat eqv-hashtable-arguments: "make-ephemeron-eqv-hashtable: invalid size argument #f".
---- 8495,8623 ----
+--- 8507,8635 ----
   hash.mo:Expected error in mat hash-return-value: "hashtable-delete!: invalid hash-function #<procedure> return value "oops" for any".
   hash.mo:Expected error in mat hash-return-value: "hashtable-delete!: invalid hash-function #<procedure> return value 3.5 for any".
   hash.mo:Expected error in mat hash-return-value: "hashtable-delete!: invalid hash-function #<procedure> return value 1+2i for any".
@@ -5211,7 +5209,7 @@
   hash.mo:Expected error in mat eqv-hashtable-arguments: "make-ephemeron-eqv-hashtable: invalid size argument #t".
   hash.mo:Expected error in mat eqv-hashtable-arguments: "make-ephemeron-eqv-hashtable: invalid size argument #f".
 ***************
-*** 8625,8656 ****
+*** 8637,8668 ****
   hash.mo:Expected error in mat generic-hashtable: "hashtable-delete!: #<hashtable> is not mutable".
   hash.mo:Expected error in mat generic-hashtable: "hashtable-update!: #<hashtable> is not mutable".
   hash.mo:Expected error in mat generic-hashtable: "hashtable-update!: #<hashtable> is not mutable".
@@ -5244,7 +5242,7 @@
   hash.mo:Expected error in mat hash-functions: "string-ci-hash: hello is not a string".
   hash.mo:Expected error in mat fasl-other-hashtable: "fasl-write: invalid fasl object #<eqv hashtable>".
   hash.mo:Expected error in mat fasl-other-hashtable: "fasl-write: invalid fasl object #<hashtable>".
---- 8625,8656 ----
+--- 8637,8668 ----
   hash.mo:Expected error in mat generic-hashtable: "hashtable-delete!: #<hashtable> is not mutable".
   hash.mo:Expected error in mat generic-hashtable: "hashtable-update!: #<hashtable> is not mutable".
   hash.mo:Expected error in mat generic-hashtable: "hashtable-update!: #<hashtable> is not mutable".
@@ -5278,7 +5276,7 @@
   hash.mo:Expected error in mat fasl-other-hashtable: "fasl-write: invalid fasl object #<eqv hashtable>".
   hash.mo:Expected error in mat fasl-other-hashtable: "fasl-write: invalid fasl object #<hashtable>".
 ***************
-*** 8768,8775 ****
+*** 8780,8787 ****
   8.mo:Expected error in mat with-syntax: "invalid syntax a".
   8.mo:Expected error in mat with-syntax: "duplicate pattern variable x in (x x)".
   8.mo:Expected error in mat with-syntax: "duplicate pattern variable x in (x x)".
@@ -5287,7 +5285,7 @@
   8.mo:Expected error in mat generate-temporaries: "generate-temporaries: improper list structure (a b . c)".
   8.mo:Expected error in mat generate-temporaries: "generate-temporaries: cyclic list structure (a b c b c b ...)".
   8.mo:Expected error in mat syntax->list: "syntax->list: invalid argument #<syntax a>".
---- 8768,8775 ----
+--- 8780,8787 ----
   8.mo:Expected error in mat with-syntax: "invalid syntax a".
   8.mo:Expected error in mat with-syntax: "duplicate pattern variable x in (x x)".
   8.mo:Expected error in mat with-syntax: "duplicate pattern variable x in (x x)".
@@ -5297,7 +5295,7 @@
   8.mo:Expected error in mat generate-temporaries: "generate-temporaries: cyclic list structure (a b c b c b ...)".
   8.mo:Expected error in mat syntax->list: "syntax->list: invalid argument #<syntax a>".
 ***************
-*** 9386,9401 ****
+*** 9411,9426 ****
   8.mo:Expected error in mat rnrs-eval: "attempt to assign unbound identifier foo".
   8.mo:Expected error in mat rnrs-eval: "invalid definition in immutable environment (define cons (quote #<procedure vector>))".
   8.mo:Expected error in mat top-level-syntax-functions: "top-level-syntax: "hello" is not a symbol".
@@ -5314,7 +5312,7 @@
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: hello is not an environment".
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: #<environment *scheme*> is not a symbol".
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: cannot modify immutable environment #<environment *scheme*>".
---- 9386,9401 ----
+--- 9411,9426 ----
   8.mo:Expected error in mat rnrs-eval: "attempt to assign unbound identifier foo".
   8.mo:Expected error in mat rnrs-eval: "invalid definition in immutable environment (define cons (quote #<procedure vector>))".
   8.mo:Expected error in mat top-level-syntax-functions: "top-level-syntax: "hello" is not a symbol".
@@ -5332,7 +5330,7 @@
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: #<environment *scheme*> is not a symbol".
   8.mo:Expected error in mat top-level-syntax-functions: "define-top-level-syntax: cannot modify immutable environment #<environment *scheme*>".
 ***************
-*** 9494,9516 ****
+*** 9519,9541 ****
   fx.mo:Expected error in mat fx=?: "fx=?: (a) is not a fixnum".
   fx.mo:Expected error in mat fx=?: "fx=?: <int> is not a fixnum".
   fx.mo:Expected error in mat fx=?: "fx=?: <-int> is not a fixnum".
@@ -5356,7 +5354,7 @@
   fx.mo:Expected error in mat $fxu<: "incorrect number of arguments 1 to #<procedure $fxu<>".
   fx.mo:Expected error in mat $fxu<: "incorrect number of arguments 3 to #<procedure $fxu<>".
   fx.mo:Expected error in mat $fxu<: "$fxu<: <-int> is not a fixnum".
---- 9494,9516 ----
+--- 9519,9541 ----
   fx.mo:Expected error in mat fx=?: "fx=?: (a) is not a fixnum".
   fx.mo:Expected error in mat fx=?: "fx=?: <int> is not a fixnum".
   fx.mo:Expected error in mat fx=?: "fx=?: <-int> is not a fixnum".
@@ -5381,7 +5379,7 @@
   fx.mo:Expected error in mat $fxu<: "incorrect number of arguments 3 to #<procedure $fxu<>".
   fx.mo:Expected error in mat $fxu<: "$fxu<: <-int> is not a fixnum".
 ***************
-*** 9552,9564 ****
+*** 9577,9589 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -5395,7 +5393,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9552,9564 ----
+--- 9577,9589 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -5410,7 +5408,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
 ***************
-*** 9613,9625 ****
+*** 9638,9650 ****
   fx.mo:Expected error in mat fx1+: "fx1+: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx1+: "fx1+: <int> is not a fixnum".
   fx.mo:Expected error in mat fx1+: "fx1+: a is not a fixnum".
@@ -5424,7 +5422,7 @@
   fx.mo:Expected error in mat fxmax: "fxmax: a is not a fixnum".
   fx.mo:Expected error in mat fxmax: "fxmax: <int> is not a fixnum".
   fx.mo:Expected error in mat fxmax: "fxmax: <-int> is not a fixnum".
---- 9613,9625 ----
+--- 9638,9650 ----
   fx.mo:Expected error in mat fx1+: "fx1+: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx1+: "fx1+: <int> is not a fixnum".
   fx.mo:Expected error in mat fx1+: "fx1+: a is not a fixnum".
@@ -5439,7 +5437,7 @@
   fx.mo:Expected error in mat fxmax: "fxmax: <int> is not a fixnum".
   fx.mo:Expected error in mat fxmax: "fxmax: <-int> is not a fixnum".
 ***************
-*** 9725,9734 ****
+*** 9750,9759 ****
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments <int> and 10".
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments -4097 and <int>".
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments <-int> and 1".
@@ -5450,7 +5448,7 @@
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 35.0 is not a fixnum".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 5.0 is not a valid start index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 8.0 is not a valid end index".
---- 9725,9734 ----
+--- 9750,9759 ----
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments <int> and 10".
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments -4097 and <int>".
   fx.mo:Expected error in mat fxarithmetic-shift: "fxarithmetic-shift: fixnum overflow with arguments <-int> and 1".
@@ -5462,7 +5460,7 @@
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 5.0 is not a valid start index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: 8.0 is not a valid end index".
 ***************
-*** 9742,9775 ****
+*** 9767,9800 ****
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid end index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid start index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid end index".
@@ -5497,7 +5495,7 @@
   fx.mo:Expected error in mat fxif: "fxif: a is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: 3.4 is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: (a) is not a fixnum".
---- 9742,9775 ----
+--- 9767,9800 ----
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid end index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid start index".
   fx.mo:Expected error in mat fxbit-field: "fxbit-field: <int> is not a valid end index".
@@ -5533,7 +5531,7 @@
   fx.mo:Expected error in mat fxif: "fxif: 3.4 is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: (a) is not a fixnum".
 ***************
-*** 9779,9822 ****
+*** 9804,9847 ****
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
@@ -5578,7 +5576,7 @@
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: 3.4 is not a fixnum".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: "3" is not a fixnum".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: <int> is not a fixnum".
---- 9779,9822 ----
+--- 9804,9847 ----
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
   fx.mo:Expected error in mat fxif: "fxif: <-int> is not a fixnum".
@@ -5624,7 +5622,7 @@
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: "3" is not a fixnum".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: <int> is not a fixnum".
 ***************
-*** 9825,9835 ****
+*** 9850,9860 ****
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index -1".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index <int>".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index <int>".
@@ -5636,7 +5634,7 @@
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: "3" is not a fixnum".
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: 3.4 is not a valid start index".
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: 3/4 is not a valid end index".
---- 9825,9835 ----
+--- 9850,9860 ----
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index -1".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index <int>".
   fx.mo:Expected error in mat fxcopy-bit: "fxcopy-bit: invalid bit index <int>".
@@ -5649,7 +5647,7 @@
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: 3.4 is not a valid start index".
   fx.mo:Expected error in mat fxcopy-bit-field: "fxcopy-bit-field: 3/4 is not a valid end index".
 ***************
-*** 9889,9898 ****
+*** 9914,9923 ****
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: (a) is not a fixnum".
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: undefined for 0".
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: undefined for 0".
@@ -5660,7 +5658,7 @@
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 1.0 is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 3.0 is not a fixnum".
---- 9889,9898 ----
+--- 9914,9923 ----
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: (a) is not a fixnum".
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: undefined for 0".
   fx.mo:Expected error in mat fxdiv0-and-mod0: "fxmod0: undefined for 0".
@@ -5672,7 +5670,7 @@
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: 3.0 is not a fixnum".
 ***************
-*** 9908,9917 ****
+*** 9933,9942 ****
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
@@ -5683,7 +5681,7 @@
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 1.0 is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 3.0 is not a fixnum".
---- 9908,9917 ----
+--- 9933,9942 ----
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx+/carry: "fx+/carry: <-int> is not a fixnum".
@@ -5695,7 +5693,7 @@
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: 3.0 is not a fixnum".
 ***************
-*** 9927,9936 ****
+*** 9952,9961 ****
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
@@ -5706,7 +5704,7 @@
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 1.0 is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 3.0 is not a fixnum".
---- 9927,9936 ----
+--- 9952,9961 ----
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/carry: "fx-/carry: <-int> is not a fixnum".
@@ -5718,7 +5716,7 @@
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 2.0 is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: 3.0 is not a fixnum".
 ***************
-*** 9946,9956 ****
+*** 9971,9981 ****
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
@@ -5730,7 +5728,7 @@
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: a is not a fixnum".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid start index 0.0".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index 2.0".
---- 9946,9956 ----
+--- 9971,9981 ----
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*/carry: "fx*/carry: <-int> is not a fixnum".
@@ -5743,7 +5741,7 @@
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid start index 0.0".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index 2.0".
 ***************
-*** 9973,9982 ****
+*** 9998,10007 ****
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: count 1 is greater than difference between end index 5 and start index 5".
@@ -5754,7 +5752,7 @@
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: a is not a fixnum".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid start index 0.0".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index 2.0".
---- 9973,9982 ----
+--- 9998,10007 ----
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxrotate-bit-field: "fxrotate-bit-field: count 1 is greater than difference between end index 5 and start index 5".
@@ -5766,7 +5764,7 @@
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid start index 0.0".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index 2.0".
 ***************
-*** 9992,10009 ****
+*** 10017,10034 ****
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index <-int>".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: start index 7 is greater than end index 5".
@@ -5785,7 +5783,7 @@
   fl.mo:Expected error in mat fl=: "fl=: (a) is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: a is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: a is not a flonum".
---- 9992,10009 ----
+--- 10017,10034 ----
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index <int>".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: invalid end index <-int>".
   fx.mo:Expected error in mat fxreverse-bit-field: "fxreverse-bit-field: start index 7 is greater than end index 5".
@@ -5805,7 +5803,7 @@
   fl.mo:Expected error in mat fl=: "fl=: a is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: a is not a flonum".
 ***************
-*** 10011,10017 ****
+*** 10036,10042 ****
   fl.mo:Expected error in mat fl=: "fl=: 3 is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: 7/2 is not a flonum".
@@ -5813,7 +5811,7 @@
   fl.mo:Expected error in mat fl<: "fl<: (a) is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: a is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: a is not a flonum".
---- 10011,10017 ----
+--- 10036,10042 ----
   fl.mo:Expected error in mat fl=: "fl=: 3 is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl=: "fl=: 7/2 is not a flonum".
@@ -5822,7 +5820,7 @@
   fl.mo:Expected error in mat fl<: "fl<: a is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: a is not a flonum".
 ***************
-*** 10019,10025 ****
+*** 10044,10050 ****
   fl.mo:Expected error in mat fl<: "fl<: 3 is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: 7/2 is not a flonum".
@@ -5830,7 +5828,7 @@
   fl.mo:Expected error in mat fl>: "fl>: (a) is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: a is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: a is not a flonum".
---- 10019,10025 ----
+--- 10044,10050 ----
   fl.mo:Expected error in mat fl<: "fl<: 3 is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl<: "fl<: 7/2 is not a flonum".
@@ -5839,7 +5837,7 @@
   fl.mo:Expected error in mat fl>: "fl>: a is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: a is not a flonum".
 ***************
-*** 10027,10033 ****
+*** 10052,10058 ****
   fl.mo:Expected error in mat fl>: "fl>: 3 is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: 7/2 is not a flonum".
@@ -5847,7 +5845,7 @@
   fl.mo:Expected error in mat fl<=: "fl<=: (a) is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: a is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: a is not a flonum".
---- 10027,10033 ----
+--- 10052,10058 ----
   fl.mo:Expected error in mat fl>: "fl>: 3 is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl>: "fl>: 7/2 is not a flonum".
@@ -5856,7 +5854,7 @@
   fl.mo:Expected error in mat fl<=: "fl<=: a is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: a is not a flonum".
 ***************
-*** 10035,10041 ****
+*** 10060,10066 ****
   fl.mo:Expected error in mat fl<=: "fl<=: 3 is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: 7/2 is not a flonum".
@@ -5864,7 +5862,7 @@
   fl.mo:Expected error in mat fl>=: "fl>=: (a) is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: a is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: a is not a flonum".
---- 10035,10041 ----
+--- 10060,10066 ----
   fl.mo:Expected error in mat fl<=: "fl<=: 3 is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl<=: "fl<=: 7/2 is not a flonum".
@@ -5873,7 +5871,7 @@
   fl.mo:Expected error in mat fl>=: "fl>=: a is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: a is not a flonum".
 ***************
-*** 10043,10082 ****
+*** 10068,10107 ****
   fl.mo:Expected error in mat fl>=: "fl>=: 3 is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: 7/2 is not a flonum".
@@ -5914,7 +5912,7 @@
   fl.mo:Expected error in mat fl>=?: "fl>=?: a is not a flonum".
   fl.mo:Expected error in mat fl>=?: "fl>=?: a is not a flonum".
   fl.mo:Expected error in mat fl>=?: "fl>=?: 3 is not a flonum".
---- 10043,10082 ----
+--- 10068,10107 ----
   fl.mo:Expected error in mat fl>=: "fl>=: 3 is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: 7/2 is not a flonum".
   fl.mo:Expected error in mat fl>=: "fl>=: 7/2 is not a flonum".
@@ -5956,7 +5954,7 @@
   fl.mo:Expected error in mat fl>=?: "fl>=?: a is not a flonum".
   fl.mo:Expected error in mat fl>=?: "fl>=?: 3 is not a flonum".
 ***************
-*** 10086,10092 ****
+*** 10111,10117 ****
   fl.mo:Expected error in mat fl+: "fl+: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl+: "fl+: 1 is not a flonum".
   fl.mo:Expected error in mat fl+: "fl+: 2/3 is not a flonum".
@@ -5964,7 +5962,7 @@
   fl.mo:Expected error in mat fl-: "fl-: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl-: "fl-: 1 is not a flonum".
   fl.mo:Expected error in mat fl-: "fl-: a is not a flonum".
---- 10086,10092 ----
+--- 10111,10117 ----
   fl.mo:Expected error in mat fl+: "fl+: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl+: "fl+: 1 is not a flonum".
   fl.mo:Expected error in mat fl+: "fl+: 2/3 is not a flonum".
@@ -5973,7 +5971,7 @@
   fl.mo:Expected error in mat fl-: "fl-: 1 is not a flonum".
   fl.mo:Expected error in mat fl-: "fl-: a is not a flonum".
 ***************
-*** 10096,10185 ****
+*** 10121,10210 ****
   fl.mo:Expected error in mat fl*: "fl*: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl*: "fl*: 1 is not a flonum".
   fl.mo:Expected error in mat fl*: "fl*: 2/3 is not a flonum".
@@ -6064,7 +6062,7 @@
   fl.mo:Expected error in mat flsingle: "flsingle: a is not a flonum".
   fl.mo:Expected error in mat flsingle: "flsingle: 3 is not a flonum".
   fl.mo:Expected error in mat flsingle: "flsingle: 2.0+1.0i is not a flonum".
---- 10096,10185 ----
+--- 10121,10210 ----
   fl.mo:Expected error in mat fl*: "fl*: (a . b) is not a flonum".
   fl.mo:Expected error in mat fl*: "fl*: 1 is not a flonum".
   fl.mo:Expected error in mat fl*: "fl*: 2/3 is not a flonum".
@@ -6156,7 +6154,7 @@
   fl.mo:Expected error in mat flsingle: "flsingle: 3 is not a flonum".
   fl.mo:Expected error in mat flsingle: "flsingle: 2.0+1.0i is not a flonum".
 ***************
-*** 10198,10233 ****
+*** 10223,10258 ****
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: 3 is not a flonum".
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: 3/4 is not a flonum".
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: hi is not a flonum".
@@ -6193,7 +6191,7 @@
   fl.mo:Expected error in mat fleven?: "fleven?: a is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: 3 is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: 3.2 is not an integer".
---- 10198,10233 ----
+--- 10223,10258 ----
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: 3 is not a flonum".
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: 3/4 is not a flonum".
   fl.mo:Expected error in mat flinfinite?: "flinfinite?: hi is not a flonum".
@@ -6231,7 +6229,7 @@
   fl.mo:Expected error in mat fleven?: "fleven?: 3 is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: 3.2 is not an integer".
 ***************
-*** 10235,10242 ****
+*** 10260,10267 ****
   fl.mo:Expected error in mat fleven?: "fleven?: 1+1i is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: +inf.0 is not an integer".
   fl.mo:Expected error in mat fleven?: "fleven?: +nan.0 is not an integer".
@@ -6240,7 +6238,7 @@
   fl.mo:Expected error in mat flodd?: "flodd?: a is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: 3 is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: 3.2 is not an integer".
---- 10235,10242 ----
+--- 10260,10267 ----
   fl.mo:Expected error in mat fleven?: "fleven?: 1+1i is not a flonum".
   fl.mo:Expected error in mat fleven?: "fleven?: +inf.0 is not an integer".
   fl.mo:Expected error in mat fleven?: "fleven?: +nan.0 is not an integer".
@@ -6250,7 +6248,7 @@
   fl.mo:Expected error in mat flodd?: "flodd?: 3 is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: 3.2 is not an integer".
 ***************
-*** 10244,10250 ****
+*** 10269,10275 ****
   fl.mo:Expected error in mat flodd?: "flodd?: 3+1i is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: +inf.0 is not an integer".
   fl.mo:Expected error in mat flodd?: "flodd?: +nan.0 is not an integer".
@@ -6258,7 +6256,7 @@
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
---- 10244,10250 ----
+--- 10269,10275 ----
   fl.mo:Expected error in mat flodd?: "flodd?: 3+1i is not a flonum".
   fl.mo:Expected error in mat flodd?: "flodd?: +inf.0 is not an integer".
   fl.mo:Expected error in mat flodd?: "flodd?: +nan.0 is not an integer".
@@ -6267,7 +6265,7 @@
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
 ***************
-*** 10252,10258 ****
+*** 10277,10283 ****
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: 0.0+1.0i is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: 0+1i is not a flonum".
@@ -6275,7 +6273,7 @@
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 3 is not a flonum".
---- 10252,10258 ----
+--- 10277,10283 ----
   fl.mo:Expected error in mat flmin: "flmin: a is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: 0.0+1.0i is not a flonum".
   fl.mo:Expected error in mat flmin: "flmin: 0+1i is not a flonum".
@@ -6284,7 +6282,7 @@
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 3 is not a flonum".
 ***************
-*** 10260,10273 ****
+*** 10285,10298 ****
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 0.0+1.0i is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 0+1i is not a flonum".
@@ -6299,7 +6297,7 @@
   fl.mo:Expected error in mat fldenominator: "fldenominator: a is not a flonum".
   fl.mo:Expected error in mat fldenominator: "fldenominator: 3 is not a flonum".
   fl.mo:Expected error in mat fldenominator: "fldenominator: 0+1i is not a flonum".
---- 10260,10273 ----
+--- 10285,10298 ----
   fl.mo:Expected error in mat flmax: "flmax: a is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 0.0+1.0i is not a flonum".
   fl.mo:Expected error in mat flmax: "flmax: 0+1i is not a flonum".
@@ -6315,7 +6313,7 @@
   fl.mo:Expected error in mat fldenominator: "fldenominator: 3 is not a flonum".
   fl.mo:Expected error in mat fldenominator: "fldenominator: 0+1i is not a flonum".
 ***************
-*** 10296,10304 ****
+*** 10321,10329 ****
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: 17 is not a flonum".
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: a is not a flonum".
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: (a) is not a flonum".
@@ -6325,7 +6323,7 @@
   fl.mo:Expected error in mat flbit-field: "flbit-field: 0 is not a flonum".
   fl.mo:Expected error in mat flbit-field: "flbit-field: invalid start index -1".
   fl.mo:Expected error in mat flbit-field: "flbit-field: invalid end index 1".
---- 10296,10304 ----
+--- 10321,10329 ----
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: 17 is not a flonum".
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: a is not a flonum".
   fl.mo:Expected error in mat fldiv0-and-mod0: "flmod0: (a) is not a flonum".
@@ -6336,7 +6334,7 @@
   fl.mo:Expected error in mat flbit-field: "flbit-field: invalid start index -1".
   fl.mo:Expected error in mat flbit-field: "flbit-field: invalid end index 1".
 ***************
-*** 10324,10330 ****
+*** 10349,10355 ****
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
@@ -6344,7 +6342,7 @@
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
---- 10324,10330 ----
+--- 10349,10355 ----
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
@@ -6353,7 +6351,7 @@
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
   cfl.mo:Expected error in mat cfl-: "cfl-: a is not a cflonum".
 ***************
-*** 10334,10347 ****
+*** 10359,10372 ****
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
@@ -6368,7 +6366,7 @@
   foreign.mo:Expected error in mat load-shared-object: "load-shared-object: invalid path 3".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: no entry for "i do not exist"".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: no entry for "i do not exist"".
---- 10334,10347 ----
+--- 10359,10372 ----
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
   cfl.mo:Expected error in mat cfl/: "cfl/: a is not a cflonum".
@@ -6384,7 +6382,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: no entry for "i do not exist"".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: no entry for "i do not exist"".
 ***************
-*** 10376,10383 ****
+*** 10401,10408 ****
   foreign.mo:Expected error in mat foreign-procedure: "id: invalid foreign-procedure argument foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle abcde".
   foreign.mo:Expected error in mat foreign-procedure: "float_id: invalid foreign-procedure argument 0".
@@ -6393,7 +6391,7 @@
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
   foreign.mo:Expected error in mat foreign-bytevectors: "u8*->u8*: invalid foreign-procedure argument "hello"".
---- 10376,10383 ----
+--- 10401,10408 ----
   foreign.mo:Expected error in mat foreign-procedure: "id: invalid foreign-procedure argument foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle abcde".
   foreign.mo:Expected error in mat foreign-procedure: "float_id: invalid foreign-procedure argument 0".
@@ -6403,7 +6401,7 @@
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
   foreign.mo:Expected error in mat foreign-bytevectors: "u8*->u8*: invalid foreign-procedure argument "hello"".
 ***************
-*** 10905,10917 ****
+*** 10930,10942 ****
   unix.mo:Expected error in mat file-operations: "file-access-time: failed for "testlink": no such file or directory".
   unix.mo:Expected error in mat file-operations: "file-change-time: failed for "testlink": no such file or directory".
   unix.mo:Expected error in mat file-operations: "file-modification-time: failed for "testlink": no such file or directory".
@@ -6417,7 +6415,7 @@
   windows.mo:Expected error in mat registry: "get-registry: pooh is not a string".
   windows.mo:Expected error in mat registry: "put-registry!: 3 is not a string".
   windows.mo:Expected error in mat registry: "put-registry!: 3 is not a string".
---- 10905,10917 ----
+--- 10930,10942 ----
   unix.mo:Expected error in mat file-operations: "file-access-time: failed for "testlink": no such file or directory".
   unix.mo:Expected error in mat file-operations: "file-change-time: failed for "testlink": no such file or directory".
   unix.mo:Expected error in mat file-operations: "file-modification-time: failed for "testlink": no such file or directory".
@@ -6432,7 +6430,7 @@
   windows.mo:Expected error in mat registry: "put-registry!: 3 is not a string".
   windows.mo:Expected error in mat registry: "put-registry!: 3 is not a string".
 ***************
-*** 10939,11010 ****
+*** 10964,11035 ****
   ieee.mo:Expected error in mat flonum->fixnum: "flonum->fixnum: result for -inf.0 would be outside of fixnum range".
   ieee.mo:Expected error in mat flonum->fixnum: "flonum->fixnum: result for +nan.0 would be outside of fixnum range".
   ieee.mo:Expected error in mat fllp: "fllp: 3 is not a flonum".
@@ -6505,7 +6503,7 @@
   date.mo:Expected error in mat time: "time>=?: 3 is not a time record".
   date.mo:Expected error in mat time: "time>=?: #<procedure car> is not a time record".
   date.mo:Expected error in mat time: "time>=?: types of <time> and <time> differ".
---- 10939,11010 ----
+--- 10964,11035 ----
   ieee.mo:Expected error in mat flonum->fixnum: "flonum->fixnum: result for -inf.0 would be outside of fixnum range".
   ieee.mo:Expected error in mat flonum->fixnum: "flonum->fixnum: result for +nan.0 would be outside of fixnum range".
   ieee.mo:Expected error in mat fllp: "fllp: 3 is not a flonum".
@@ -6579,7 +6577,7 @@
   date.mo:Expected error in mat time: "time>=?: #<procedure car> is not a time record".
   date.mo:Expected error in mat time: "time>=?: types of <time> and <time> differ".
 ***************
-*** 11012,11025 ****
+*** 11037,11050 ****
   date.mo:Expected error in mat time: "add-duration: <time> does not have type time-duration".
   date.mo:Expected error in mat time: "subtract-duration: <time> does not have type time-duration".
   date.mo:Expected error in mat time: "copy-time: <date> is not a time record".
@@ -6594,7 +6592,7 @@
   date.mo:Expected error in mat date: "make-date: invalid nanosecond -1".
   date.mo:Expected error in mat date: "make-date: invalid nanosecond <int>".
   date.mo:Expected error in mat date: "make-date: invalid nanosecond zero".
---- 11012,11025 ----
+--- 11037,11050 ----
   date.mo:Expected error in mat time: "add-duration: <time> does not have type time-duration".
   date.mo:Expected error in mat time: "subtract-duration: <time> does not have type time-duration".
   date.mo:Expected error in mat time: "copy-time: <date> is not a time record".
@@ -6610,7 +6608,7 @@
   date.mo:Expected error in mat date: "make-date: invalid nanosecond <int>".
   date.mo:Expected error in mat date: "make-date: invalid nanosecond zero".
 ***************
-*** 11045,11105 ****
+*** 11070,11130 ****
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset 90000".
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset est".
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset "est"".
@@ -6672,7 +6670,7 @@
   date.mo:Expected error in mat date: "current-date: invalid time-zone offset -90000".
   date.mo:Expected error in mat date: "current-date: invalid time-zone offset 90000".
   date.mo:Expected error in mat conversions/sleep: "date->time-utc: <time> is not a date record".
---- 11045,11105 ----
+--- 11070,11130 ----
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset 90000".
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset est".
   date.mo:Expected error in mat date: "make-date: invalid time-zone offset "est"".

--- a/mats/patch-compile-0-t-f-t
+++ b/mats/patch-compile-0-t-f-t
@@ -1,7 +1,7 @@
-*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Feb 24 19:38:21 2023
---- output-compile-0-t-f-t-experr/errors-compile-0-t-f-t	Fri Feb 24 19:41:49 2023
+*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2025-04-28 11:24:00.793487089 +0200
+--- output-compile-0-t-f-t-experr/errors-compile-0-t-f-t	2025-04-28 11:28:55.501786646 +0200
 ***************
-*** 4052,4058 ****
+*** 4069,4075 ****
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation "static"".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: 17 is not a procedure".
@@ -9,7 +9,7 @@
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation oldgen".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation -1".
   misc.mo:Expected error in mat make-object-finder: "incorrect number of arguments 1 to #<procedure find-next>".
---- 4052,4058 ----
+--- 4069,4075 ----
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation "static"".
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: 17 is not a procedure".
@@ -18,7 +18,7 @@
   misc.mo:Expected error in mat make-object-finder: "make-object-finder: invalid generation -1".
   misc.mo:Expected error in mat make-object-finder: "incorrect number of arguments 1 to #<procedure find-next>".
 ***************
-*** 7881,7891 ****
+*** 8023,8033 ****
   7.mo:Expected error in mat sstats: "set-sstats-gc-bytes!: twelve is not an exact integer".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation yuk".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation -1".
@@ -30,7 +30,7 @@
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
---- 7881,7891 ----
+--- 8023,8033 ----
   7.mo:Expected error in mat sstats: "set-sstats-gc-bytes!: twelve is not an exact integer".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation yuk".
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid generation -1".

--- a/mats/patch-compile-0-t-t-f
+++ b/mats/patch-compile-0-t-t-f
@@ -1,26 +1,24 @@
-*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Feb 24 19:38:21 2023
---- output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	Fri Feb 24 19:40:20 2023
+*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2025-04-28 11:24:00.793487089 +0200
+--- output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	2025-04-28 11:29:25.030615765 +0200
 ***************
-*** 226,233 ****
+*** 243,249 ****
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
+! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
-- 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
-  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
---- 226,233 ----
+--- 243,249 ----
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
-+ 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
+! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
-  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
 ***************
-*** 4094,4100 ****
+*** 4113,4119 ****
   misc.mo:Expected error in mat cpletrec: "foreign-procedure: no entry for "foo"".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable q".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable bar".
@@ -28,7 +26,7 @@
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable a".
---- 4094,4100 ----
+--- 4113,4119 ----
   misc.mo:Expected error in mat cpletrec: "foreign-procedure: no entry for "foo"".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable q".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable bar".
@@ -37,7 +35,7 @@
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable b".
   misc.mo:Expected error in mat cpletrec: "attempt to reference undefined variable a".
 ***************
-*** 7891,7898 ****
+*** 8033,8040 ****
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -46,7 +44,7 @@
   record.mo:Expected error in mat record2: "invalid value 3 for foreign type double-float".
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
---- 7891,7898 ----
+--- 8033,8040 ----
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -56,7 +54,7 @@
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
 ***************
-*** 7900,7914 ****
+*** 8042,8056 ****
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -72,7 +70,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid input #f".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
---- 7900,7914 ----
+--- 8042,8056 ----
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -89,7 +87,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
 ***************
-*** 7921,7946 ****
+*** 8063,8088 ****
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -116,7 +114,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: 0 is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
---- 7921,7946 ----
+--- 8063,8088 ----
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -144,7 +142,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
 ***************
-*** 8075,8113 ****
+*** 8225,8263 ****
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -184,7 +182,7 @@
   record.mo:Expected error in mat record?: "record?: 4 is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
---- 8075,8113 ----
+--- 8225,8263 ----
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -225,7 +223,7 @@
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
 ***************
-*** 8135,8171 ****
+*** 8285,8321 ****
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
   record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
@@ -263,7 +261,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "parent record type is sealed ex3".
---- 8135,8171 ----
+--- 8285,8321 ----
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
   record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".

--- a/mats/patch-interpret-0-f-f-f
+++ b/mats/patch-interpret-0-f-f-f
@@ -1,5 +1,5 @@
-*** errors-compile-0-f-f-f	Wed Feb 12 08:37:37 2025
---- output-interpret-0-f-f-f-cl6/errors-interpret-0-f-f-f	Wed Feb 12 04:06:51 2025
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2025-04-28 11:23:44.687579691 +0200
+--- output-interpret-0-f-f-f-experr/errors-interpret-0-f-f-f	2025-04-28 11:25:13.423069015 +0200
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -20,7 +20,7 @@
   primvars.mo:Expected error testing (expand 1.0+2.0i (quote #f)): Exception in sc-expand: #f is not an environment
   primvars.mo:Expected error testing (expand 1.0+2.0i (quote ((a . b))) 1.0+2.0i): Exception in sc-expand: ((a . b)) is not an environment
 ***************
-*** 85,91 ****
+*** 97,103 ****
   primvars.mo:Expected error in mat make-parameter: "make-parameter: 2 is not a procedure".
   primvars.mo:Expected error in mat make-parameter: "+: a is not a number".
   primvars.mo:Expected error in mat make-parameter: "incorrect number of arguments 1 to #<procedure>".
@@ -28,7 +28,7 @@
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: a is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: -1 is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: 0 is not a positive fixnum".
---- 85,91 ----
+--- 97,103 ----
   primvars.mo:Expected error in mat make-parameter: "make-parameter: 2 is not a procedure".
   primvars.mo:Expected error in mat make-parameter: "+: a is not a number".
   primvars.mo:Expected error in mat make-parameter: "incorrect number of arguments 1 to #<procedure>".
@@ -37,7 +37,7 @@
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: -1 is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: 0 is not a positive fixnum".
 ***************
-*** 115,185 ****
+*** 127,197 ****
   primvars.mo:Expected error in mat print-radix: "print-radix: 1 is not between 2 and 36".
   primvars.mo:Expected error in mat timer-interrupt-handler: "timer-interrupt-handler: midnight is not a procedure".
   primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input port string> is not a textual output port".
@@ -109,7 +109,7 @@
   3.mo:Expected error in mat let: "incorrect argument count in call ((lambda (x . r) (eq? x (...))))".
   3.mo:Expected error in mat letrec: "variable f is not bound".
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
---- 115,185 ----
+--- 127,197 ----
   primvars.mo:Expected error in mat print-radix: "print-radix: 1 is not between 2 and 36".
   primvars.mo:Expected error in mat timer-interrupt-handler: "timer-interrupt-handler: midnight is not a procedure".
   primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input port string> is not a textual output port".
@@ -182,7 +182,7 @@
   3.mo:Expected error in mat letrec: "variable f is not bound".
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
 ***************
-*** 278,289 ****
+*** 290,301 ****
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 0 values to single value return context".
@@ -195,7 +195,7 @@
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
   3.mo:Expected error in mat mrvs: "cdr: a is not a pair".
---- 278,289 ----
+--- 290,301 ----
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".
   3.mo:Expected error in mat mrvs: "returned 0 values to single value return context".
@@ -209,7 +209,7 @@
   3.mo:Expected error in mat mrvs: "returned 2 values to single value return context".
   3.mo:Expected error in mat mrvs: "cdr: a is not a pair".
 ***************
-*** 659,669 ****
+*** 671,681 ****
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: #f is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: (1 2 3) is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "incorrect argument count in call (call-in-continuation 1)".
@@ -221,7 +221,7 @@
   4.mo:Expected error in mat refcount-guardians: "unrecognized ftype name NO!".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
---- 659,669 ----
+--- 671,681 ----
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: #f is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: (1 2 3) is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "incorrect argument count in call (call-in-continuation 1)".
@@ -234,7 +234,7 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7488,7496 ****
+*** 7558,7566 ****
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect argument count in call (make-codec-buffer (lambda (bp) (make-bytevector 4)) "extra arg")".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -244,7 +244,7 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: foo is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
---- 7488,7496 ----
+--- 7558,7566 ----
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect argument count in call (make-codec-buffer (lambda (bp) (make-bytevector 4)) "extra arg")".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -255,26 +255,24 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
 ***************
-*** 7763,7770 ****
+*** 7833,7839 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7763,7770 ----
+--- 7833,7839 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
+! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
-+ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
-*** 8159,8165 ****
+*** 8236,8242 ****
   record.mo:Expected error in mat record25: "invalid value #\9 for foreign type uptr".
   record.mo:Expected error in mat record25: "invalid value 10 for foreign type float".
   record.mo:Expected error in mat record25: "invalid value 11.0+0.0i for foreign type double".
@@ -282,7 +280,7 @@
   record.mo:Expected error in mat record25: "invalid value 12.0 for foreign type long-long".
   record.mo:Expected error in mat record25: "invalid value 13.0 for foreign type unsigned-long-long".
   record.mo:Expected error in mat record25: "invalid value 3.0 for foreign type int".
---- 8159,8165 ----
+--- 8236,8242 ----
   record.mo:Expected error in mat record25: "invalid value #\9 for foreign type uptr".
   record.mo:Expected error in mat record25: "invalid value 10 for foreign type float".
   record.mo:Expected error in mat record25: "invalid value 11.0+0.0i for foreign type double".
@@ -291,26 +289,24 @@
   record.mo:Expected error in mat record25: "invalid value 13.0 for foreign type unsigned-long-long".
   record.mo:Expected error in mat record25: "invalid value 3.0 for foreign type int".
 ***************
-*** 8203,8210 ****
+*** 8280,8286 ****
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
-- record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
-  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
---- 8203,8210 ----
+--- 8280,8286 ----
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
+! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
-+ record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
-  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
 ***************
-*** 9487,9499 ****
+*** 9577,9589 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -324,7 +320,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9487,9499 ----
+--- 9577,9589 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -339,7 +335,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
 ***************
-*** 10284,10308 ****
+*** 10374,10398 ****
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
@@ -365,7 +361,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier booleen".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier integer-34".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure result type specifier chare".
---- 10284,10308 ----
+--- 10374,10398 ----
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
@@ -392,7 +388,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier integer-34".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure result type specifier chare".
 ***************
-*** 10315,10346 ****
+*** 10405,10436 ****
   foreign.mo:Expected error in mat foreign-sizeof: "incorrect argument count in call (foreign-sizeof (quote int) (quote int))".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
@@ -425,7 +421,7 @@
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
---- 10315,10346 ----
+--- 10405,10436 ----
   foreign.mo:Expected error in mat foreign-sizeof: "incorrect argument count in call (foreign-sizeof (quote int) (quote int))".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
@@ -459,7 +455,7 @@
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
 ***************
-*** 10348,10373 ****
+*** 10438,10463 ****
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
@@ -486,7 +482,7 @@
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
---- 10348,10373 ----
+--- 10438,10463 ----
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
@@ -514,7 +510,7 @@
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
 ***************
-*** 10379,10413 ****
+*** 10469,10503 ****
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
@@ -550,7 +546,7 @@
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
---- 10379,10413 ----
+--- 10469,10503 ----
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
@@ -587,7 +583,7 @@
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
 ***************
-*** 10452,10460 ****
+*** 10542,10550 ****
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: 1000000 is not a string".
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: no entry for "i am not defined"".
   foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name outside pointer field A".
@@ -597,7 +593,7 @@
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
---- 10452,10460 ----
+--- 10542,10550 ----
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: 1000000 is not a string".
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: no entry for "i am not defined"".
   foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name outside pointer field A".
@@ -608,7 +604,7 @@
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 ***************
-*** 11043,11052 ****
+*** 11133,11142 ****
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".
@@ -619,7 +615,7 @@
   oop.mo:Expected error in mat oop: "m1: not applicable to 17".
   oop.mo:Expected error in mat oop: "variable <a>-x1 is not bound".
   oop.mo:Expected error in mat oop: "variable <a>-x1-set! is not bound".
---- 11043,11052 ----
+--- 11133,11142 ----
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".

--- a/mats/patch-interpret-0-f-t-f
+++ b/mats/patch-interpret-0-f-t-f
@@ -1,5 +1,5 @@
-*** output-compile-0-f-t-f-cl3/errors-compile-0-f-t-f	Wed Feb 12 04:06:08 2025
---- output-interpret-0-f-t-f-rmg2/errors-interpret-0-f-t-f	Wed Feb 12 04:06:43 2025
+*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	2025-04-28 11:23:35.327633488 +0200
+--- output-interpret-0-f-t-f-experr/errors-interpret-0-f-t-f	2025-04-28 11:25:00.443143786 +0200
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -20,7 +20,7 @@
   primvars.mo:Expected error testing (expand 1.0+2.0i (quote #f)): Exception in sc-expand: #f is not an environment
   primvars.mo:Expected error testing (expand 1.0+2.0i (quote ((a . b))) 1.0+2.0i): Exception in sc-expand: ((a . b)) is not an environment
 ***************
-*** 85,91 ****
+*** 97,103 ****
   primvars.mo:Expected error in mat make-parameter: "make-parameter: 2 is not a procedure".
   primvars.mo:Expected error in mat make-parameter: "+: a is not a number".
   primvars.mo:Expected error in mat make-parameter: "incorrect number of arguments 1 to #<procedure>".
@@ -28,7 +28,7 @@
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: a is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: -1 is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: 0 is not a positive fixnum".
---- 85,91 ----
+--- 97,103 ----
   primvars.mo:Expected error in mat make-parameter: "make-parameter: 2 is not a procedure".
   primvars.mo:Expected error in mat make-parameter: "+: a is not a number".
   primvars.mo:Expected error in mat make-parameter: "incorrect number of arguments 1 to #<procedure>".
@@ -37,7 +37,7 @@
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: -1 is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: 0 is not a positive fixnum".
 ***************
-*** 115,185 ****
+*** 127,197 ****
   primvars.mo:Expected error in mat print-radix: "print-radix: 1 is not between 2 and 36".
   primvars.mo:Expected error in mat timer-interrupt-handler: "timer-interrupt-handler: midnight is not a procedure".
   primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input port string> is not a textual output port".
@@ -109,7 +109,7 @@
   3.mo:Expected error in mat let: "incorrect argument count in call ((lambda (x . r) (eq? x (...))))".
   3.mo:Expected error in mat letrec: "variable f is not bound".
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
---- 115,185 ----
+--- 127,197 ----
   primvars.mo:Expected error in mat print-radix: "print-radix: 1 is not between 2 and 36".
   primvars.mo:Expected error in mat timer-interrupt-handler: "timer-interrupt-handler: midnight is not a procedure".
   primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input port string> is not a textual output port".
@@ -182,7 +182,7 @@
   3.mo:Expected error in mat letrec: "variable f is not bound".
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
 ***************
-*** 659,669 ****
+*** 671,681 ****
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: #f is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: (1 2 3) is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "incorrect argument count in call (call-in-continuation 1)".
@@ -194,7 +194,7 @@
   4.mo:Expected error in mat refcount-guardians: "unrecognized ftype name NO!".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
---- 659,669 ----
+--- 671,681 ----
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: #f is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "call-in-other-continuation: (1 2 3) is not an extension of of the attachments of #<continuation>".
   4.mo:Expected error in mat call-in-continuation: "incorrect argument count in call (call-in-continuation 1)".
@@ -207,7 +207,7 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7488,7496 ****
+*** 7558,7566 ****
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect argument count in call (make-codec-buffer (lambda (bp) (make-bytevector 4)) "extra arg")".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -217,7 +217,7 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: foo is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
---- 7488,7496 ----
+--- 7558,7566 ----
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect argument count in call (make-codec-buffer (lambda (bp) (make-bytevector 4)) "extra arg")".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -228,26 +228,24 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
 ***************
-*** 7763,7770 ****
+*** 7833,7839 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7763,7770 ----
+--- 7833,7839 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
+! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
-+ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
-*** 7963,7970 ****
+*** 8033,8040 ****
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -256,7 +254,7 @@
   record.mo:Expected error in mat record2: "invalid value 3 for foreign type double-float".
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
---- 7963,7970 ----
+--- 8033,8040 ----
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -266,7 +264,7 @@
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
 ***************
-*** 7972,7986 ****
+*** 8042,8056 ****
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -282,7 +280,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid input #f".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
---- 7972,7986 ----
+--- 8042,8056 ----
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -299,7 +297,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
 ***************
-*** 7993,8018 ****
+*** 8063,8088 ****
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -326,7 +324,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: 0 is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
---- 7993,8018 ----
+--- 8063,8088 ----
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -354,7 +352,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
 ***************
-*** 8148,8186 ****
+*** 8225,8263 ****
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -394,7 +392,7 @@
   record.mo:Expected error in mat record?: "record?: 4 is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
---- 8148,8186 ----
+--- 8225,8263 ----
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -435,7 +433,7 @@
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
 ***************
-*** 8197,8254 ****
+*** 8274,8331 ****
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: invalid protocol flimflam".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure not-a-procedure".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure spam".
@@ -494,7 +492,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "cannot extend define-record-type parent fratrat".
---- 8197,8254 ----
+--- 8274,8331 ----
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: invalid protocol flimflam".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure not-a-procedure".
   record.mo:Expected error in mat r6rs-records-procedural: "attempt to apply non-procedure spam".
@@ -554,7 +552,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "define-record-type: incompatible record type cpoint - different parent".
   record.mo:Expected error in mat r6rs-records-syntactic: "cannot extend define-record-type parent fratrat".
 ***************
-*** 9487,9499 ****
+*** 9577,9589 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -568,7 +566,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
---- 9487,9499 ----
+--- 9577,9589 ----
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".
   fx.mo:Expected error in mat fx*: "fx*: (a . b) is not a fixnum".
@@ -583,7 +581,7 @@
   fx.mo:Expected error in mat r6rs:fx*: "fx*: <-int> is not a fixnum".
   fx.mo:Expected error in mat r6rs:fx*: "fx*: #f is not a fixnum".
 ***************
-*** 11043,11052 ****
+*** 11133,11142 ****
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".
@@ -594,7 +592,7 @@
   oop.mo:Expected error in mat oop: "m1: not applicable to 17".
   oop.mo:Expected error in mat oop: "variable <a>-x1 is not bound".
   oop.mo:Expected error in mat oop: "variable <a>-x1-set! is not bound".
---- 11043,11052 ----
+--- 11133,11142 ----
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".

--- a/mats/patch-interpret-0-t-f-f
+++ b/mats/patch-interpret-0-t-f-f
@@ -1,5 +1,5 @@
-*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Dec 20 18:23:34 2024
---- output-interpret-0-t-f-f-experr/errors-interpret-0-t-f-f	Fri Dec 20 18:25:02 2024
+*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2025-04-28 11:24:00.793487089 +0200
+--- output-interpret-0-t-f-f-experr/errors-interpret-0-t-f-f	2025-04-28 11:25:53.609837378 +0200
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -20,7 +20,7 @@
   primvars.mo:Expected error testing (expand 1.0+2.0i (quote #f)): Exception in sc-expand: #f is not an environment
   primvars.mo:Expected error testing (expand 1.0+2.0i (quote ((a . b))) 1.0+2.0i): Exception in sc-expand: ((a . b)) is not an environment
 ***************
-*** 85,91 ****
+*** 97,103 ****
   primvars.mo:Expected error in mat make-parameter: "make-parameter: 2 is not a procedure".
   primvars.mo:Expected error in mat make-parameter: "+: a is not a number".
   primvars.mo:Expected error in mat make-parameter: "incorrect number of arguments 1 to #<procedure>".
@@ -28,7 +28,7 @@
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: a is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: -1 is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: 0 is not a positive fixnum".
---- 85,91 ----
+--- 97,103 ----
   primvars.mo:Expected error in mat make-parameter: "make-parameter: 2 is not a procedure".
   primvars.mo:Expected error in mat make-parameter: "+: a is not a number".
   primvars.mo:Expected error in mat make-parameter: "incorrect number of arguments 1 to #<procedure>".
@@ -37,7 +37,7 @@
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: -1 is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: 0 is not a positive fixnum".
 ***************
-*** 115,185 ****
+*** 127,197 ****
   primvars.mo:Expected error in mat print-radix: "print-radix: 1 is not between 2 and 36".
   primvars.mo:Expected error in mat timer-interrupt-handler: "timer-interrupt-handler: midnight is not a procedure".
   primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input port string> is not a textual output port".
@@ -109,7 +109,7 @@
   3.mo:Expected error in mat let: "incorrect argument count in call ((lambda (x . r) ((...) x (...))))".
   3.mo:Expected error in mat letrec: "variable f is not bound".
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
---- 115,185 ----
+--- 127,197 ----
   primvars.mo:Expected error in mat print-radix: "print-radix: 1 is not between 2 and 36".
   primvars.mo:Expected error in mat timer-interrupt-handler: "timer-interrupt-handler: midnight is not a procedure".
   primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input port string> is not a textual output port".
@@ -182,7 +182,7 @@
   3.mo:Expected error in mat letrec: "variable f is not bound".
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
 ***************
-*** 663,669 ****
+*** 675,681 ****
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #<procedure> is not a continuation".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #f is not a continuation mark sequence".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: (1 2 3) is not a continuation mark sequence".
@@ -190,7 +190,7 @@
   4.mo:Expected error in mat refcount-guardians: "unrecognized ftype name NO!".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
---- 663,669 ----
+--- 675,681 ----
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #<procedure> is not a continuation".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #f is not a continuation mark sequence".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: (1 2 3) is not a continuation mark sequence".
@@ -199,7 +199,7 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7488,7496 ****
+*** 7558,7566 ****
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect number of arguments 2 to #<procedure make-codec-buffer>".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -209,7 +209,7 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: foo is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
---- 7488,7496 ----
+--- 7558,7566 ----
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect number of arguments 2 to #<procedure make-codec-buffer>".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -220,26 +220,24 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
 ***************
-*** 7763,7770 ****
+*** 7833,7839 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7763,7770 ----
+--- 7833,7839 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
+! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
-+ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
-*** 8158,8164 ****
+*** 8236,8242 ****
   record.mo:Expected error in mat record25: "invalid value #\9 for foreign type uptr".
   record.mo:Expected error in mat record25: "invalid value 10 for foreign type float".
   record.mo:Expected error in mat record25: "invalid value 11.0+0.0i for foreign type double".
@@ -247,7 +245,7 @@
   record.mo:Expected error in mat record25: "invalid value 12.0 for foreign type long-long".
   record.mo:Expected error in mat record25: "invalid value 13.0 for foreign type unsigned-long-long".
   record.mo:Expected error in mat record25: "invalid value 3.0 for foreign type int".
---- 8158,8164 ----
+--- 8236,8242 ----
   record.mo:Expected error in mat record25: "invalid value #\9 for foreign type uptr".
   record.mo:Expected error in mat record25: "invalid value 10 for foreign type float".
   record.mo:Expected error in mat record25: "invalid value 11.0+0.0i for foreign type double".
@@ -256,7 +254,7 @@
   record.mo:Expected error in mat record25: "invalid value 13.0 for foreign type unsigned-long-long".
   record.mo:Expected error in mat record25: "invalid value 3.0 for foreign type int".
 ***************
-*** 10283,10307 ****
+*** 10374,10398 ****
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
@@ -282,7 +280,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier booleen".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier integer-34".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure result type specifier chare".
---- 10283,10307 ----
+--- 10374,10398 ----
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
   foreign.mo:Expected error in mat foreign-procedure: "foreign-procedure: invalid foreign procedure handle foo".
@@ -309,7 +307,7 @@
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure argument type specifier integer-34".
   foreign.mo:Expected error in mat foreign-procedure: "invalid foreign-procedure result type specifier chare".
 ***************
-*** 10314,10345 ****
+*** 10405,10436 ****
   foreign.mo:Expected error in mat foreign-sizeof: "incorrect number of arguments 2 to #<procedure foreign-sizeof>".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
@@ -342,7 +340,7 @@
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
---- 10314,10345 ----
+--- 10405,10436 ----
   foreign.mo:Expected error in mat foreign-sizeof: "incorrect number of arguments 2 to #<procedure foreign-sizeof>".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier i-am-not-a-type".
   foreign.mo:Expected error in mat foreign-sizeof: "foreign-sizeof: invalid foreign type specifier 1".
@@ -376,7 +374,7 @@
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
 ***************
-*** 10347,10372 ****
+*** 10438,10463 ****
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
@@ -403,7 +401,7 @@
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
---- 10347,10372 ----
+--- 10438,10463 ----
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
   foreign.mo:Expected error in mat foreign-strings: "foreign-callable: invalid return value ("ello" 4) from #<procedure>".
@@ -431,7 +429,7 @@
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
 ***************
-*** 10378,10412 ****
+*** 10469,10503 ****
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
@@ -467,7 +465,7 @@
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
---- 10378,10412 ----
+--- 10469,10503 ----
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
   foreign.mo:Expected error in mat foreign-fixed-types: "foreign-callable: invalid return value (- x 7) from #<procedure>".
@@ -504,7 +502,7 @@
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
   foreign.mo:Expected error in mat foreign-C-types: "foreign-callable: invalid return value (73 74) from #<procedure>".
 ***************
-*** 10451,10459 ****
+*** 10542,10550 ****
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: 1000000 is not a string".
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: no entry for "i am not defined"".
   foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name outside pointer field A".
@@ -514,7 +512,7 @@
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
---- 10451,10459 ----
+--- 10542,10550 ----
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: 1000000 is not a string".
   foreign.mo:Expected error in mat foreign-ftype: "foreign-entry: no entry for "i am not defined"".
   foreign.mo:Expected error in mat foreign-ftype: "unexpected function ftype name outside pointer field A".
@@ -525,7 +523,7 @@
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
   foreign.mo:Expected error in mat foreign-callable: "foreign-callable: spam is not a procedure".
 ***************
-*** 11042,11051 ****
+*** 11133,11142 ****
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".
@@ -536,7 +534,7 @@
   oop.mo:Expected error in mat oop: "m1: not applicable to 17".
   oop.mo:Expected error in mat oop: "variable <a>-x1 is not bound".
   oop.mo:Expected error in mat oop: "variable <a>-x1-set! is not bound".
---- 11042,11051 ----
+--- 11133,11142 ----
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".

--- a/mats/patch-interpret-0-t-t-f
+++ b/mats/patch-interpret-0-t-t-f
@@ -1,5 +1,5 @@
-*** output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	Sat Aug  5 15:06:57 2023
---- output-interpret-0-t-t-f-experr/errors-interpret-0-t-t-f	Sat Aug  5 15:07:21 2023
+*** output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	2025-04-28 11:29:25.030615765 +0200
+--- output-interpret-0-t-t-f-experr/errors-interpret-0-t-t-f	2025-04-28 11:31:11.002001954 +0200
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -20,7 +20,7 @@
   primvars.mo:Expected error testing (expand 1.0+2.0i (quote #f)): Exception in sc-expand: #f is not an environment
   primvars.mo:Expected error testing (expand 1.0+2.0i (quote ((a . b))) 1.0+2.0i): Exception in sc-expand: ((a . b)) is not an environment
 ***************
-*** 85,91 ****
+*** 97,103 ****
   primvars.mo:Expected error in mat make-parameter: "make-parameter: 2 is not a procedure".
   primvars.mo:Expected error in mat make-parameter: "+: a is not a number".
   primvars.mo:Expected error in mat make-parameter: "incorrect number of arguments 1 to #<procedure>".
@@ -28,7 +28,7 @@
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: a is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: -1 is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: 0 is not a positive fixnum".
---- 85,91 ----
+--- 97,103 ----
   primvars.mo:Expected error in mat make-parameter: "make-parameter: 2 is not a procedure".
   primvars.mo:Expected error in mat make-parameter: "+: a is not a number".
   primvars.mo:Expected error in mat make-parameter: "incorrect number of arguments 1 to #<procedure>".
@@ -37,7 +37,7 @@
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: -1 is not a positive fixnum".
   primvars.mo:Expected error in mat collect-generation-radix: "collect-generation-radix: 0 is not a positive fixnum".
 ***************
-*** 115,185 ****
+*** 127,197 ****
   primvars.mo:Expected error in mat print-radix: "print-radix: 1 is not between 2 and 36".
   primvars.mo:Expected error in mat timer-interrupt-handler: "timer-interrupt-handler: midnight is not a procedure".
   primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input port string> is not a textual output port".
@@ -109,7 +109,7 @@
   3.mo:Expected error in mat let: "incorrect argument count in call ((lambda (x . r) ((...) x (...))))".
   3.mo:Expected error in mat letrec: "variable f is not bound".
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
---- 115,185 ----
+--- 127,197 ----
   primvars.mo:Expected error in mat print-radix: "print-radix: 1 is not between 2 and 36".
   primvars.mo:Expected error in mat timer-interrupt-handler: "timer-interrupt-handler: midnight is not a procedure".
   primvars.mo:Expected error in mat trace-output-port: "trace-output-port: #<input port string> is not a textual output port".
@@ -182,7 +182,7 @@
   3.mo:Expected error in mat letrec: "variable f is not bound".
   3.mo:Expected error in mat letrec: "attempt to reference undefined variable a".
 ***************
-*** 663,669 ****
+*** 675,681 ****
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #<procedure> is not a continuation".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #f is not a continuation mark sequence".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: (1 2 3) is not a continuation mark sequence".
@@ -190,7 +190,7 @@
   4.mo:Expected error in mat refcount-guardians: "unrecognized ftype name NO!".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
---- 663,669 ----
+--- 675,681 ----
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #<procedure> is not a continuation".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: #f is not a continuation mark sequence".
   4.mo:Expected error in mat call-in-continuation: "call-in-continuation: (1 2 3) is not a continuation mark sequence".
@@ -199,7 +199,7 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7453,7461 ****
+*** 7558,7566 ****
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect number of arguments 2 to #<procedure make-codec-buffer>".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -209,7 +209,7 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: foo is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
---- 7453,7461 ----
+--- 7558,7566 ----
   io.mo:Expected error in mat transcoded-port-buffer-size: "transcoded-port-buffer-size: 1024.0 is not a positive fixnum".
   io.mo:Expected error in mat make-codec-buffer: "incorrect number of arguments 2 to #<procedure make-codec-buffer>".
   io.mo:Expected error in mat make-codec-buffer: "make-codec-buffer: shoe is not a procedure".
@@ -220,26 +220,24 @@
   io.mo:Expected error in mat compress-parameters: "compress-format: "gzip" is not a supported format".
   io.mo:Expected error in mat compress-parameters: "compress-level: foo is not a supported level".
 ***************
-*** 7728,7735 ****
+*** 7833,7839 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7728,7735 ----
+--- 7833,7839 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
+! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
-+ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
-  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
-*** 7928,7935 ****
+*** 8033,8040 ****
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -248,7 +246,7 @@
   record.mo:Expected error in mat record2: "invalid value 3 for foreign type double-float".
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
---- 7928,7935 ----
+--- 8033,8040 ----
   7.mo:Expected error in mat bytes-allocated: "bytes-allocated: invalid space gnu".
   7.mo:Expected error in mat error: "a: hit me!".
   7.mo:Expected error in mat error: "f: n is 0".
@@ -258,7 +256,7 @@
   record.mo:Expected error in mat record2: "3 is not of type #<record type fudge>".
   record.mo:Expected error in mat record2: "make-record-type: invalid field list ((immutable double-float a) . b)".
 ***************
-*** 7937,7951 ****
+*** 8042,8056 ****
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -274,7 +272,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid input #f".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
---- 7937,7951 ----
+--- 8042,8056 ----
   record.mo:Expected error in mat type-descriptor: "invalid syntax (type-descriptor 3)".
   record.mo:Expected error in mat type-descriptor: "type-descriptor: unrecognized record car".
   record.mo:Expected error in mat record3: "variable set-fudge-a! is not bound".
@@ -291,7 +289,7 @@
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
   record.mo:Expected error in mat record9: "record-reader: invalid second argument fudge".
 ***************
-*** 7958,7983 ****
+*** 8063,8088 ****
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -318,7 +316,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: 0 is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
---- 7958,7983 ----
+--- 8063,8088 ----
   record.mo:Expected error in mat record10: "read: unresolvable cycle constructing record of type #<record type bar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
   record.mo:Expected error in mat record16: "read: unresolvable cycle constructing record of type #<record type bazar> at char 3 of #<input port string>".
@@ -346,7 +344,7 @@
   record.mo:Expected error in mat foreign-data: "foreign-alloc: <int> is not a positive fixnum".
   record.mo:Expected error in mat foreign-data: "foreign-alloc: -5 is not a positive fixnum".
 ***************
-*** 8112,8150 ****
+*** 8225,8263 ****
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -386,7 +384,7 @@
   record.mo:Expected error in mat record?: "record?: 4 is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
---- 8112,8150 ----
+--- 8225,8263 ----
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record22: "invalid field specifier (immutable creepy q)".
   record.mo:Expected error in mat record23: "make-record-type: cannot extend sealed record type #<record type foo> as bar".
@@ -427,7 +425,7 @@
   record.mo:Expected error in mat record?: "record?: a is not a record type descriptor".
   record.mo:Expected error in mat record?: "record?: #(1) is not a record type descriptor".
 ***************
-*** 8172,8208 ****
+*** 8285,8321 ****
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
   record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
@@ -465,7 +463,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "parent record type is sealed ex3".
---- 8172,8208 ----
+--- 8285,8321 ----
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
   record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
@@ -504,7 +502,7 @@
   record.mo:Expected error in mat r6rs-records-syntactic: "record-rtd: #<ex3> is not a record".
   record.mo:Expected error in mat r6rs-records-syntactic: "parent record type is sealed ex3".
 ***************
-*** 10973,10982 ****
+*** 11133,11142 ****
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".
@@ -515,7 +513,7 @@
   oop.mo:Expected error in mat oop: "m1: not applicable to 17".
   oop.mo:Expected error in mat oop: "variable <a>-x1 is not bound".
   oop.mo:Expected error in mat oop: "variable <a>-x1-set! is not bound".
---- 10973,10982 ----
+--- 11133,11142 ----
   exceptions.mo:Expected error in mat assert: "failed assertion (memq (quote b) (quote (1 2 a 3 4)))".
   exceptions.mo:Expected error in mat assert: "failed assertion (q ...)".
   exceptions.mo:Expected error in mat assert: "failed assertion (andmap symbol? (syntax (x ...)))".

--- a/mats/root-experr-compile-0-f-f-f
+++ b/mats/root-experr-compile-0-f-f-f
@@ -57,6 +57,18 @@ primvars.mo:Expected error testing (make-sstats *time *time (- (most-negative-fi
 primvars.mo:Expected error testing (make-sstats *time *time (- (most-negative-fixnum) 1) (- (most-negative-fixnum) 1) *time *time (quote 2.0)): Exception in make-sstats: gc-bytes value 2.0 is not an exact integer
 primvars.mo:Expected error testing (make-sstats *time *time (- (most-negative-fixnum) 1) (- (most-negative-fixnum) 1) *time *time (quote 1/2)): Exception in make-sstats: gc-bytes value 1/2 is not an exact integer
 primvars.mo:Expected error testing (make-sstats *time *time (- (most-negative-fixnum) 1) (- (most-negative-fixnum) 1) *time *time (quote #f)): Exception in make-sstats: gc-bytes value #f is not an exact integer
+primvars.mo:Expected error testing (property-value (quote x) (syntax x)): Exception in property-value: first argument x is not an identifier
+primvars.mo:Expected error testing (property-value (quote 17) (syntax x)): Exception in property-value: first argument 17 is not an identifier
+primvars.mo:Expected error testing (property-value (quote #f) (syntax x)): Exception in property-value: first argument #f is not an identifier
+primvars.mo:Expected error testing (property-value (syntax x) (quote x)): Exception in property-value: second argument #<syntax x> is not an identifier
+primvars.mo:Expected error testing (property-value (syntax x) (quote 17)): Exception in property-value: second argument #<syntax x> is not an identifier
+primvars.mo:Expected error testing (property-value (syntax x) (quote #f)): Exception in property-value: second argument #<syntax x> is not an identifier
+primvars.mo:Expected error testing (property-value (quote x) (syntax x) 1.0+2.0i): Exception in property-value: first argument x is not an identifier
+primvars.mo:Expected error testing (property-value (quote 17) (syntax x) 1.0+2.0i): Exception in property-value: first argument 17 is not an identifier
+primvars.mo:Expected error testing (property-value (quote #f) (syntax x) 1.0+2.0i): Exception in property-value: first argument #f is not an identifier
+primvars.mo:Expected error testing (property-value (syntax x) (quote x) 1.0+2.0i): Exception in property-value: second argument #<syntax x> is not an identifier
+primvars.mo:Expected error testing (property-value (syntax x) (quote 17) 1.0+2.0i): Exception in property-value: second argument #<syntax x> is not an identifier
+primvars.mo:Expected error testing (property-value (syntax x) (quote #f) 1.0+2.0i): Exception in property-value: second argument #<syntax x> is not an identifier
 primvars.mo:Expected error testing (pseudo-random-generator->vector (quote #f)): Exception in pseudo-random-generator->vector: not a pseudo-random generator #f
 primvars.mo:Expected error testing (pseudo-random-generator-seed! *pseudo-random-generator (quote #!eof)): Exception in pseudo-random-generator-seed!: not a nonnegative exact integer #!eof
 primvars.mo:Expected error testing (pseudo-random-generator-seed! *pseudo-random-generator (quote #f)): Exception in pseudo-random-generator-seed!: not a nonnegative exact integer #f
@@ -9229,6 +9241,19 @@ enum.mo:Expected error in mat enumeration: "make-record-type: cannot extend seal
 8.mo:Expected error in mat define-property: "set-top-level-value!: dp9-x is not a variable".
 8.mo:Expected error in mat define-property: "set-top-level-value!: cannot assign immutable variable dp10-x".
 8.mo:Expected error in mat define-property: "attempt to export multiple bindings for x from module (module () (export x (rename (...))) (define x 3) (define-property x k1 4) (alias y x) ...)".
+8.mo:Expected error in mat property-value: "multiple definitions for list in body (let () (define-property list type "procedure") (define list (lambda x x)) (list (get-property list type) (get-property car type)))".
+8.mo:Expected error in mat property-value: "multiple definitions for list in body (module m (list) (define-property list type "procedure") (define list (lambda x x)) (list (get-property list type) (get-property car type)))".
+8.mo:Expected error in mat property-value: "invalid definition in immutable environment (define-property frot rat 3)".
+8.mo:Expected error in mat property-value: "invalid definition in immutable environment (define-property cons rat 3)".
+8.mo:Expected error in mat property-value: "no visible binding for define-property id frot".
+8.mo:Expected error in mat property-value: "no visible binding for define-property key rat".
+8.mo:Expected error in mat property-value: "no visible binding for define-property id x".
+8.mo:Expected error in mat property-value: "no visible binding for define-property key frip".
+8.mo:Expected error in mat property-value: "no visible binding for define-property id x".
+8.mo:Expected error in mat property-value: "no visible binding for define-property key frip".
+8.mo:Expected error in mat property-value: "set-top-level-value!: dp9-x is not a variable".
+8.mo:Expected error in mat property-value: "set-top-level-value!: cannot assign immutable variable dp10-x".
+8.mo:Expected error in mat property-value: "attempt to export multiple bindings for x from module (module () (export x (rename (...))) (define x 3) (define-property x k1 4) (alias y x) ...)".
 8.mo:Expected error in mat library1: "compile-library: failed for /file/not/there.ss: no such file or directory".
 8.mo:Expected error in mat library1: "load-library: failed for /file/not/there: no such file or directory".
 8.mo:Expected error in mat library1: "load-library: abc is not a string".

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -116,6 +116,15 @@ Online versions of both books can be found at
 %-----------------------------------------------------------------------------
 \section{Functionality Changes}\label{section:functionality}
 
+\subsection{Simpified lookup of property values (10.2.0)}
+
+The \scheme{property-value} procedure, which can be used within the
+dynamic extent of the expander's call to a macro transformer, looks up
+the value of a property of an identifier in the macro's use
+environment.  This obviates the need to follow a specific transformer
+protocol to obtain a \scheme{lookup} that returns property values and
+lets macro helper functions look up property values independently.
+
 \subsection{Efficient in-place fxvector and flvector copying (10.2.0)}
 
 The \scheme{fxvector-copy!} and \scheme{flvector-copy!} functions

--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -1,11 +1,11 @@
 ;;; Copyright 1984-2017 Cisco Systems, Inc.
-;;; 
+;;;
 ;;; Licensed under the Apache License, Version 2.0 (the "License");
 ;;; you may not use this file except in compliance with the License.
 ;;; You may obtain a copy of the License at
-;;; 
+;;;
 ;;; http://www.apache.org/licenses/LICENSE-2.0
-;;; 
+;;;
 ;;; Unless required by applicable law or agreed to in writing, software
 ;;; distributed under the License is distributed on an "AS IS" BASIS,
 ;;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -748,7 +748,7 @@
                  (define-constant max-sweep-space last-swept-value)
                  (define-constant max-real-space last-unswept-value)
                  (define-constant max-space last-unreal-value)))))])))
-  
+
 (define-alloc-spaces
   (real
     (swept
@@ -1636,6 +1636,7 @@
    [ptr fxlength-bv]
    [ptr fxfirst-bit-set-bv]
    [ptr meta-level]
+   [ptr expand-time-environment]
    [ptr compile-profile]
    [ptr generate-inspector-information]
    [ptr generate-procedure-source-information]
@@ -2286,12 +2287,12 @@
 (define-primitive-structure-disps vfasl-header type-untyped
   ([uptr data-size]
    [uptr table-size]
-   
+
    [uptr result-offset]
-   
+
    ;; first starting offset is 0, so skip it in this array:
    [uptr vspace-rel-offsets (constant vspaces-offsets-count)]
-   
+
    [uptr symref-count]
    [uptr rtdref-count]
    [uptr singletonref-count]))
@@ -2769,7 +2770,7 @@
                                (make-libspec-flags xindex-base #f xclosure? xinterface xerror? xhas-does-not-expect-headroom-version?)))
                            (when xhas-does-not-expect-headroom-version?
                              ($sputprop xname '*does-not-expect-headroom-libspec*
-                               (make-libspec xname 
+                               (make-libspec xname
                                  (make-libspec-flags xindex-base #t xclosure? xinterface xerror? xhas-does-not-expect-headroom-version?)))))
                  '(name ...)
                  '(index-base ...)
@@ -3266,7 +3267,7 @@
     pb-uint64
     pb-single
     pb-double)
-  
+
   (define-pb-enum pb-move-types
     pb-i->i
     pb-d->d

--- a/s/mkgc.ss
+++ b/s/mkgc.ss
@@ -162,7 +162,7 @@
 
 (define-trace-root
   (case-type
-   
+
    [pair
     (case-space
      [(< space-weakpair)
@@ -309,7 +309,7 @@
        (pad (when (== (& len 1) 0)
               (set! (closure-data _copy_ len) (FIX 0))))
        (count countof-closure)])]
-   
+
    [symbol
     (space space-symbol)
     (size size-symbol)
@@ -321,7 +321,7 @@
     (trace-nonself symbol-splist)
     (trace-nonself symbol-hash)
     (count countof-symbol)]
-   
+
    [flonum
     (space space-data)
     (size size-flonum)
@@ -329,7 +329,7 @@
     (copy-flonum flonum-data)
     (count countof-flonum)
     (skip-forwarding)]
-   
+
    [typed-object
     (case-typefield
 
@@ -672,7 +672,7 @@
         [off])
        (count count-pair size-pair 2)]
       [else
-       (size size-pair) 
+       (size size-pair)
        (do-car pair-car)
        (do-cdr pair-cdr)
        (count count-pair)])]
@@ -990,10 +990,11 @@
       (trace-pure (tc-winders tc))
       (trace-pure (tc-attachments tc))
       (trace-pure (tc-handler-stack tc))
+      (trace-pure (tc-expand-time-environment tc))
       (case-mode
-       [sweep
-        (set! (tc-cached-frame tc) Sfalse)]
-       [else])
+        [sweep
+          (set! (tc-cached-frame tc) Sfalse)]
+        [else])
       (trace-return NO-COPY-MODE (FRAME tc 0))
       (trace-stack (cast uptr (tc-scheme-stack tc))
                    (cast uptr (SFP tc))
@@ -1312,7 +1313,7 @@
 (let ()
 
   (define preserve-flonum-eq? #t)
-  
+
   ;; A config is an association list. Mostly, it determines the
   ;; generation mode, but it is also used to some degree as an
   ;; environment-like map to communicate information from one
@@ -1399,7 +1400,7 @@
                      [(null? object-types)
                       (generate-type-dispatch base-types config)]
                      [else
-                      (generate-type-dispatch 
+                      (generate-type-dispatch
                        (cons (cons 'typed-object
                                    (generate-typed-object-dispatch object-types (cons '(basetype typed-object)
                                                                                       config)))
@@ -2328,7 +2329,7 @@
          (when (and index (not (eq? index 0)))
            (error 'field-ref "index not allowed for non-array field ~s" acc-name))
          (format "~a(~a)" c-ref obj)])))
-  
+
   (define (ensure-segment-mark-mask si inset)
     (code
      (format "~aif (!~a->marked_mask) {" inset si)
@@ -2582,7 +2583,7 @@
   ;; macros:
   (let-values ([(op get) (open-bytevector-output-port (native-transcoder))])
     (mkequates.h op))
-  
+
   (set! mkgc-ocd.inc (lambda (ofn) (gen-gc ofn #f #f #f)))
   (set! mkgc-oce.inc (lambda (ofn) (gen-gc ofn #t #t #f))) ; not currently parallel (but could be "parallel" for ownership preservation)
   (set! mkgc-par.inc (lambda (ofn) (gen-gc ofn #f #f #t)))

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1636,6 +1636,7 @@
   (profile-load-data [sig [(pathname ...) -> (void)]] [flags true])
   (profile-release-counters [sig [() -> (void)]] [flags true])
   (property-list [sig [(symbol) -> (list)]] [flags discard true safeongoodargs])
+  (property-value [sig [(identifier identifier) (identifier identifier ptr) -> (ptr)]] [flags pure mifoldable discard])
   (put-bytevector-some [sig [(binary-output-port bytevector) (binary-output-port bytevector length) (binary-output-port bytevector length length) -> (uint)]] [flags true])
   (put-hash-table! [sig [(old-hash-table ptr ptr) -> (void)]] [flags true])
   (put-source-table [sig [(textual-output-port source-table) -> (void)]] [flags true])


### PR DESCRIPTION
The `property-value` procedure, which can be used within the dynamic extent of the expander's call to a macro transformer, looks up the value of a property of an identifier in the macro's use environment.  This obviates the need to follow a specific transformer protocol to obtain a `lookup` procedure that returns property values and lets macro helper functions look up property values independently.