### PR TITLE
Allow setting history file location from environment

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -99,7 +99,9 @@ int main(int argc, const char *argv[]) {
   int exists_timestamp_mode = 0;
 #ifdef FEATURE_EXPEDITOR
   int expeditor_enable = 1;
-  const char *expeditor_history_file = "";  /* use "" for default location */
+  /* use "" for default location */
+  const char *expeditor_history_file = getenv("CHEZSCHEME_HISTORY");
+  if (!expeditor_history_file) expeditor_history_file = "";
 #endif /* FEATURE_EXPEDITOR */
 
   if (strcmp(Skernel_version(), VERSION) != 0) {

--- a/csug/use.stex
+++ b/csug/use.stex
@@ -347,6 +347,8 @@ been redirected, or if the \scheme{--eedisable} command-line option
 (Section~\ref{SECTUSECOMMANDLINE}) has been used.
 The history is saved across sessions, by default, in the file
 ``.chezscheme\_history'' in the user's home directory.
+If the \scheme{CHEZSCHEME_HISTORY} environment variable is set during startup,
+its value becomes the default history file location.
 The \scheme{--eehistory} command-line option
 (Section~\ref{SECTUSECOMMANDLINE}) can be used to specify a different
 location for the history file or to disable the saving and restoring of

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -116,6 +116,13 @@ Online versions of both books can be found at
 %-----------------------------------------------------------------------------
 \section{Functionality Changes}\label{section:functionality}
 
+\subsection{Support for setting the default history file location using the \scheme{CHEZSCHEME_HISTORY environment variable}}
+
+If the environment variable \scheme{CHEZSCHEME_HISTORY} is set during
+startup, and the \scheme{--eehistory} command-line option isn't used,
+the value of said environment variable will determine the history file
+location that will be used.
+
 \subsection{Type recovery improvements (10.3.0)}
 
 The type recovery pass has improved support for \scheme{cfl+} and

--- a/scheme.1.in
+++ b/scheme.1.in
@@ -196,6 +196,8 @@ not set, if the standard input or output files have been redirected, or
 if the --eedisable command-line option has been used.
 The history is saved across sessions, by default, in the file
 \*(lq$HOME/.chezscheme_history\*(rq.
+This default can be changed by setting the \*(lqCHEZSCHEME_HISTORY\*(rq
+environment variable.
 The --eehistory command-line option
 can be used to specify a different
 location for the history file or to disable the saving and restoring of
@@ -750,6 +752,11 @@ The environment variable
 (see above) may be set
 to a colon-separated (semi-colon under Windows) list of directories
 in which to search for boot files.
+
+The environment variable
+.B CHEZSCHEME_HISTORY \fR
+(see above) may be set
+to the location to use as the default history file location.
 .SH FILES
 .if 0 COMMENT: put the longest path from below in the tab computation:
 .ta \w'{InstallLibExamples}'u+.25i


### PR DESCRIPTION
A CLI flag isn't very convenient for modifying history file locations, since it needs to be specified in many contexts, some of which are difficult to actually modify the argument list for.
It's common practice (less, node, psql, python, sqlite… the list goes on) to allow setting the history file location from an environment variable named something like `PROJECT_HISTORY`.
When set, it overrides the default when nothing else is specified, but is still overriden by a CLI argument.
This implements this feature in Chez.

I haven't tested this yet (I might get to it somewhat later), and I'm relatively unfamiliar with sTeX (changes to which I also haven't tested so far). I figured I would open this "early" to allow for any relevant comments to be made in the interim, though I don't expect this change to be controversial.

The expected UX is that a user that wants all of their history files in a centralized location (e.g. I use ~/.local/state/history/*) shall set a bunch of environment variables in their login shell, and from that point on won't have to think about it anymore.

The final questions remain with respect to the release notes and tests.
How exactly should I test this? Where in the release notes should this be mentioned?
This part of the contributing document wasn't entirely clear, besides that it should be done.
I'm perfectly willing to, but would rather have a little bit of direction as to what's expected (while I do other things and later make sure the documentation changes actually look correct) :)