### PR TITLE
improve `expt` on a flonum to a large exact power

### DIFF
--- a/c/prim5.c
+++ b/c/prim5.c
@@ -1463,13 +1463,16 @@ static double s_pow(double x, double y) {
   } else
     return pow(x, y);
 }
-#elif defined(MACOSX)
-/* intel macosx delivers precise results for integer inputs, e.g.,
- * 10.0^21.0, only with long double version of pow */
+#elif (machine_type == machine_type_i3osx || machine_type == machine_type_ti3osx)
+/* intel macosx delivers accurate results for integer inputs, e.g.,
+ * 10.0^21.0, only with long double version of pow; it's not clear
+ * whether that has been true for x86_64 as opposed to i386, but as
+ * of macOS 10.15 (Catalina), pow seems ok for x86_64, while powl
+ * is less accurate as of macOS 13; so, we're using powl only for i3osx */
 static double s_pow(double x, double y) { return powl(x, y); }
-#else /* i3fb/ti3fb */
-static double s_pow(double x, double y) { return pow(x, y); }
-#endif /* i3fb/ti3fb */
+#else /* i3fb/ti3fb/i3osx/ti3osx */
+static double s_pow(double x, double y) { return powl(x, y); }
+#endif /* i3fb/ti3fb/i3osx/ti3osx */
 
 #ifdef __MINGW32__
 /* asinh() and atanh() sometimes get zero sign wrong */

--- a/mats/5_3.ms
+++ b/mats/5_3.ms
@@ -2706,6 +2706,65 @@
                        (begin (set! ls (reverse ls)) 3))])
           (cons n ls)))
       '(8 c b a c b a))
+    (eqv? 0.0 (expt 0.0 (add1 (expt 2 10))))
+    (eqv? +inf.0 (expt 0.0 (- (add1 (expt 2 10)))))
+    (eqv? -0.0 (expt -0.0 (add1 (expt 2 10))))
+    (eqv? -inf.0 (expt -0.0 (- (add1 (expt 2 10)))))
+    (eqv? 0.0 (expt 0.0 (add1 (expt 2 55))))
+    (eqv? +inf.0 (expt 0.0 (- (add1 (expt 2 55)))))
+    (eqv? -0.0 (expt -0.0 (add1 (expt 2 55))))
+    (eqv? -inf.0 (expt -0.0 (- (add1 (expt 2 55)))))
+    (eqv? 0.0 (expt 0.0 (add1 (expt 2 155))))
+    (eqv? +inf.0 (expt 0.0 (- (add1 (expt 2 155)))))
+    (eqv? -0.0 (expt -0.0 (add1 (expt 2 155))))
+    (eqv? -inf.0 (expt -0.0 (- (add1 (expt 2 155)))))
+    (begin
+      (define ($flexpt~= a b)
+        ;; The accuracy of `expt` ultimately depends on the C
+        ;; library's `pow`, and platforms vary. The `fl~=` predicate
+        ;; reflects that variation for most purposes, but `pow` can
+        ;; var more. Enumerate a few platforms where we trust `pow` to
+        ;; be good, and increase the fuzz for other platforms.
+        (fl~= a b
+              (case (machine-type)
+                [(i3le ti3le a6le ta6le arm64osx tarm64osx)
+                 *fuzz*]
+                [else
+                 1e-5])))
+      #t)
+    ;; In the following tests, the expected value comes from taking
+    ;; the number represented the flonum first argument to `expt` and
+    ;; finding the flonum that most accurately represents the exact
+    ;; power of that number --- as computed by Brad Lucier's package
+    ;; for computable reals.
+    ($flexpt~= (expt 1.000000000000001 72057594037927936) 5.540622384393264e34)
+    ($flexpt~= (expt -1.000000000000001 72057594037927936) 5.540622384393264e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927937) 5.54062238439327e34)
+    ($flexpt~= (expt -1.000000000000001 72057594037927937) -5.54062238439327e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927938) 5.5406223843932765e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927939) 5.540622384393282e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927940) 5.5406223843932885e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927941) 5.540622384393295e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927942) 5.5406223843933005e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927943) 5.540622384393307e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927944) 5.540622384393313e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927945) 5.540622384393319e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927946) 5.540622384393325e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927947) 5.540622384393332e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927948) 5.540622384393337e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927949) 5.540622384393344e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927950) 5.54062238439335e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927951) 5.540622384393357e34)
+    ($flexpt~= (expt 1.000000000000001 72057594037927952) 5.540622384393362e34)
+    ($flexpt~= (expt .999999999999923 9113206036900117) 1.1282707411034352e-305)
+    ($flexpt~= (expt .999999999999923 9113206036900118) 1.1282707411033483e-305)
+    ($flexpt~= (expt .999999999999923 9113206036900119) 1.1282707411032614e-305)
+    ($flexpt~= (expt .999999999999923 9113206036900120) 1.1282707411031744e-305)
+    ($flexpt~= (expt .999999999999923 9113206036900121) 1.1282707411030875e-305)
+    ($flexpt~= (expt .999999999999923 9113206036900122) 1.1282707411030006e-305)
+    ($flexpt~= (expt .999999999999923 9113206036900123) 1.1282707411029136e-305)
+    ($flexpt~= (expt .999999999999923 9113206036900124) 1.1282707411028267e-305)
+    ($flexpt~= (expt .999999999999923 9113206036900125) 1.1282707411027398e-305)
  )
 
 (mat expt-mod

--- a/mats/mat.ss
+++ b/mats/mat.ss
@@ -416,15 +416,17 @@
                      (inexact (imag-part y)))))))
 
 (define fl~=
-   (lambda (x y)
-      (cond
-         [(and (fl>= (flabs x) 2.0) (fl>= (flabs y) 2.0))
-          (fl~= (fl/ x 2.0) (fl/ y 2.0))]
-         [(and (fl< 0.0 (flabs x) 1.0) (fl< 0.0 (flabs y) 1.0))
-          (fl~= (fl* x 2.0) (fl* y 2.0))]
-         [else (let ([d (flabs (fl- x y))])
-                  (or (fl<= d *fuzz*)
-                      (begin (printf "fl~~=: ~s~%" d) #f)))])))
+  (case-lambda
+   [(x y fuzz)
+    (cond
+      [(and (fl>= (flabs x) 2.0) (fl>= (flabs y) 2.0))
+       (fl~= (fl/ x 2.0) (fl/ y 2.0) fuzz)]
+      [(and (fl< 0.0 (flabs x) 1.0) (fl< 0.0 (flabs y) 1.0))
+       (fl~= (fl* x 2.0) (fl* y 2.0) fuzz)]
+      [else (let ([d (flabs (fl- x y))])
+              (or (fl<= d fuzz)
+                  (begin (printf "fl~~=: ~s~%" d) #f)))])]
+   [(x y) (fl~= x y *fuzz*)]))
 
 (define cfl~=
    (lambda (x y)

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -133,6 +133,12 @@ similar functions.
 The character sets, character classes, and word-breaking algorithms for character, string,
 and Unicode-related bytevector operations have now been updated to Unicode 16.0.0.
 
+\subsection{Improved \scheme{expt} on a flonum and a large exact power (10.3.0)}
+
+The \scheme{expt} function produces a more accurate result when its
+first argument is a flonum and its second argument is an exact integer
+that has no equivalent flonum representation.
+
 \subsection{Command-line options \scheme{--version} and \scheme{--help} write to stdout
 (10.2.0)}
 


### PR DESCRIPTION
Advice and implementation provided by @gambiteer via racket/racket#5228.

I'm not sure about my approach to testing here. In principle, `expt` should produce a accurate result, but the result relies on `pow` from the C library, and the quality of that function varies. On GitHub CI, even `a6osx` doesn't produce a accurate result, even though it does on machines that I have access to — at least, I get a precise result with the changes in `prim5.c`. Overall, maybe there is a better approach.