### PR TITLE
correct `powl` that was intended to be `pow`

### DIFF
--- a/c/prim5.c
+++ b/c/prim5.c
@@ -1467,11 +1467,10 @@ static double s_pow(double x, double y) {
 /* intel macosx delivers accurate results for integer inputs, e.g.,
  * 10.0^21.0, only with long double version of pow; it's not clear
  * whether that has been true for x86_64 as opposed to i386, but as
- * of macOS 10.15 (Catalina), pow seems ok for x86_64, while powl
- * is less accurate as of macOS 13; so, we're using powl only for i3osx */
+ * of macOS 10.15 (Catalina), pow seems ok for x86_64 */
 static double s_pow(double x, double y) { return powl(x, y); }
 #else /* i3fb/ti3fb/i3osx/ti3osx */
-static double s_pow(double x, double y) { return powl(x, y); }
+static double s_pow(double x, double y) { return pow(x, y); }
 #endif /* i3fb/ti3fb/i3osx/ti3osx */
 
 #ifdef __MINGW32__

--- a/mats/5_3.ms
+++ b/mats/5_3.ms
@@ -2723,11 +2723,11 @@
         ;; The accuracy of `expt` ultimately depends on the C
         ;; library's `pow`, and platforms vary. The `fl~=` predicate
         ;; reflects that variation for most purposes, but `pow` can
-        ;; var more. Enumerate a few platforms where we trust `pow` to
+        ;; vary more. Enumerate a few platforms where we trust `pow` to
         ;; be good, and increase the fuzz for other platforms.
         (fl~= a b
               (case (machine-type)
-                [(i3le ti3le a6le ta6le arm64osx tarm64osx)
+                [(i3le ti3le a6le ta6le a6osx ta6osx arm64osx tarm64osx)
                  *fuzz*]
                 [else
                  1e-5])))


### PR DESCRIPTION
Despite helpful reviews, I managed to mangle part of #950.

An intended change was to use `pow` instead of `powl` for x86_64 and AArch64 macOS. The mangled change caused `powl` to be used even more broadly, instead. Also, simplify the comment, since extra caveats seem related to experiments with a similarly incorrect change, and adjust the test, since results on x86_64 macOS should be reliably accurate.

Noticed by @gambiteer by the time it was merged to Racket: https://github.com/racket/racket/commit/de67e3372038316b956b958d1f9864a406d20d01#r161150380