### PR TITLE
Fix build-let in cptypes

### DIFF
--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -1606,6 +1606,18 @@
                        (if (#2%fixnum? y) ;the specialization uses #2%fixnum?
                            (fxand x y)
                            (bitwise-and x y))))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (bitwise-and (begin (newline) 7) x))
+    '(lambda (x) (newline) ; ensure side effects are not duplicated
+                 (if (#2%fixnum? x) ;the specialization uses #2%fixnum?
+                     (fxand 7 x)
+                     (bitwise-and 7 x))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (bitwise-and 7 (begin (newline) x)))
+    '(lambda (x) (newline) ; ensure side effects are not duplicated
+                 (if (#2%fixnum? x) ;the specialization uses #2%fixnum?
+                     (fxand 7 x)
+                     (bitwise-and 7 x))))
 )
 
 (mat cptypes-unreachable


### PR DESCRIPTION
When `cptypes` has to duplicate an expression, it uses `build-let` to create temporary variables
But it tries to propagate the obvious cases, like in

    (bitwise-and (f) 7)
    =>
    (let ([t (f)])
      (if (fixnum? t)
          (fxand t 7)
          (bitwise-and t 7)))

where `7` is copied instead of assigned to a temporary variable.

Don't propagate numbers that are not fixnums to avoid problems with `eq?`.

The main idea is that it's fine to have information moduo `eqv?` inside the `types tree`, that is good to reduce

    (when (eqv? x 7.0) (eqv? x 8.0)
    =>
    (when (eqv? x 7.0) #f)

but it's important to not copy that info like in 

    (when (eqv? x 7.0) (list x 8.0)
    => this does not happen =>
    (when (eqv? x 7.0) (list 7.0 8.0))

I took a look and I think all the other similar sites are careful to avoid copying non-fixnum-numbers, but the auxiliar function `prepare-let` does not check this, so I'm adding the check now.

I used `prepare-let` and `build-let` mostly with special cases for fixnums, so I couldn't find a way to cause a bug, but I think it's better to be more cautions. So, this is a change to make it more safe just in case.

 