### PR TITLE
wraparound fixnum operations in the implementation of `flbit-field`

### DIFF
--- a/s/5_3.ss
+++ b/s/5_3.ss
@@ -3433,7 +3433,7 @@
     (let ()
       (define (fxextract n start end)
         (fxand (fxsrl n start)
-               (fx- (fxsll 1 (fx- end start)) 1)))
+               (fx-/wraparound (fxsll/wraparound 1 (fx- end start)) 1)))
       (cond
         [(fx<= end (constant positive-fixnum-bits))
          (fxextract (flbit-field x 0 (constant positive-fixnum-bits)) start end)]


### PR DESCRIPTION
This change will have no affect on the machine code generated for `flbit-field`, normally, since `fx-` and `fx-/wraparound` produce the same code in unsafe mode, as do `fxsll` and `fxsll/wraparound`. But this repair avoids failure in "fl.ms" afer compiling Chez Scheme itself in safe mode with something like `zuo . o=0`.

Another possibility is to allow only a smaller bit width (by 1 bit) to reach the relevant expression. Using wraparound operators seems more conservative in that it keeps the generated code the same.