### PR TITLE
Load without seek support.

### DIFF
--- a/s/7.ss
+++ b/s/7.ss
@@ -305,7 +305,10 @@
     (lambda (x) (run-outer x)))
 
   (define (do-load who fn situation for-import? importer ksrc)
-    (let ([ip ($open-file-input-port who fn)])
+    (let ([ip (let ([ip ($open-file-input-port who fn)])
+          (if (port-has-set-port-position!? ip)
+              (open-bytevector-input-port (get-bytevector-all ip))
+              ip))])
       (on-reset (close-port ip)
         (let ([fp (let ([start-pos (port-position ip)])
                     (if (and (eqv? (get-u8 ip) (char->integer #\#))


### PR DESCRIPTION
It will appear when using stream transmission:

```bash
rmolives@debian:~/works/bin$ chezscheme --script <(echo "(display (+ 2 3))")
Exception in port-position: failed on #<binary input port /dev/fd/63>: illegal seek
```

Related issues are #901 

So we changed some codes to make it support the same operation as Python.