### PR TITLE
exit with non-0 code on boot-file errors

### DIFF
--- a/mats/7.ms
+++ b/mats/7.ms
@@ -1068,12 +1068,17 @@
            (lambda ()
              (pretty-print '(display "hello 5\n")))
            '(replace))
+         (with-output-to-file "testfile-6.ss"
+           (lambda ()
+             (pretty-print '(error 'boot "fail")))
+           '(replace))
          (parameterize ([optimize-level 2])
            (compile-script "testfile-1")
            (compile-script "testfile-2")
            (compile-file "testfile-3")
            (compile-file "testfile-4")
-           (compile-file "testfile-5")))
+           (compile-file "testfile-5")
+           (compile-file "testfile-6")))
        (void))
   (equal?
     (begin
@@ -1180,6 +1185,14 @@
           (unless (eof-object? err) (error 'bootfile-test2 err))
           out)))
     "#<code>\n"))
+  ;; make sure an error from a boot file exits with a non-0 exit code
+  (not (equal?
+        (begin
+          (parameterize ([optimize-level 2])
+            (make-boot-file "testfile.boot" '("petite")
+                            "testfile-6.so"))
+          (system (format "~a -b ./testfile.boot -q" (patch-exec-path *scheme*))))
+        0))
 )
 
 (mat hostop

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2868,6 +2868,13 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Exit with failure on error from boot file (10.3.0)}
+
+When an error is encountered within a boot file---either raised
+explicitly by the boot file's code or due to certain kinds of problems
+with a boot file's content---then exit with a non-0 code (meaning
+failure) instead of a 0 exit code.
+
 \subsection{Respect constraint on \scheme{make-record-constructor-descriptor} (10.2.0)}
 
 The source optimizer (cp0) overlooked the constraint that, when forming a

--- a/s/7.ss
+++ b/s/7.ss
@@ -659,7 +659,7 @@
 
   (set! reset-handler
     ($make-thread-parameter
-      (lambda () (c-exit 0))
+      (lambda () (c-exit -1)) ; error during load of boot file uses this handler
       (lambda (v)
         (unless (procedure? v)
           ($oops 'reset-handler "~s is not a procedure" v))


### PR DESCRIPTION
When an error is encountered within a boot file — either raised explicitly by the boot file's code or due to certain kinds of problems with a boot file's content — then exit with a non-0 code (meaning failure) instead of a 0 exit code.

Fixes #973
