### PR TITLE
repair pb `vector-cas!` for large immediate offsets

### DIFF
--- a/mats/5_6.ms
+++ b/mats/5_6.ms
@@ -2118,6 +2118,11 @@
   (error? (vector-cas! vec1 (expt 2 26) 2 3)) ; out of range
   (error? (vector-cas! vec1 (expt 2 40) 2 3)) ; out of range
 
+  ;; large immediate index without write barrier
+  (let ([vec (make-vector (expt 2 17))])
+    (and (retry-for-spurious (vector-cas! vec (sub1 (expt 2 17)) 0 42))
+         (eq? (vector-ref vec (sub1 (expt 2 17))) 42)))
+
   ;; make sure `vector-cas!` works with GC generations:
   (begin
     (collect 0)

--- a/mats/mat.ss
+++ b/mats/mat.ss
@@ -622,7 +622,8 @@
 (define-syntax retry-for-spurious
   (let ([mt (symbol->string (machine-type))])
     (if (or (memq (substring mt 0 2) '("a6" "i3"))
-            (memq (substring mt 0 3) '("ta6" "ti3")))
+            (and (> (string-length mt) 2)
+                 (memq (substring mt 0 3) '("ta6" "ti3"))))
         ;; no retry loop needed on x86
         (lambda (stx)
           (syntax-case stx ()

--- a/s/pb.ss
+++ b/s/pb.ss
@@ -551,7 +551,17 @@
       [(op (x ur) (y ur) (w signed16) (old ur) (new ur))
        (addr-reg x y w (lambda (u)
                          ;; signals on successful swap
-                         `(asm ,info ,asm-cas! ,u ,old ,new)))]))
+                         `(asm ,info ,asm-cas! ,u ,old ,new)))]
+      [(op (x ur) (y ur) (w ur) (old ur) (new ur))
+       (let ([zero-imm (with-output-language (L15d Triv) `(immediate 0))])
+         (cond
+           [(eq? y %zero)
+            (addr-reg x w zero-imm (lambda (u) `(asm ,info ,asm-cas! ,u ,old ,new)))]
+           [else
+            (let ([u0 (make-tmp 'u)])
+              (seq
+               `(set! ,(make-live-info) ,u0 (asm ,null-info ,(asm-add #f) ,y ,w))
+               (addr-reg x u0 zero-imm (lambda (u) `(asm ,info ,asm-cas! ,u ,old ,new)))))]))]))
 
   (define-instruction effect (store-store-fence)
     [(op)


### PR DESCRIPTION
The `vector-cas!` operation was not compiled correctly for pb with immediate offsets that don't fit into 16 bits. This case was indirectly covered by some existing tests, but not test in the `test-some` set.