### PR TITLE
add `black-box`

### DIFF
--- a/csug/system.stex
+++ b/csug/system.stex
@@ -5375,6 +5375,67 @@ The cpu time is returned as a time object with time-type \scheme{time-duration}.
 This procedure resets the costs recorded by \var{cost-center} to zero.
 
 
+\section{Black-Box Procedure\label{SECTMISCBLACKBOX}}
+
+\noskipentryheader
+\formdef{black-box}{\categoryprocedure}{(black-box \var{obj})}
+\returns \var{obj}
+\listlibraries
+\endnoskipentryheader
+
+\noindent
+The \scheme{black-box} procedure simply returns its argument, but
+optimization passes make no assumptions about how \scheme{black-box}
+uses its argument, whether \scheme{black-box} has side effects,
+or what \scheme{black-box} returns beyond the fact that it is a
+single value.
+
+The intended use of \scheme{black-box} is for benchmarking and testing
+tasks that need to simulate an arbitrary consumption context for a
+computation, but without otherwise adding overhead to the computation
+by adding a non-inlined function call or other obfuscating work.
+
+Examples:
+
+\schemedisplay
+(time
+ (let ([to-power 100])
+   (let loop ([i 1000])
+     (unless (zero? i)
+       ; call to `expt` is likely optimized away entirely, since there's
+       ; no effect and the result is unused:
+       (expt 2 to-power)
+       (loop (sub1 i))))))
+
+(time
+ (let ([to-power 100])
+   (let loop ([i 1000])
+     (unless (zero? i)
+       ; likely optimized to just returning a folded constant, instead of
+       ; calling `expt` each iteration:
+       (black-box (expt 2 to-power))
+       (loop (sub1 i))))))
+
+(time
+ (let ([to-power (black-box 100)])
+   (let loop ([i 1000])
+     (unless (zero? i)
+       ; in safe mode, likely calls `expt`, because `to-power` is not known
+       ; to be a number, but likely optimized away with `(optimize-level 3)`:
+       (expt 2 to-power)
+       (loop (sub1 i))))))
+
+(time
+ (let ([to-power (black-box 100)])
+   (let loop ([i 1000])
+     (unless (zero? i)
+       ; arithmetic really performed every iteration, since `to-power` value
+       ; is assumed unknown, and `expt` result is assumed to be used
+       (black-box (expt 2 to-power))
+       (loop (sub1 i))))))
+\endschemedisplay
+
+
 \section{Parameters\label{SECTPARAMETERS}}
 
 This section describes mechanisms for creating and manipulating parameters.

--- a/mats/misc.ms
+++ b/mats/misc.ms
@@ -4242,16 +4242,16 @@
       ;;; set-cdr! as it does not appear that frequently in tests.ss
       ;;;
       ;;;  before
-      ;;;      +--+--+    +--+--+    +--+--+         +--+--+    +--+--+    +--+--+
-      ;;;      | 1|------>| 2|------>| 3|------> ... | 6|------>| 7|------>| 8|#f|
-      ;;;      +--+--+    +--+--+    +--+--+         +--+--+    +--+--+    +--+--+
+      ;;;      +--+--+    +--+--+    +--+--+         +--+--+    +--+--+    +--+----+
+      ;;;      | 1|------>| 2|------>| 3|------> ... | 6|------>| 7|------>| 8| #f |
+      ;;;      +--+--+    +--+--+    +--+--+         +--+--+    +--+--+    +--+----+
       ;;;       ^^
       ;;;       yx
       ;;;
       ;;;  after
-      ;;;      +--+--+    +--+--+         +--+--+    +--+--+    +--+--+    +--+--+
-      ;;;      | 4|------>| 5|------> ... | 8|------>| 1|------>| 2|------>| 3|#f|
-      ;;;      +--+--+    +--+--+         +--+--+    +--+--+    +--+--+    +--+--+
+      ;;;      +--+--+    +--+--+         +--+--+    +--+--+    +--+--+    +--+----+
+      ;;;      | 4|------>| 5|------> ... | 8|------>| 1|------>| 2|------>| 3| #f |
+      ;;;      +--+--+    +--+--+         +--+--+    +--+--+    +--+--+    +--+----+
       ;;;       ^                                     ^
       ;;;       x                                     y
       (let ([x (cons 1 (cons 2 (cons 3 (cons 4 (cons 5 (cons 6 (cons 7 (cons 8 '()))))))))])
@@ -5522,4 +5522,65 @@
    (if (fx= (optimize-level) 3)
        '(lambda (x) (#3%fx+ 2 (#3%fx+ 1 x)))
        '(lambda (x) (#2%fx+ 2 (#3%fx+ 1 x)))))
+  )
+
+(mat black-box
+  (begin
+    ;; detect whether `expt` work is done by counting allocation
+    (define-syntax does-the-work-at-run-time?
+      (syntax-rules ()
+        [(_ opt? e)
+         (equal?
+          opt?
+          (let ([SLOP 100])
+            (with-interrupts-disabled
+             (let ([before (bytes-allocated)])
+               e
+               (let ([after (bytes-allocated)])
+                 (> after (+ before SLOP)))))))]))
+    #t)
+
+  (does-the-work-at-run-time?
+   (or (not (enable-cp0))
+       (#%$suppress-primitive-inlining))
+   (let ([to-power 100])
+     (let loop ([i 1000])
+       (unless (zero? i)
+         ;; call to `expt` is likely optimized away entirely, since there's
+         ;; no effect and the result is unused:
+         (expt 2 to-power)
+         (loop (sub1 i))))))
+
+  (does-the-work-at-run-time?
+   (or (not (enable-cp0))
+       (#%$suppress-primitive-inlining))
+   (let ([to-power 100])
+     (let loop ([i 1000])
+       (unless (zero? i)
+         ;; likely optimized to just returning a folded constant, instead of
+         ;; calling `expt` each iteration:
+         (black-box (expt 2 to-power))
+         (loop (sub1 i))))))
+
+  (does-the-work-at-run-time?
+   (not (and (enable-cp0)
+             (not (#%$suppress-primitive-inlining))
+             (eqv? 3 (optimize-level))))
+   (let ([to-power (black-box 100)])
+     (let loop ([i 1000])
+       (unless (zero? i)
+         ;; in safe mode, likely calls `expt`, because `to-power` is not known
+         ;; to be a number, but likely optimized away with `(optimize-level 3)`:
+         (expt 2 to-power)
+         (loop (sub1 i))))))
+
+  (does-the-work-at-run-time?
+   #t
+   (let ([to-power (black-box 100)])
+   (let loop ([i 1000])
+     (unless (zero? i)
+       ;; arithmetic really performed every iteration, since `to-power` value
+       ;; is assumed unknown, and `expt` result is assumed to be used
+       (black-box (expt 2 to-power))
+       (loop (sub1 i))))))
   )

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -173,6 +173,19 @@ The new procedures \scheme{car-cas!} and \scheme{cdr-cas!}
 atomically update a pair, analogous to \scheme{box-cas!}
 on a box.
 
+\subsection{Black-box procedure (10.3.0)}
+
+The new procedure \scheme{black-box} simply returns its argument, but
+optimization passes make no assumptions about how \scheme{black-box}
+uses its argument, whether \scheme{black-box} has side effects,
+or what \scheme{black-box} returns beyond the fact that it is a
+single value.
+
+The intended use of \scheme{black-box} is for benchmarking and testing
+tasks that need to simulate an arbitrary consumption context for a
+computation, but without otherwise adding overhead to the computation
+by adding a non-inlined function call or other obfuscating work.
+
 \subsection{Command-line options \scheme{--version} and \scheme{--help} write to stdout
 (10.2.0)}
 

--- a/s/cpprim.ss
+++ b/s/cpprim.ss
@@ -1558,6 +1558,9 @@
            (%inline eq? ,e1 ,e2))])
     (define-inline 2 keep-live
       [(e) (%seq ,(%inline keep-live ,e) ,(%constant svoid))])
+    (define-inline 2 black-box
+      [(e) (bind #t (e)
+             (%seq ,(%inline keep-live ,e) ,e))])
     (let ()
       (define (zgo src sexpr e e1 e2 r6rs?)
         (build-simple-or

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -909,6 +909,7 @@
 (define-symbol-flags* ([libraries] [flags primitive proc]) ; variable parameters
   (abort-handler [sig [() -> (procedure)] [(procedure) -> (void)]] [flags])
   (base-exception-handler [sig [() -> (procedure)] [(procedure) -> (void)]] [flags])
+  (black-box [sig [(ptr) -> (ptr)]] [flags])
   (break-handler [sig [() -> (procedure)] [(procedure) -> (void)]] [flags])
   (case-sensitive [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
   (cd [sig [() -> (pathname)] [(pathname) -> (void)]] [flags])

--- a/s/prims.ss
+++ b/s/prims.ss
@@ -2872,6 +2872,10 @@
   (lambda (x)
     (#2%keep-live x)))
 
+(define black-box
+  (lambda (x)
+    (#2%black-box x)))
+
 (when-feature windows
 (let ()
   (define mbtwc


### PR DESCRIPTION
The `black-box` function takes one argument and returns it, but optimization knows only that `black-box` returns a single value. This makes `black-box` useful for some testing and benchmarking tasks.