### PR TITLE
Only check the label, not the label/pl, for duplicate imports

### DIFF
--- a/s/syntax.ss
+++ b/s/syntax.ss
@@ -3039,7 +3039,8 @@
                 (symbol-hashtable-set! ht sym (cons (make-entry marks label) orig-entry*))
                 (let ([entry (car entry*)])
                   (if (same-marks? (entry-marks entry) marks)
-                      (unless (eq? (entry-label entry) label)
+                      (unless (eq? (label/pl->label (entry-label entry))
+                                   label)
                         (defn-table-dup*-set! tbl (cons sym (defn-table-dup* tbl))))
                       (f (cdr entry*))))))))))
   (define record-only!


### PR DESCRIPTION
Fixes #929.

I am not yet certain that this patch is complete. At the very least, this demonstrates that the behaviour of importing identifier properties appears to work as expected:

<details>

```scheme
(library (foo)
  (export floop floop-val)
  (import (chezscheme))
  (define floop)
  (define-syntax floop-val
    (lambda (stx)
      (lambda (lookup)
        (syntax-case stx ()
          ((_ id) #`'#,(lookup #'id #'floop))))))
  (define-property floop floop #t))

(library (bar)
  (export floop bart)
  (import (foo) (chezscheme))
  (define-syntax bart
    (lambda (stx)
      (lambda (lookup)
        (syntax-case stx ()
          ((_ id) #`'#,(lookup #'id #'bart))))))
  (define-property floop bart 12))

(library (baz)
  (export barted flooped)
  (import (foo) (bar) (chezscheme))
  (define barted (bart floop))
  (define flooped (floop-val floop)))

(library (baz2)
  (export barted flooped)
  (import (foo) (only (bar) bart) (chezscheme))
  (define barted (bart floop))
  (define flooped (floop-val floop)))

(eval 'barted (environment '(baz)))   ;=> 12
(eval 'flooped (environment '(baz)))  ;=> #t

(eval 'barted (environment '(baz2)))  ;=> #f
(eval 'flooped (environment '(baz2))) ;=> #t
```

</details>

However, I am not sure if `label` can contain a `label/pl` as well as the `entry-label`. Moreover, the Right Thing is probably to still signal a duplicate if an imported identifier has a *conflicting* property definition, but this patch won’t do that. (Then again, this matches the behaviour that it also won’t stop you defining the same property multiple times in a body.)

It may also be that there is a better place to fix this.

There should likely also be a test for this; the above example could serve as a basis.

I would appreciate feedback from those familiar with the innards of `syntax.ss`.