### PR TITLE
pb foreign-function interface: refine `union` handling for s390x

### DIFF
--- a/c/ffi.c
+++ b/c/ffi.c
@@ -145,6 +145,12 @@ ffi_type *decode_type(alloc_state *alloc, ptr type, ffi_abi abi, IBOOL *all_floa
         type = Scdr(type);
       }
 
+# ifdef __s390x__
+      /* s390x: unions containing only floats are not treated the
+         same as structs containing only floats */
+      union_all_float = 0;
+# endif
+
       if (!union_all_float)
         *all_float = 0;
 


### PR DESCRIPTION
With pb, foreign calls in general use libffi, which does not provide support for `union` arguments and results. The binding in "c/ffi.c" approximates `union` handling by constructing a `struct` description that is likely to be treated the same in the platform's ABI. The approximation was wrong for s390x in the case of `union`s that contain only floating-point fields, so add a special case for s390x. There are surely other platforms that would need similar treatment, but s390x is relevant because there's no native-code backend for that architecture.

Related to #956