### PR TITLE
repair argument-count error for `list*`

### DIFF
--- a/mats/patch-compile-0-t-f-f
+++ b/mats/patch-compile-0-t-f-f
@@ -192,8 +192,8 @@
   5_2.mo:Expected error in mat c....r-errors: "cddadr: incorrect list structure (a . b)".
   5_2.mo:Expected error in mat c....r-errors: "cdddar: incorrect list structure (a . b)".
   5_2.mo:Expected error in mat c....r-errors: "cddddr: incorrect list structure (a . b)".
-! 5_2.mo:Expected error in mat list*: "incorrect number of arguments -1 to #<procedure list*>".
-! 5_2.mo:Expected error in mat cons*: "incorrect number of arguments -1 to #<procedure cons*>".
+! 5_2.mo:Expected error in mat list*: "incorrect number of arguments 0 to #<procedure list*>".
+! 5_2.mo:Expected error in mat cons*: "incorrect number of arguments 0 to #<procedure cons*>".
   5_2.mo:Expected error in mat list-ref: "list-ref: index 0 reaches a non-pair in a".
   5_2.mo:Expected error in mat list-ref: "list-ref: index 4 reaches a non-pair in (a b . c)".
   5_2.mo:Expected error in mat list-ref: "list-ref: index 4 is out of range for list (a b)".

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2897,6 +2897,12 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Corrections and refinements to error reporting (10.4.0)}
+
+Repaired the error message for applying \scheme{list*} or
+\scheme{cons*} to zero arguments so that it reports \scheme{0} instead
+of \scheme{-1} as the argument count.
+
 \subsection{Exit with failure on error from boot file (10.3.0)}
 
 When an error is encountered within a boot file---either raised

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -5705,7 +5705,9 @@
                          (jump ,%ref-ret (,%ac0)))
                        ; TODO: would be nice to avoid second cmpl here
                        (if ,(%inline < ,%ac0 (immediate 0))
-                           (seq (pariah) (goto ,Ldoargerr))
+                           ,(%seq (pariah)
+                                  (set! ,%ac0 (immediate 0)) ; restore supplied argument count
+                                  (goto ,Ldoargerr))
                            ,(%seq
                               (set! ,%ac0 ,(%inline sll ,%ac0 ,(%constant pair-shift)))
                               (set! ,%xp (alloc ,(make-info-alloc (constant type-pair) #f #f) ,%ac0))


### PR DESCRIPTION
When `list*` is applied to zero arguments (and the call is not converted due to `(enable-error-source-expression)` as true), the error message incorrectly claimed -1 arguments. That's because the error dispatch in `list*` was written before error reporting was changed to expect the original argument count still in ac0.