### PR TITLE
trigger interrupts after long vector operations

### DIFF
--- a/mats/4.ms
+++ b/mats/4.ms
@@ -4181,6 +4181,133 @@
       (eqv?
         (test6B/counter 125 (lambda () (spin n)))
         n)))
+
+  ;; check that some operations that end up calling `memmove`/`memcpy`
+  ;; use a suitable amount of fuel
+  (begin
+    (define (check-uses-fuel make copy!)
+      (and (eq? (let ([vec (make 1024)])
+                  ((make-engine (lambda ()
+                                  (copy! vec 512)
+                                  'done))
+                   4096
+                   (lambda (fuel v) v)
+                   (lambda (e) 'not-done)))
+                'done)
+           (eq? (let ([vec (make 8192)])
+                  ((make-engine (lambda ()
+                                  (copy! vec 4096)
+                                  'done))
+                   128
+                   (lambda (fuel v) v)
+                   (lambda (e) 'not-done)))
+                'not-done)))
+    #t)
+  (check-uses-fuel make-bytevector
+                   (lambda (src amt)
+                     (bytevector-copy! src 0 src amt amt)))
+  (check-uses-fuel make-bytevector
+                   (lambda (src amt)
+                     (bytevector-copy src)))
+  (check-uses-fuel make-bytevector
+                   (lambda (src amt)
+                     (make-bytevector amt 0)))
+  (check-uses-fuel make-bytevector
+                   (lambda (src amt)
+                     (make-bytevector amt)))
+  (check-uses-fuel make-bytevector
+                   (lambda (src amt)
+                     (make-reference-bytevector amt)))
+  (check-uses-fuel make-bytevector
+                   (lambda (src amt)
+                     (make-immobile-reference-bytevector amt)))
+  (check-uses-fuel make-bytevector
+                   (lambda (src amt)
+                     (bytevector-fill! src 1)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (vector-copy! src 0 src amt amt)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (vector-copy src)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (vector-append src src)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (immutable-vector-append src src)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (vector-set/copy src 0 1)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (immutable-vector-set/copy src 0 1)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (make-vector amt 0)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (make-immobile-vector amt)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (make-immobile-vector amt 0)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (vector-fill! src 1)))
+  (check-uses-fuel make-flvector
+                   (lambda (src amt)
+                     (flvector-copy! src 0 src amt amt)))
+  (check-uses-fuel make-flvector
+                   (lambda (src amt)
+                     (flvector-copy src)))
+  (check-uses-fuel make-flvector
+                   (lambda (src amt)
+                     (make-flvector amt)))
+  (check-uses-fuel make-fxvector
+                   (lambda (src amt)
+                     (fxvector-copy! src 0 src amt amt)))
+  (check-uses-fuel make-fxvector
+                   (lambda (src amt)
+                     (fxvector-copy src)))
+  (check-uses-fuel make-fxvector
+                   (lambda (src amt)
+                     (make-fxvector amt)))
+  (check-uses-fuel make-string
+                   (lambda (src amt)
+                     (string-append src src)))
+  (check-uses-fuel make-string
+                   (lambda (src amt)
+                     (make-string amt)))
+  (check-uses-fuel make-string
+                   (lambda (src amt)
+                     (make-string amt #\x)))
+  (check-uses-fuel make-string
+                   (lambda (src amt)
+                     (string-fill! src #\x)))
+
+  ;; list operations are not obligated to use fuel in unsafe mode
+  (check-uses-fuel make-list
+                   (lambda (src amt)
+                     (#2%length src)))
+  (check-uses-fuel make-list
+                   (lambda (src amt)
+                     (#2%list-tail src amt)))
+  (check-uses-fuel make-list
+                   (lambda (src amt)
+                     (#2%list-ref src amt)))
+  (check-uses-fuel make-list
+                   (lambda (src amt)
+                     (#2%memq 'not-there src)))
+  (check-uses-fuel (lambda (n) (make-list n '(here)))
+                   (lambda (src amt)
+                     (#2%assq 'not-there src)))
+  (check-uses-fuel make-list
+                   (lambda (src amt)
+                     (#2%append src src)))
+  (check-uses-fuel make-list
+                   (lambda (src amt)
+                     (#2%reverse src)))
+
 )
 
 ;;; section 4-8:

--- a/mats/7.ms
+++ b/mats/7.ms
@@ -6195,8 +6195,8 @@ evaluating module init
    (>= (bytes-deallocated) 0)
    (let ([b (bytes-deallocated)] [c (collections)])
      (with-interrupts-disabled ; ensure allocated list stays in generation 0 until printed
-      (let ([x (make-list 10 'a)])
-        (pretty-print x))
+      (let ([x (make-list 10000 'a)])
+        (pretty-print (list-tail x 9990)))
       (collect))
      (and (> (collections) c) (or (eq? (current-eval) interpret)
                                   (> (bytes-deallocated) b))))

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -116,6 +116,25 @@ Online versions of both books can be found at
 %-----------------------------------------------------------------------------
 \section{Functionality Changes}\label{section:functionality}
 
+\subsection{Interrupts and Large-Vector Operations (10.4.0)}
+
+Vector and string operations such as \scheme{make-vector},
+\scheme{make-bytevector}, \scheme{make-string},
+\scheme{string-append}, and \scheme{vector-append}---whose run times
+depend on the length of the vector, bytevector, or string---were
+treated for the purposes of scheduling interrupt checking as
+essentially constant-time operations. As a result, garbage collections
+and timer expirations could be too infrequent. These operations still
+will not be interrupted during their execution, but they are treated
+as taking time proportional to their work for the purpose of
+scheduling interrupts.
+
+List operations such as \scheme{length}, \scheme{list-ref},
+\scheme{list-tail}, \scheme{append}, \scheme{reverse}, \scheme{assq},
+and \scheme{memq} suffer from the same problem only in unsafe mode.
+Direct use of these procedures in unsafe mode continues to be treated
+as essentialy constant-time.
+
 \subsection{Type recovery improvements (10.4.0)}
 
 The compiler now avoids moving predicates from tail position when they may raise an error,

--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -2117,6 +2117,8 @@
 (define-constant default-heap-reserve-ratio 1.0)
 (define-constant default-max-nonstatic-generation 4)
 
+(define-constant fuel-word-count-shift 2)
+
 (constant-case address-bits
   [(32)
    (constant-case segment-table-levels

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -2514,6 +2514,7 @@
   ($unknown-undefined-violation [flags abort-op])
   ($update-mark [flags pure discard unrestricted single-valued alloc])
   ($untrace [flags single-valued])
+  ($use-trap-fuel [flags single-valued])
   ($unwrap-ftype-pointer [flags single-valued])
   ($value [sig [(ptr) -> (ptr)]] [flags pure unrestricted discard cp02])
   ($vector-ref-check? [sig [(ptr ptr) -> (boolean)]] [flags unrestricted pure])


### PR DESCRIPTION
Here's a program that should not need too much memory at its peak. The program allocates a 4 MB string and the appends to it 1000 times, but each appended string is immediately discarded. Nevertheless, running the problem on a 64-bit platform before this PR will hit peak memory use of 1.5 GB or so:

```
(let ([s (make-string (expt 2 20))]) ; 4 MB
  (let loop ([i 1000])
    (unless (fx= i 0)
      (black-box (string-append s "x"))
      (loop (fx- i 1)))))
```

The problem is that the implementation of `string-append` performs each 4 MB allocation as an atomic-seeming kernel step, including a copy via `memcpy` — as opposed to a loop in Scheme where the trap register would be decremented every time around the loop. In other words, a large amount of work is done, but it is treated as effectively constant for the purposes of deciding when to fire interrupts, including GC interrupts. The `vector-append` operation does not use `memcpy`, but it uses a hand-code loop that (before this PR) similarly dis not adjust the trap register. Operations that don't allocate, such as `bytevector-fill!` won't create GC trouble, but infrequent timer-interrupt checking can interfere with using timers/engines for coroutines.

So, for operations that are atomic from the perspective of interrupts but that may work on large objects, such as `vector-append`, the change here adjusts the trap counter proportional to work done. That way, interrupts are dispatched in a more timely manner, especially GC interrupts.

(The change to "7.ms" is unrelated. Wrapping that test with its smaller list size in a loop could provoke a failure before these changes.)

There should be a runtime cost, but it is small. The `string-append` function turns out to sometimes run a little faster on small strings, but that's because because `memcpy` is now called via an `__atomic` foreign procedure. I've observed a slowdown as large as 10% for fast operations like `(#3%vector-set/copy '#(1) 0 1)` on x86_64, but the same example has 0% difference on AArch64, and generally the differences are in the noise.

Unsafe list operations like `#3%length` or `#3%memq` have the same issue, but since it's only the unsafe versions of those functions (safe versions of `length` and `memq` are normal Scheme code), and since those operations tend not to have an overall length straightforwardly available (except in the case of a `#3%length` result), there's no attempt to adjust those here.

Setting aside unsafe list operations, I'm not sure this commit covers all relevant operations. The "4.ms" changes show the ones that I found.