### PR TITLE
repair `hashtable-keys` and similar with weakly held keys

### DIFF
--- a/mats/4.ms
+++ b/mats/4.ms
@@ -4202,6 +4202,23 @@
                    (lambda (fuel v) v)
                    (lambda (e) 'not-done)))
                 'not-done)))
+    (define (fill-hashtable! ht n)
+      (let loop ([i 0])
+        (unless (= i n)
+          (hashtable-set! ht (gensym) i)
+          (loop (add1 i)))))
+    (define (make-filled-hashtable n)
+      (let ([ht (make-hashtable equal-hash equal?)])
+        (fill-hashtable! ht n)
+        ht))
+    (define (make-filled-symbol-hashtable n)
+      (let ([ht (make-hashtable symbol-hash symbol=?)])
+        (fill-hashtable! ht n)
+        ht))
+    (define (make-filled-eq-hashtable n)
+      (let ([ht (make-eq-hashtable)])
+        (fill-hashtable! ht n)
+        ht))
     #t)
   (check-uses-fuel make-bytevector
                    (lambda (src amt)
@@ -4233,6 +4250,12 @@
   (check-uses-fuel make-vector
                    (lambda (src amt)
                      (vector-append src src)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (vector-map (lambda (x) x) src)))
+  (check-uses-fuel make-vector
+                   (lambda (src amt)
+                     (vector-map (lambda (x y) x) src src)))
   (check-uses-fuel make-vector
                    (lambda (src amt)
                      (immutable-vector-append src src)))
@@ -4284,6 +4307,30 @@
   (check-uses-fuel make-string
                    (lambda (src amt)
                      (string-fill! src #\x)))
+  (check-uses-fuel make-filled-hashtable
+                   (lambda (src amt)
+                     (hashtable-copy src)))
+  (check-uses-fuel make-filled-symbol-hashtable
+                   (lambda (src amt)
+                     (hashtable-copy src)))
+  (check-uses-fuel make-filled-eq-hashtable
+                   (lambda (src amt)
+                     (hashtable-copy src)))
+  (check-uses-fuel make-filled-eq-hashtable
+                   (lambda (src amt)
+                     (hashtable-keys src)))
+  (check-uses-fuel make-filled-eq-hashtable
+                   (lambda (src amt)
+                     (hashtable-values src)))
+  (check-uses-fuel make-filled-eq-hashtable
+                   (lambda (src amt)
+                     (hashtable-entries src)))
+  (check-uses-fuel make-filled-eq-hashtable
+                   (lambda (src amt)
+                     (hashtable-cells src)))
+  (check-uses-fuel make-filled-eq-hashtable
+                   (lambda (src amt)
+                     (hashtable-clear! src)))
 
   ;; list operations are not obligated to use fuel in unsafe mode
   (check-uses-fuel make-list

--- a/mats/hash.ms
+++ b/mats/hash.ms
@@ -930,6 +930,24 @@
     (eq-hashtable-ephemeron? $ht 3))
   (error? ; not a hashtable
     (eq-hashtable-ephemeron? '(hash . table)))
+
+  ; make sure a trap interrupt does not break `hashtable-keys`
+  (let loop ([i 1000])
+    (cond
+      [(= i 0) #t]
+      [else
+       (let ([ht (make-weak-eq-hashtable)])
+         (let loop ([i 1000])
+           (unless (= i 0)
+             (hashtable-set! ht (gensym) i)
+             (loop (sub1 i))))
+         (let ([vec (hashtable-keys ht)])
+           (let loop ([i 0])
+             (unless (= i (vector-length vec))
+               (unless (symbol? (vector-ref vec i))
+                 (error 'keys "not a symbol: ~s" (vector-ref vec i)))
+               (loop (add1 i))))))
+       (loop (sub1 i))]))
 )
 
 (mat symbol-hashtable-arguments

--- a/s/library.ss
+++ b/s/library.ss
@@ -1701,7 +1701,7 @@
 
     (define adjust!
       (lambda (h vec1 n2)
-        (let ([vec2 (make-vector n2 '())]
+        (let ([vec2 ($make-vector/no-interrupt-trap n2 '())]
               [mask2 (fx- n2 1)])
           (vector-for-each
             (lambda (b)

--- a/s/newhash.ss
+++ b/s/newhash.ss
@@ -1296,10 +1296,12 @@ Documentation notes:
   (set! $eq-hashtable-keys
     (lambda (h max-sz)
       (let ([vec (ht-vec h)] [size (fxmin max-sz (ht-size h))])
-        (let ([n (vector-length vec)] [keys (make-vector size)])
+        (let ([n (vector-length vec)] [keys ($make-vector/no-interrupt-trap size)])
           (let outer ([i 0] [j 0])
             (if (or (fx= i n) (fx= j size))
-                keys
+                (begin
+                  ($use-trap-fuel size (constant fuel-word-count-shift))
+                  keys)
                 (let inner ([b (vector-ref vec i)] [j j])
                   (if (or (fixnum? b) (fx= j size))
                       (outer (fx+ i 1) j)
@@ -1310,10 +1312,12 @@ Documentation notes:
   (set! $eq-hashtable-values
     (lambda (h max-sz)
       (let ([vec (ht-vec h)] [size (fxmin max-sz (ht-size h))])
-        (let ([n (vector-length vec)] [vals (make-vector size)])
+        (let ([n (vector-length vec)] [vals ($make-vector/no-interrupt-trap size)])
           (let outer ([i 0] [j 0])
             (if (or (fx= i n) (fx= j size))
-                vals
+                (begin
+                  ($use-trap-fuel size (constant fuel-word-count-shift))
+                  vals)
                 (let inner ([b (vector-ref vec i)] [j j])
                   (if (or (fixnum? b) (fx= j size))
                       (outer (fx+ i 1) j)
@@ -1325,11 +1329,13 @@ Documentation notes:
     (lambda (h max-sz)
       (let ([vec (ht-vec h)] [size (fxmin max-sz (ht-size h))])
         (let ([n (vector-length vec)]
-              [keys (make-vector size)]
-              [vals (make-vector size)])
+              [keys ($make-vector/no-interrupt-trap size)]
+              [vals ($make-vector/no-interrupt-trap size)])
           (let outer ([i 0] [j 0])
             (if (or (fx= i n) (fx= j size))
-                (values keys vals)
+                (begin
+                  ($use-trap-fuel size (constant fuel-word-count-shift))
+                  (values keys vals))
                 (let inner ([b (vector-ref vec i)] [j j])
                   (if (or (fixnum? b) (fx= j size))
                       (outer (fx+ i 1) j)
@@ -1341,10 +1347,12 @@ Documentation notes:
   (set! $eq-hashtable-cells
     (lambda (h max-sz)
       (let ([vec (ht-vec h)] [size (fxmin max-sz (ht-size h))])
-        (let ([n (vector-length vec)] [cells (make-vector size)])
+        (let ([n (vector-length vec)] [cells ($make-vector/no-interrupt-trap size)])
           (let outer ([i 0] [j 0])
             (if (or (fx= i n) (fx= j size))
-                cells
+                (begin
+                  ($use-trap-fuel size (constant fuel-word-count-shift))
+                  cells)
                 (let inner ([b (vector-ref vec i)] [j j])
                   (if (or (fixnum? b) (fx= j size))
                       (outer (fx+ i 1) j)
@@ -1361,7 +1369,9 @@ Documentation notes:
                [h2 (make-eq-ht 'eq mutable? vec2 (ht-minlen h1) (ht-size h1) subtype)])
           (let outer ([i 0])
             (if (fx= i n)
-                h2
+                (begin
+                  ($use-trap-fuel n (constant fuel-word-count-shift))
+                  h2)
                 (begin
                   (vector-set! vec2 i
                     (let inner ([b (vector-ref vec1 i)])
@@ -1390,7 +1400,8 @@ Documentation notes:
                   (loop next)))))
         (ht-size-set! h 0)
         (unless (fx= n minlen)
-          (ht-vec-set! h ($make-eqhash-vector minlen))))))
+          (ht-vec-set! h ($make-eqhash-vector minlen)))
+        ($use-trap-fuel n (constant fuel-word-count-shift)))))
   
   (let ()
     ;; An equal/hash mapping contains an equal or hash procedure (or #f)

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -2332,6 +2332,7 @@
   ($make-textual-output-port [sig [(string port-handler string) (string port-handler string ptr) -> (textual-output-port)]] [flags alloc])
   ($make-tlc [flags single-valued alloc])
   ($make-uninitialized-string [sig [(length) -> (string)]] [flags alloc])
+  ($make-vector/no-interrupt-trap [flags single-valued])
   ($make-vtable [flags single-valued])
   ($make-wrapper-procedure [flags single-valued])
   ($map [flags single-valued])

--- a/s/prims.ss
+++ b/s/prims.ss
@@ -401,6 +401,17 @@
          ($oops who "~s is not a valid vector length" n))
        (make-vector n)]))
 
+(define-who $make-vector/no-interrupt-trap
+   (case-lambda
+      [(n x)
+       (unless (and (fixnum? n) (not ($fxu< (constant maximum-vector-length) n)))
+         ($oops who "~s is not a valid vector length" n))
+       ($make-vector/no-interrupt-trap n x)]
+      [(n)
+       (unless (and (fixnum? n) (not ($fxu< (constant maximum-vector-length) n)))
+         ($oops who "~s is not a valid vector length" n))
+       ($make-vector/no-interrupt-trap n)]))
+
 (define-who make-immobile-vector
   (let ([$make-immobile-vector (foreign-procedure "(cs)make_immobile_vector" (uptr ptr) ptr)])
    (case-lambda


### PR DESCRIPTION
This commit repairs a problem created by the previous commit (#994), and it further repairs some hashtable operations alog the same lines as vector operations in that commit.

> The problem was exposed by Racket's test suite, eventually. Unfortunately, I was unlucky and didn't see a failure all the times I tested #994 before merging. Since that change broke Racket, I've taken the rare step of merging the first cut at this PR to Racket while it's pending here.

The implementation of `eq?`-based hashtables turns off interrupts, but the parameter setting had no effect on the checks now inserted for `make-vector`. An interrupt can go wrong with operations like `hashtable-keys` with weekly held keys, because keys could disappear before being transferred to a newly allocated vector.

The solution of not inserting an interrupt trap in `make-vector` when `generate-interrupt-trap` is `#f` seems like the obvious approach, but that interacts badly with wrappers for `make-vector` and similar as defined in "prims.ss". Instead, this commit adds a new procedure `$make-vector/no-interrupt-trap`. In general, functions that need to avoid interrupts must choose the functions they call carefully, anyway, and `make-vector` has become one that cannot be called.

The repaired operations `$eq-hashtable-keys`, etc., now use `$make-vector/no-interrupt-trap`, but they also use `$use-trap-fuel` after the result is created. The `$eq-hashtable-copy` and `$eq-hashtable-clear` operations similarly need `$use-trap-fuel`, and they previously did not use `make-vector` or another operation that would have inserted interrupt checks.