### PR TITLE
add __collect_errno foreign-procedure convention for reliable errno c…

### DIFF
--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -1657,6 +1657,7 @@
    [uptr pb-regs (constant pb-reg-count)] ; "pb.c" assumes that `pb-regs` through `pb-call-arena` are together
    [double pb-fpregs (constant pb-fpreg-count)]
    [uptr pb-call-arena (constant pb-call-arena-size)]
+   [iptr saved-errno] ; errno captured from __collect_errno foreign calls
    [xptr gc-data]))
 
 (define tc-field-list
@@ -3166,7 +3167,8 @@
      flsqrt
      null-immutable-vector
      null-immutable-bytevector
-     null-immutable-string))
+     null-immutable-string
+     errno-location))
 )
 
 

--- a/s/cpprim.ss
+++ b/s/cpprim.ss
@@ -3596,6 +3596,12 @@
       (define-tc-parameter default-record-hash-procedure default-record-hash-procedure)
       )
 
+    ; $saved-errno: read errno captured by __collect_errno foreign calls
+    (define-inline 2 $saved-errno
+      [() (%tc-ref saved-errno)])
+    (define-inline 3 $saved-errno
+      [() (%tc-ref saved-errno)])
+
     (let ()
       (define (make-wrapper-closure-alloc e-proc e-arity-mask e-data libspec)
         (bind #t ([c (%constant-alloc type-closure (fx* (if e-data 4 3) (constant ptr-bytes)))])

--- a/s/cprep.ss
+++ b/s/cprep.ss
@@ -92,6 +92,7 @@
                       [(i3nt-stdcall) '__stdcall]
                       [(i3nt-com) '__com]
                       [(adjust-active) '__collect_safe]
+                      [(collect-errno) '__collect_errno]
                       [(varargs) '__varargs]
                       [else #f]))
                   x*)))

--- a/s/loongarch64.ss
+++ b/s/loongarch64.ss
@@ -2233,7 +2233,8 @@
                                                            (not pass-result-ptr?))
                                                       (cdr arg-type*)
                                                       arg-type*)]
-                                       [adjust-active? (if-feature pthreads (memq 'adjust-active conv*) #f)])
+                                       [adjust-active? (if-feature pthreads (memq 'adjust-active conv*) #f)]
+                                       [collect-errno? (memq 'collect-errno conv*)])
                                   (with-values (do-args arg-type* (extract-varargs-after-conv conv*))
                                     (lambda (locs live* frame-size)
                                       (returnem (if (and ftd-result?
@@ -2250,17 +2251,36 @@
                                                   (let* ([cat (categorize-result result-type)]
                                                          [result-reg* (if pass-result-ptr?
                                                                           '()
-                                                                          (cat-regs cat))])
-                                                    (add-fill-result
-                                                     ;;@ foreign-procedure always generates the first arg which points to
-                                                     ;;@ the place where the retval is to be stored. But since this ftd is
-                                                     ;;@ less than 16 bytes, there's no need to actually pass it to C functions,
-                                                     ;;@ so don't use that. BUT, we still have to store the retval in regs into
-                                                     ;;@ the place pointed to by the pointer.
-                                                     (and ftd-result? (not pass-result-ptr?)) cat frame-size
-                                                     (add-deactivate adjust-active? t0 live* result-reg*
-                                                                     (lambda (t0)
-                                                                       `(inline ,(make-info-kill*-live* (add-caller-save-registers result-reg*) live*) ,%c-call ,t0))))))
+                                                                          (cat-regs cat))]
+                                                         [base-call
+                                                          (add-fill-result
+                                                           ;;@ foreign-procedure always generates the first arg which points to
+                                                           ;;@ the place where the retval is to be stored. But since this ftd is
+                                                           ;;@ less than 16 bytes, there's no need to actually pass it to C functions,
+                                                           ;;@ so don't use that. BUT, we still have to store the retval in regs into
+                                                           ;;@ the place pointed to by the pointer.
+                                                           (and ftd-result? (not pass-result-ptr?)) cat frame-size
+                                                           (add-deactivate adjust-active? t0 live* result-reg*
+                                                                           (lambda (t0)
+                                                                             `(inline ,(make-info-kill*-live* (add-caller-save-registers result-reg*) live*) ,%c-call ,t0))))])
+                                                    (if collect-errno?
+                                                        ;; Add errno capture after the C call
+                                                        (%seq
+                                                         ,base-call
+                                                         ;; Save return value on stack
+                                                         (set! ,%sp ,(%inline - ,%sp (immediate 16)))
+                                                         (set! ,(%mref ,%sp 0) ,%Cretval)
+                                                         ;; Call errno-location (returns int*)
+                                                         (inline ,(make-info-kill*-live* (list %Cretval %Carg2 %Carg3 %Carg4 %Carg5 %Carg6 %Carg7 %Carg8 %ra) '())
+                                                                 ,%c-call ,(lookup-c-entry errno-location))
+                                                         ;; Load errno value (32-bit signed int) from returned pointer
+                                                         (set! ,%Cretval (inline ,(make-info-load 'integer-32 #f) ,%load ,%Cretval ,%zero (immediate 0)))
+                                                         ;; Store in tc->saved-errno
+                                                         (set! ,(%tc-ref saved-errno) ,%Cretval)
+                                                         ;; Restore original return value from stack
+                                                         (set! ,%Cretval ,(%mref ,%sp 0))
+                                                         (set! ,%sp ,(%inline + ,%sp (immediate 16))))
+                                                        base-call)))
                                                 (nanopass-case (Ltype Type) result-type
                                                                ;;@ TODO check the two
                                                                [(fp-double-float)

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1994,6 +1994,7 @@
   ($eq-hashtable-values [flags true discard])
   ($errno [flags single-valued])
   ($errno->string [flags single-valued])
+  ($saved-errno [sig [() -> (fixnum)] flags single-valued])
   ($error-handling-mode? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable])
   ($event [flags single-valued])
   ($event-and-resume [flags])


### PR DESCRIPTION
…apture

This adds a new `__collect_errno` convention for foreign procedures that captures errno atomically immediately after the C call, before any potential GC or interrupt handling can corrupt it.

Usage:
  (define my-open
    (foreign-procedure __collect_errno "open" (string int int) int))

  (let-values ([(fd err) (my-open "/path" O_RDONLY 0)])
    (if (= fd -1)
        (error 'my-open ($errno->string err))
        fd))

Implementation:
- Added `saved-errno` field to thread context (cmacros.ss)
- Added `__collect_errno` convention recognition (syntax.ss)
- Added `$saved-errno` primitive to read captured errno (cpprim.ss, primdata.ss)
- Modified wrapper generation to return (values result errno) (syntax.ss)
- Added `errno-location` C entry for platform-specific errno access (prim5.c)
- Implemented errno capture in all architecture backends: x86_64, arm64, arm32, riscv64, loongarch64, ppc32, x86, pb

The convention is mutually exclusive with __collect_safe as errno capture requires atomic-like behavior to prevent GC from corrupting errno.