### PR TITLE
add allow-interleaved-definitions parameter

### DIFF
--- a/mats/3.ms
+++ b/mats/3.ms
@@ -922,6 +922,77 @@
     (error? (if (define x 3) x x))
  )
 
+(mat interleaved-definitions
+  ; parameter defaults to #f
+  (not (allow-interleaved-definitions))
+
+  ; basic interleaved definition test
+  (begin (allow-interleaved-definitions #t) (allow-interleaved-definitions))
+
+  (eqv?
+    (let ()
+      (define x 1)
+      (set! x (+ x 1))  ; expression between definitions
+      (define y x)
+      (+ x y))
+    4)
+
+  ; multiple expressions between definitions
+  (equal?
+    (let ()
+      (define a 10)
+      (set! a (+ a 1))
+      (define b a)
+      (set! b (+ b 1))
+      (define c b)
+      (list a b c))
+    '(11 12 12))
+
+  ; works with lambda
+  (eqv?
+    ((lambda ()
+       (define x 5)
+       (set! x (* x 2))
+       (define y x)
+       y))
+    10)
+
+  ; ensure proper sequencing (letrec* semantics)
+  (equal?
+    (let ()
+      (define x 1)
+      (set! x (+ x 1))  ; x = 2
+      (define y x)      ; y = 2
+      (set! y (+ y 1))  ; y = 3
+      (define z y)      ; z = 3
+      (list x y z))
+    '(2 3 3))
+
+  ; body ending with definition (no trailing expression)
+  (eqv?
+    (let ()
+      (define x 1)
+      (set! x (+ x 1))
+      (define y x))
+    (void))
+
+  ; expressions using defined values
+  (equal?
+    (let ()
+      (define x 1)
+      (define y 2)
+      (list x y)
+      (define z (+ x y))
+      z)
+    3)
+
+  ; restore default
+  (begin (allow-interleaved-definitions #f) #t)
+
+  ; verify still errors when disabled
+  (error? (let () 0 (define x 3) x))
+)
+
 (mat define-values
   (begin (define-values ($dv-x $dv-y) (values 'a 'b)) #t)
   (eq? $dv-x 'a)

--- a/s/back.ss
+++ b/s/back.ss
@@ -224,6 +224,9 @@
 (define internal-defines-as-letrec*
   ($make-thread-parameter #t (lambda (x) (and x #t))))
 
+(define allow-interleaved-definitions
+  ($make-thread-parameter #f (lambda (x) (and x #t))))
+
 (define self-evaluating-vectors
   ($make-thread-parameter #f (lambda (x) (and x #t))))
 

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -908,6 +908,7 @@
 
 (define-symbol-flags* ([libraries] [flags primitive proc]) ; variable parameters
   (abort-handler [sig [() -> (procedure)] [(procedure) -> (void)]] [flags])
+  (allow-interleaved-definitions [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
   (base-exception-handler [sig [() -> (procedure)] [(procedure) -> (void)]] [flags])
   (black-box [sig [(ptr) -> (ptr)]] [flags])
   (break-handler [sig [() -> (procedure)] [(procedure) -> (void)]] [flags])


### PR DESCRIPTION
When enabled, allows definitions to be interleaved with expressions in internal bodies (lambda, let, letrec, etc.). Interleaved expressions become dummy bindings that evaluate for effect and return (void), enabling sequential processing with letrec* semantics.

Disabled by default to preserve standard R6RS behavior.