### PR TITLE
Fix type of (- x)

### DIFF
--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -1251,6 +1251,9 @@
   (not (cptypes-equivalent-expansion? ; integer? is not closed
          '(lambda (x y) (when (and (integer? x) (integer? y)) (integer? (- x y))))
          '(lambda (x y) (when (and (integer? x) (integer? y)) (- x y) #t))))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x y) (when (fixnum? x) (fixnum? (- x))))
+         '(lambda (x y) (when (fixnum? x) #t))))
   (cptypes-equivalent-expansion?
     '(lambda (x y) (when (and (fixnum? x) (fixnum? y))
                      (- x y)))

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -143,6 +143,8 @@ even if the result is known in case of a success.
 The type recovery pass has improved support for \scheme{exact}, \scheme{inexact},
 and similar functions.
 
+A bug that incorrectly determined the type of \scheme{(- x)} has been fixed.
+
 \subsection{In-place vector copying (10.3.0)}
 
 The \scheme{vector-copy!} procedure copies a subsequence

--- a/s/cptypes.ss
+++ b/s/cptypes.ss
@@ -1284,7 +1284,10 @@ Notes:
 
       (define-specialize 2 -
         [(x) (values `(call ,preinfo ,pr ,x)
-                     (predicate-intersect (get-type x) number-pred) ntypes #f #f)]
+                     (predicate-close/plus (list `(quote 0)
+                                                 (predicate-intersect (get-type x) number-pred))
+                                           pr)
+                     ntypes #f #f)]
         [x* ; x* has at least 2 arguments
             (let* ([r* (get-type x*)]
                    [ret (predicate-close/plus


### PR DESCRIPTION
cptypes was just copying the type from `x` to `(- x)`. Use `predicate-close/plus` to get a closed set that includes the result.

Is it possible to try to get a more precise type for the result, like in the `(+ x)` case, but I think it's better to fix the bug now and improve the code later.

Thanks to @wtakuo for the [bug report in Racket #5408](https://github.com/racket/racket/issues/5408) and @mflatt for minimizing it to code in Chez Scheme. 