### PR TITLE
Avoid incorrect tranformation in + and - in cptypes

### DIFF
--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -1236,6 +1236,21 @@
                    (+ -0.0 x)))
     '(lambda (x) (when (bignum? x)
                    (#3%fl+ -0.0 (real->flonum x)))))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x y) (when (and (flonum? x) (real? y))
+                          (+ x y)))
+         '(lambda (x y) (when (and (flonum? x) (real? y))
+                          (#3%fl+ x (real->flonum y))))))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x y) (when (and (flonum? x) (real? y))
+                          (+ x y)))
+         '(lambda (x y) (when (and (flonum? x) (real? y))
+                          (#3%fl+ x (if (#3%eqv? y 0) -0.0 (real->flonum y)))))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (flonum? x)
+                   (+ x 1/2)))
+    '(lambda (x) (when (flonum? x)
+                   (#3%fl+ x 0.5))))
   (cptypes-equivalent-expansion?
     '(lambda (x) (when (flonum? x)
                    (+ 1.0 x)))
@@ -1410,6 +1425,16 @@
                    (- x 1.0)))
     '(lambda (x) (when (number? x)
                    (#3%- x 1.0))))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x y) (when (and (flonum? x) (real? y))
+                          (- x y)))
+         '(lambda (x y) (when (and (flonum? x) (real? y))
+                          (#3%fl- x (real->flonum y))))))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x y) (when (and (flonum? x) (real? y))
+                          (- x y)))
+         '(lambda (x y) (when (and (flonum? x) (real? y))
+                          (#3%fl- x (if (#3%eqv? y 0) -0.0 (real->flonum y)))))))
   (cptypes-equivalent-expansion?
     '(lambda (x) (when (fixnum? x)
                    (- 1 x x)))

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -160,6 +160,10 @@ and \scheme{real-valued?}.
 
 A bug that incorrectly determined the type of \scheme{(- x)} has been fixed.
 
+The compiler avoids transforming an expression like \scheme{(+ -inf.0 x)}, where
+\scheme{x} is known to be real, into \scheme{(fl+ -inf.0 (real->flonum x))}
+in case \scheme{x} is a bignum that would be converted into \scheme{+inf.0}.
+
 \subsection{In-place vector copying (10.3.0)}
 
 The \scheme{vector-copy!} procedure copies a subsequence


### PR DESCRIPTION
In expressions like `(+ -inf.0 x)`, where `x` is known to be real, it's not possible to transform it into `(fl+ -inf.0 (real->flonum x))` in case x is a bignum that is transformed into `+inf.0`.

The problem with this incorrect transformation the result is`+nan.0` instead of `-inf.0`. So I added more restrictions to check before this transformation is applied.

---

Backstory: I was brute-force-testing `div`, `mod`, and a few more similar primitives, with combinations of two numbers from a long list of interesting tricky numbers. Then I decided to add `+` and `-` to the list of primitives to test. I found that

    (+ -inf.0 #e1e1000)

had a different result when `cptypes` was applied before `cp0`.

    ((eval '(lambda () (+ -inf.0 #e1e1000))))  ;==> -inf.0

    ((eval (parameterize ([run-cp0 (lambda (cp0 x)
                                      (cp0 (#3%$cptypes x)))])
                         (expand/optimize '(lambda () (+ -inf.0 #e1e1000))))))  ;==> +nan.0
