### PR TITLE
Use no-return in cptypes

### DIFF
--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -2482,3 +2482,19 @@
         '(lambda (x y) (fxdiv-and-mod x y) (zero? x))
         '(lambda (x y) (fxdiv-and-mod x y) #f)))
 )
+
+(mat cptypes-no-return
+  ; Ensure that cptypes and cp0 cooperate using no-return.
+  ; In particular, this is like a `begin0` form
+  ; where cptypes detects one of the branches will fail
+  ; and then cp0 can detect the first lambda is single-valued
+  ; so it can reduce the `begin0` to a `let`.
+  (cptypes-equivalent-expansion?
+    '(lambda (t m)
+       (call-with-values
+         (lambda () (if t (random) (div-and-mod "2" m)))
+         (lambda (x) (list x x x))))
+    '(lambda (t m)
+       (let ([x (if t (random) (div-and-mod "2" m))])
+         (list x x x))))
+)

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -151,7 +151,8 @@ as essentialy constant-time.
 \subsection{Type recovery improvements (10.4.0)}
 
 The compiler now avoids moving predicates from tail position when they may raise an error,
-even if the result is known in case of a success.
+even if the result is known in case of a success; and it records must-error information
+that is inferred by type recovery so that it can be used by other optimization passes.
 
 The type recovery pass has improved support for \scheme{exact}, \scheme{inexact},
 and similar functions; improved support for \scheme{quotient},

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -1887,7 +1887,7 @@
   ($allocate-thread-parameter [feature pthreads] [flags single-valued alloc])
   ($app [flags])
   ($app/no-inline [flags])
-  ($app/no-return [flags])
+  ($app/no-return [sig [(procedure ptr ...) -> (bottom)]] [flags abort-op])
   ($app/value [flags])
   ($apply [sig [(procedure exact-integer list) -> (ptr ...)]] [flags cptypes2x])
   ($assembly-output [flags single-valued])


### PR DESCRIPTION
There are a few things that I don't understand, so this is more a long question with a proof of concept than a finished PR.

---

When `cptypes` detects an error that is not obvious, use `$app/no-return` so the other passes can notice it. But `cp0` transform `$app/no-return` to special flags in `preinfo`, so let's add the flags directly instead.

After this change, in the second leap `cp0` can notice that `cptypes` detected an error and apply more reductions. See the example at the bottom of cptypes.ms  Also, there is an old example in `cp0.ms` that has type problems on purpose, and is broken with an explicit use of `$app/no-return`.

I'm worry that this is wrong for some primitives that write/read the continuation attachment. Is there an obvious example? Is there a not obvious example?

Is it wrong with `lambdas` instead of primitives? I'm almost sure it is, but I'd like to see an example to be sure what to care about . (Anyway, probably `lambdas` will be left for a PR in  the future.)

---   

If this make sense and is (almost) correct, I'd like to take a look if the same change can be applied in more parts of `cptypes`, and do some refactor and cleanup. 