### PR TITLE
repair pbchunk for skipped foreign calls

### DIFF
--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -3019,6 +3019,13 @@ too aggressively when partially folding \scheme{+}. In expressions such as
 discard non-real contributions. The fold now uses a complex-NaN predicate for
 the generic \scheme{+} case so non-real contributions are preserved.
 
+\subsection{Fix interaction of pbchunk and atomic foreign procedures (10.4.0)}
+
+The output of \scheme{pbchunk-convert-file} could be incorrect in the
+case of an inlined foreign call within certain blocks. The generated
+source was ill-formed in the case of a block that has too many entries
+and exits around unconvertible code to productively compile via C.
+
 \subsection{Exit with failure on error from boot file (10.3.0)}
 
 When an error is encountered within a boot file---either raised

--- a/s/pbchunk.ss
+++ b/s/pbchunk.ss
@@ -919,7 +919,7 @@
            (next))
 
          (define (call-form _op)
-           (emit-foreign-call o instr)
+           (emit-foreign-call o instr emit-pre emit-post)
            (next))
 
          (define-syntax (emit stx)
@@ -1081,12 +1081,13 @@
 
          (instruction-cases instr emit))])))
 
-(define (emit-foreign-call o instr)
+(define (emit-foreign-call o instr emit-pre emit-post)
   (let* ([proto-index (instr-dri-imm instr)]
          [proto (ormap (lambda (p) (and (eqv? (cdr p) proto-index) (car p)))
                        (constant pb-prototype-table))])
     (unless proto ($oops 'pbchunk "could not find foreign-call prototype"))
-    (emit-c o "  ")
+    (emit-pre)
+    (emit-c o " ")
     (case (car proto)
       [(void) (void)]
       [(double) (emit-c o "fpregs[Cfpretval] = ")]
@@ -1124,7 +1125,9 @@
     (case (car proto)
       [(void*) (emit-c o ")")] ; close `TO_PTR`
       [else (void)])
-    (emit-c o "); /* pb_call ~a */\n" proto-index)))
+    (emit-c o ");")
+    (emit-post)
+    (emit-c o " /* pb_call ~a */\n" proto-index)))
 
 (define (extract-name name)
   (fasl-case* name


### PR DESCRIPTION
Changes to use `__atomic` increased inlining of function calls, which exposed a problem with pbchunk when a foreign call is inlined within a function that has too many entries and exits to productively compile via C.