### PR TITLE
repair foreign-procedure use of `S_big_first_bit_set`

### DIFF
--- a/s/5_3.ss
+++ b/s/5_3.ss
@@ -3111,7 +3111,7 @@
 (set-who! bitwise-first-bit-set
   (let ()
     (define $big-first-bit-set
-      (foreign-procedure __atomic "(cs)s_big_first_bit_set" (ptr) ptr))
+      (foreign-procedure __atomic __alloc "(cs)s_big_first_bit_set" (ptr) ptr))
     (lambda (n)
       (cond
         [(fixnum? n) (fxfirst-bit-set n)]


### PR DESCRIPTION
Add `__alloc`, needed for 32-bit platforms (as noted by @samth in the discussion of #1013) for

```
(bitwise-first-bit-set
 (bitwise-arithmetic-shift-left 1 (+ 1 (most-positive-fixnum))))
```

Due to the way `S_bignum` allocates in the "typed object" space, there doesn't appear to be a way for the call to go wrong without `__alloc`, but the intent is that `__alloc` is needed (and a future change could make it actually needed).