### PR TITLE
fix bytevector-ieee-double-native-set! error

### DIFF
--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -3012,6 +3012,9 @@ When \scheme{>} and \scheme{>=} are applied to two non-real arguments, the first
 is now reported as incorrect instead of the second. In general, when two or more arguments
 are invalid, there is no guarantee about which one is reported invalid.
 
+A bug in the error produced by \scheme{bytevector-ieee-double-native-set!}---when the last
+argument raises and error and the offset is out of bounds---has been fixed.
+
 \subsection{Fix \scheme{remainder} and \scheme{modulo} for inexact/exact mixtures (10.4.0)}
 
 When \scheme{remainder} and \scheme{modulo} receive an inexact first

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2993,7 +2993,10 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
-\subsection{Error message fixes (10.4.1)}
+\subsection{Error message fixes (10.5.0)}
+
+A bug in the error produced by \scheme{bytevector-ieee-double-native-set!}---when the last
+argument raises and error and the offset is out of bounds---has been fixed.
 
 When \scheme{log} is called with exact \scheme{1} as the second argument, the error is now
 reported in terms of \scheme{log} instead of a divide-by-zero error in \scheme{/}.

--- a/s/cpprim.ss
+++ b/s/cpprim.ss
@@ -368,7 +368,12 @@
             (let-values ([(type e)
                           (nanopass-case (L7 Expr) e
                             [(raw ,e) (values 'uptr e)]
-                            [else (values type e)])])
+                            [else (cond
+                                    [(eq? type 'try-fp)
+                                     (if (known-flonum-result? e)
+                                         (values 'fp e)
+                                         (values 'uptr e))]
+                                    [else (values type e)])])])
               (let ([t (make-tmp 't type)])
                 (values t (lift-fp-unboxed
                            (lambda (body)
@@ -7211,11 +7216,11 @@
         (define-inline 2 bytevector-ieee-double-native-set!
           [(e-bv e-offset e-val)
            (bind #t (e-bv e-offset)
-             (let ([info (make-info-call #f #f #f #f #f)])
-               `(if (call ,info ,#f ,(lookup-primref 3 '$bytevector-set!-check?) (quote 64) ,e-bv ,e-offset)
-                    ;; checks to make sure e-val produces a real number:
-                    (call ,info ,#f ,(lookup-primref 3 'bytevector-ieee-double-native-set!) ,e-bv ,e-offset ,e-val)
-                    ,(build-libcall #t src sexpr bytevector-ieee-double-native-set! e-bv e-offset))))]))
+             (bind #f try-fp (e-val)
+               (let ([info (make-info-call #f #f #f #f #f)])
+                 `(if (call ,info ,#f ,(lookup-primref 3 '$bytevector-set!-check?) (quote 64) ,e-bv ,e-offset)
+                      (call ,info ,#f ,(lookup-primref 3 'bytevector-ieee-double-native-set!) ,e-bv ,e-offset ,e-val)
+                      ,(build-libcall #t src sexpr bytevector-ieee-double-native-set! e-bv e-offset)))))]))
 
       (let ()
         (define-syntax define-bv-int-ref-inline


### PR DESCRIPTION
When the last argument raises an error and the offset is out of the bounds, the compiler was reorganizing the code and the out of bound error was raised instead.

    (define bv (make-bytevector 16 0))
    (define (f x) (bytevector-ieee-double-native-set! bv 100 (+ x 1)))
    (f 'bad)

I think it's isolated enough to be fixed now, but it's more tricky than what I expected. 

It's almost a single line change, but I'm not sure if I'm using correctly the flags of `bind` to ensure that the last argument of `#2%bytevector-ieee-double-native-set!` is correctly handled when it's an `unboxed flonum`.  Also, I think once the temporary variable is marked as `fp` then `#3%bytevector-ieee-double-native-set!` will not expand to `$real->flonum` another time, just use the variable.