### PR TITLE
Support anonymous fields in ftypes

### DIFF
--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -1735,7 +1735,13 @@ The following definitions establish ftype bindings for \scheme{F},
                  [hi unsigned 12]
                  [lo unsigned 20])]))]
     [e (* A)]
-    [f (* F)]))
+    [f (* F)]
+    [=> (endian little
+          (union
+            [=> (struct
+                  [glo unsigned-16]
+                  [ghi unsigned-16])]
+            [g unsigned-32]))]))
 \endschemedisplay
 
 The ftype \scheme{F} describes the type of a foreign function that
@@ -1743,11 +1749,11 @@ takes two arguments, a wide character and an integer, and returns an
 integer.
 The ftype \scheme{A} is simply an array of 10 \scheme{wchar_t} values,
 and its size will be 10 times the size of a single \scheme{wchar_t}.
-The ftype \scheme{E} is a structure with six fields: an integer
+The ftype \scheme{E} is a structure with seven fields: an integer
 \scheme{a}, a double-float \scheme{b}, an array \scheme{c}, a
-union \scheme{d}, a pointer \scheme{e}, and a pointer \scheme{f}.
-The array \scheme{c} is an array of 25 structs, each of which
-contains a short integer, a long integer, and a \scheme{A} array.
+union \scheme{d}, a pointer \scheme{e}, a pointer \scheme{f}, and an
+anonymous union. The array \scheme{c} is an array of 25 structs, each of
+which contains a short integer, a long integer, and a \scheme{A} array.
 The size of the \scheme{c} array will be 25 times the size of a
 single \scheme{A} array, plus 25 times the space needed to store
 each of the short and long integers.
@@ -1771,11 +1777,21 @@ cannot be accessed via the ftype operators described below.
 Thus, in the example above, the \scheme{long} field within the
 \scheme{c} array is inaccessible.
 
-Non-underscore field names are handled symbolically, i.e.,
+An arrow (~\scheme{=>}~) can be used as the field name for one or more
+fields of a \scheme{struct} or \scheme{union} ftype. Such fields must
+themselves be of a \scheme{struct}, \scheme{union}, or \scheme{bits}
+ftype and are considered anonymous as defined by C11 and
+later. Anonymous fields differ only in that their own fields are
+accessible directly from the containing ftype (recursively from the
+innermost named parent when nested). So, in the example above, the
+fields \scheme{g}, \scheme{glo}, and \scheme{ghi} are accessible as if
+they were fields of \scheme{E}.
+
+Non-underscore/arrow field names are handled symbolically, i.e.,
 they are treated as symbols rather than identifiers.
 Each symbol must be unique (as a symbol) with respect to the other
-field names within a single \scheme{struct}, \scheme{union},
-or \scheme{bits} ftype but need not be
+field names (including those from anonymous fields) within a single
+\scheme{struct}, \scheme{union}, or \scheme{bits} ftype but need not be
 unique with respect to field names in other \scheme{struct},
 \scheme{union}, or \scheme{bits} ftypes within the same
 ftype.
@@ -2539,9 +2555,9 @@ value is the symbol \scheme{invalid}.
     [a Frob]
     [b (* Frob)]
     [c (* Frob)]
-    [d (bits
-         [_ unsigned 15]
-         [dx signed 17])]
+    [=> (bits
+          [_ unsigned 15]
+          [dx signed 17])]
     [e (array 5 double)]))
 (define x
   (make-ftype-pointer Snurk
@@ -2550,12 +2566,12 @@ value is the symbol \scheme{invalid}.
   (make-ftype-pointer Frob
     (foreign-alloc (ftype-sizeof Frob))))
 (ftype-set! Snurk (c) x
-  (make-ftype-pointer Frob 0))
+  (make-ftype-pointer Frob 8))
 (ftype-set! Snurk (a p) x #t)
 (ftype-set! Snurk (a q) x #\A)
 (ftype-set! Snurk (b * p) x #f)
 (ftype-set! Snurk (b * q) x #\B)
-(ftype-set! Snurk (d dx) x -2500)
+(ftype-set! Snurk (dx) x -2500)
 (do ([i 0 (fx+ i 1)])
     ((fx= i 5))
   (ftype-set! Snurk (e i) x (+ (* i 5.0) 3.0)))
@@ -2563,7 +2579,7 @@ value is the symbol \scheme{invalid}.
                          ;==   [a (struct [p #t] [q #\A])]
                          ;==   [b (* (struct [p #f] [q #\B]))]
                          ;==   [c (* (struct [p invalid] [q invalid]))]
-                         ;==   [d (bits [_ _] [dx -2500])]
+                         ;==   [=> (bits [_ _] [dx -2500])]
                          ;==   [e (array 5 3.0 8.0 13.0 18.0 23.0)])
 \endschemedisplay
 

--- a/mats/ftype.ms
+++ b/mats/ftype.ms
@@ -460,6 +460,90 @@
 
  ; ----------------
 
+  (begin
+    (define-ftype Fa
+      (struct
+        [x integer-32]
+        [y double-float]
+        [z (array 25 (struct [_ integer-16] [b integer-16]))]
+        [w (struct
+             [a integer-32]
+             [b (union
+                  [=> (struct
+                        [a integer-32]
+                        [b integer-16]
+                        [=> (bits
+                              [c unsigned 10]
+                              [d signed 6])])]
+                  [b2 (struct [a integer-8] [b double])]
+                  [=> Aa])])]
+        [v (* Ac)]))
+    #t)
+
+  (equal?
+    (let ([x (make-ftype-pointer Fa 0)])
+      (list
+        (ftype-sizeof Fa)
+        (ftype-pointer-address (ftype-&ref Fa (x) x))
+        (ftype-pointer-address (ftype-&ref Fa (y) x))
+        (ftype-pointer-address (ftype-&ref Fa (z) x))
+        (ftype-pointer-address (ftype-&ref Fa (w) x))
+        (ftype-pointer-address (ftype-&ref Fa (v) x))
+        (ftype-pointer-address (ftype-&ref Fa (z 0) x))
+        (ftype-pointer-address (ftype-&ref Fa (z 4 b) x))
+        (ftype-pointer-address (ftype-&ref Fa (w a) x))
+        (ftype-pointer-address (ftype-&ref Fa (w b) x))
+        (ftype-pointer-address (ftype-&ref Fa (w b a) x))
+        (ftype-pointer-address (ftype-&ref Fa (w b b) x))
+        (ftype-pointer-address (ftype-&ref Fa (w b b2) x))
+        (ftype-pointer-address (ftype-&ref Fa (w b b2 a) x))
+        (ftype-pointer-address (ftype-&ref Fa (w b b2 b) x))
+        (ftype-pointer-address (ftype-&ref Fa (w b a1) x))
+        (ftype-pointer-address (ftype-&ref Fa (w b a2) x))
+        (ftype-pointer-address (ftype-&ref Fa (w b a3) x))))
+    (if (< max-float-alignment 8)
+        '(132 0 4 12 112 128 12 30 112 116 116 120 116 116 120 116 118 120)
+        '(152 0 8 16 120 144 16 34 120 128 128 132 128 128 136 128 130 132)))
+
+  (begin
+    (define-ftype Fb
+      (packed
+        (struct
+          [x integer-32]
+          [y double-float]
+          [z (array 25 (struct [_ integer-16] [b integer-16]))]
+          [=> (struct
+                [a integer-32]
+                [=> (union
+                      [b1 (struct [a integer-32] [b integer-32])]
+                      [b2 (struct [a integer-8] [b double])])])]
+          [v (* Ac)])))
+    #t)
+
+  (equal?
+    (let ([x (make-ftype-pointer Fb 0)])
+      (list
+        (ftype-sizeof Fb)
+        (ftype-pointer-address (ftype-&ref Fb (x) x))
+        (ftype-pointer-address (ftype-&ref Fb (y) x))
+        (ftype-pointer-address (ftype-&ref Fb (z) x))
+        (ftype-pointer-address (ftype-&ref Fb (a) x))
+        (ftype-pointer-address (ftype-&ref Fb (v) x))
+        (ftype-pointer-address (ftype-&ref Fb (z 0) x))
+        (ftype-pointer-address (ftype-&ref Fb (z 4 b) x))
+        (ftype-pointer-address (ftype-&ref Fb (a) x))
+        (ftype-pointer-address (ftype-&ref Fb (b1) x))
+        (ftype-pointer-address (ftype-&ref Fb (b1 a) x))
+        (ftype-pointer-address (ftype-&ref Fb (b1 b) x))
+        (ftype-pointer-address (ftype-&ref Fb (b2) x))
+        (ftype-pointer-address (ftype-&ref Fb (b2 a) x))
+        (ftype-pointer-address (ftype-&ref Fb (b2 b) x))))
+    (if (< (fixnum-width) 32)
+        '(129 0 4 12 112 125 12 30 112 116 116 120 116 116 117)
+        '(133 0 4 12 112 125 12 30 112 116 116 120 116 116 117)))
+
+ ; ----------------
+
   (equal?
     (let ()
       (define-ftype A (struct [a1 integer-32]))
@@ -991,6 +1075,39 @@
   (begin
     (fptr-free x)
     #t)
+ ; ----------------
+  (begin
+    (define-ftype Dlist
+      (struct
+        [head int]
+        [=> (struct
+              [prev (* Dlist)]
+              [next (* Dlist)]
+              [=> (bits [lock unsigned 1]
+                        [z signed 7])])]))
+    (define x (make-ftype-pointer Dlist (foreign-alloc (ftype-sizeof Dlist))))
+    (ftype-set! Dlist (head) x 17)
+    (ftype-set! Dlist (prev) x x)
+    (ftype-set! Dlist (next) x x)
+    (ftype-set! Dlist (lock) x 1)
+    (ftype-set! Dlist (z) x -6)
+    #t)
+  (eqv? (ftype-ref Dlist (head) x) 17)
+  (eqv? (ftype-ref Dlist (next * head) x) 17)
+  (eqv? (ftype-ref Dlist (prev * next * next * next * head) x) 17)
+  (eqv? (ftype-ref Dlist (lock) x) 1)
+  (eqv? (ftype-ref Dlist (z) x) -6)
+  (equal?
+    (ftype-pointer->sexpr x)
+    '#4=(struct [head 17]
+                [=> (struct
+                      [prev (* #4#)]
+                      [next (* #4#)]
+                      [=> (bits [lock 1]
+                                [z -6])])]))
+  (begin
+    (fptr-free x)
+    #t)
 
  ; ----------------
   (begin
@@ -1042,6 +1159,85 @@
       [Qsnark (struct
                 [head int]
                 [tail (* Qfrob)])]))
+
+  (begin
+    (define-ftype Qa1jk
+      (struct
+        [a1 char]
+        [j int]
+        [k short]))
+    (define-ftype Qs3d
+      (union
+        [=> (struct
+              [s0 short]
+              [s1 short]
+              [s2 short])]
+        [d double]))
+    #t)
+
+  (error? ; duplicate name (s1)
+    (define-ftype Qfrob
+      (struct
+        [i int]
+        [=> (struct
+              [j int]
+              [s1 short])]
+        [=> Qs3d]
+        [c char])))
+
+  (error? ; duplicate name (d)
+    (define-ftype Qfrob
+      (struct
+        [i int]
+        [=> Qa1jk]
+        [=> (union
+              [=> (struct
+                    [d short]
+                    [s1 short]
+                    [s2 short])]
+              [d double])]
+        [c char])))
+
+  (error? ; duplicate name (k)
+    (define-ftype Qfrob
+      (struct
+        [k char]
+        [=> Qa1jk])))
+
+  (error? ; duplicate name (a1)
+    (define-ftype Qfrob
+      (struct
+        [=> Qa1jk]
+        [=> (union
+              [=> Aa]
+              [d double])])))
+
+  (error? ; invalid anonymous field ftype
+    (define-ftype Qfrob
+      (struct
+        [i int]
+        [=> Qa1jk]
+        [c char]
+        [=> (union
+              [=> (array 10 int)]
+              [d double])])))
+
+  (begin
+    (define-ftype Qfrob-ng0
+      (struct
+        [i int]
+        [=> Qa1jk]
+        [=> Qs3d]
+        [c char])
+      (nongenerative #{g1 o9p9ilrfa6hjqgdu4l7ulfkl1-6}))
+    (define-ftype Qfrob-ng1
+      (struct
+        [i int]
+        [=> Qa1jk]
+        [=> Qs3d]
+        [c char])
+      (nongenerative #{g1 o9p9ilrfa6hjqgdu4l7ulfkl1-6}))
+    #t)
 
  ; ----------------
   (begin

--- a/mats/ftype.ms
+++ b/mats/ftype.ms
@@ -472,9 +472,10 @@
                   [=> (struct
                         [a integer-32]
                         [b integer-16]
-                        [=> (bits
-                              [c unsigned 10]
-                              [d signed 6])])]
+                        [=> (endian little
+                              (bits
+                                [c unsigned 10]
+                                [d signed 6]))])]
                   [b2 (struct [a integer-8] [b double])]
                   [=> Aa])])]
         [v (* Ac)]))
@@ -1083,8 +1084,9 @@
         [=> (struct
               [prev (* Dlist)]
               [next (* Dlist)]
-              [=> (bits [lock unsigned 1]
-                        [z signed 7])])]))
+              [=> (endian little
+                    (bits [lock unsigned 1]
+                          [z signed 7]))])]))
     (define x (make-ftype-pointer Dlist (foreign-alloc (ftype-sizeof Dlist))))
     (ftype-set! Dlist (head) x 17)
     (ftype-set! Dlist (prev) x x)

--- a/mats/ftype.ms
+++ b/mats/ftype.ms
@@ -1085,8 +1085,9 @@
               [prev (* Dlist)]
               [next (* Dlist)]
               [=> (endian little
-                    (bits [lock unsigned 1]
-                          [z signed 7]))])]))
+                    (bits
+                      [lock unsigned 1]
+                      [z signed 7]))])]))
     (define x (make-ftype-pointer Dlist (foreign-alloc (ftype-sizeof Dlist))))
     (ftype-set! Dlist (head) x 17)
     (ftype-set! Dlist (prev) x x)
@@ -1101,12 +1102,14 @@
   (eqv? (ftype-ref Dlist (z) x) -6)
   (equal?
     (ftype-pointer->sexpr x)
-    '#4=(struct [head 17]
-                [=> (struct
-                      [prev (* #4#)]
-                      [next (* #4#)]
-                      [=> (bits [lock 1]
-                                [z -6])])]))
+    '#4=(struct
+          [head 17]
+          [=> (struct
+                [prev (* #4#)]
+                [next (* #4#)]
+                [=> (bits
+                      [lock 1]
+                      [z -6])])]))
   (begin
     (fptr-free x)
     #t)

--- a/mats/root-experr-compile-0-f-f-f
+++ b/mats/root-experr-compile-0-f-f-f
@@ -10692,6 +10692,11 @@ ftype.mo:Expected error in mat ftype: "non-scalar value cannot be assigned (ftyp
 ftype.mo:Expected error in mat ftype: "non-scalar value cannot be referenced (ftype-ref B (tail *) b)".
 ftype.mo:Expected error in mat ftype: "recursive or forward reference outside pointer field Qfrob".
 ftype.mo:Expected error in mat ftype: "recursive or forward reference outside pointer field Qsnark".
+ftype.mo:Expected error in mat ftype: "duplicate field name s1".
+ftype.mo:Expected error in mat ftype: "duplicate field name d".
+ftype.mo:Expected error in mat ftype: "duplicate field name k".
+ftype.mo:Expected error in mat ftype: "duplicate field name a1".
+ftype.mo:Expected error in mat ftype: "invalid anonymous field ftype in Qfrob".
 ftype.mo:Expected error in mat ftype: "ftype-ref: ftype mismatch for <ftype-pointer>".
 ftype.mo:Expected error in mat ftype: "ftype-set!: ftype mismatch for <ftype-pointer>".
 ftype.mo:Expected error in mat ftype: "ftype-ref: ftype mismatch for <ftype-pointer>".

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -199,6 +199,15 @@ and partial support for more numeric predicates,
 including \scheme{even?}, \scheme{odd?}, \scheme{positive?}, \scheme{negative?}
 and \scheme{real-valued?}.
 
+\subsection{Anonymous fields in struct and union ftypes (10.4.0)}
+
+Struct and union ftypes now support anonymous fields, which mirror the
+functionality of anonymous struct/union members as defined by C11 and
+later. Anonymous fields have arrow (\scheme{=>}) as their name and must
+themselves be of a struct, union, or bits ftype, whose fields are
+accessible directly from the containing ftype (recursively from the
+innermost named parent when nested).
+
 \subsection{Nongenerative ftype definitions (10.4.0)}
 
 The \scheme{define-ftype} form allows a \scheme{(nongenerative \var{uid})}

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -121,6 +121,14 @@ Online versions of both books can be found at
 %-----------------------------------------------------------------------------
 \section{Functionality Changes}\label{section:functionality}
 
+\subsection{Anonymous fields in struct and union ftypes (10.5.0)}
+
+Struct and union ftypes now support anonymous fields, which mirror anonymous
+struct/union members as defined by C11 and later. Anonymous fields have arrow
+(\scheme{=>}) as their name and must themselves be of a struct, union, or bits
+ftype, whose fields are accessible directly from the containing ftype
+(recursively from the innermost named parent when nested).
+
 \subsection{Named Cost Center (10.4.0)}
 
 The procedure \scheme{make-cost-center} now
@@ -198,15 +206,6 @@ and similar functions; improved support for \scheme{quotient},
 and partial support for more numeric predicates,
 including \scheme{even?}, \scheme{odd?}, \scheme{positive?}, \scheme{negative?}
 and \scheme{real-valued?}.
-
-\subsection{Anonymous fields in struct and union ftypes (10.4.0)}
-
-Struct and union ftypes now support anonymous fields, which mirror the
-functionality of anonymous struct/union members as defined by C11 and
-later. Anonymous fields have arrow (\scheme{=>}) as their name and must
-themselves be of a struct, union, or bits ftype, whose fields are
-accessible directly from the containing ftype (recursively from the
-innermost named parent when nested).
 
 \subsection{Nongenerative ftype definitions (10.4.0)}
 

--- a/s/ftype.ss
+++ b/s/ftype.ss
@@ -90,7 +90,14 @@ notes:
     in the layout but are considered unnamed and cannot be accessed
     via the ftype operators described below.
 
-  - non-underscore field names are handled symbolically, i.e.,
+  - arrow ( => ) can be used as the field name for one or more fields
+    of a struct or union.  such fields must themselves be of a struct,
+    union, or bits ftype and are considered anonymous as defined by C11
+    and later.  anonymous fields differ only in that their own fields
+    are accessible directly from the containing ftype (recursively from
+    the innermost named parent when nested).
+
+  - non-underscore/arrow field names are handled symbolically, i.e.,
     they are treated as symbols rather than identifiers.  each
     symbol must be unique (as a symbol) with respect to the other
     field names within a single struct or union, but need not be
@@ -446,12 +453,13 @@ ftype operators:
             '()
             (let ([x (car x*)] [x* (cdr x*)])
               (unless (identifier? x) (syntax-error x "invalid field name"))
-              (if (free-identifier=? x #'_)
-                  (cons #f (f x* seen*))
-                  (let ([s (syntax->datum x)])
-                    (if (memq s seen*)
-                        (syntax-error x "duplicate field name")
-                        (cons s (f x* (cons s seen*)))))))))))
+              (cond
+                [(free-identifier=? x #'_) (cons #f (f x* seen*))]
+                [(free-identifier=? x #'=>) (cons #t (f x* seen*))]
+                [else (let ([s (syntax->datum x)])
+                        (if (memq s seen*)
+                            (syntax-error x "duplicate field name")
+                            (cons s (f x* (cons s seen*)))))]))))))
   (define expand-ftype-name
     (case-lambda
       [(r ftype) (expand-ftype-name r ftype #t)]
@@ -475,6 +483,44 @@ ftype operators:
              (unless (and (>= size 0) (< size (constant most-positive-fixnum)))
                (syntax-error ftype "non-fixnum overall size for ftype"))))
          ftd)
+       (define add-anon-accessors
+         (lambda (field* field->ftd)
+           (let ([name* (filter symbol? (map car field*))])
+             (let add ([f* field*] [added* '()])
+               (define check-unique
+                 (lambda (s)
+                   (when (or (memq s name*)
+                             (ormap (lambda (a*) (memq s a*)) added*))
+                     (syntax-error s "duplicate field name"))))
+               (if (null? f*)
+                   '()
+                   (let* ([f (car f*)]
+                          [name (car f)])
+                     (if (not (eq? name #t))
+                         (cons f (add (cdr f*) added*))
+                         (let* ([ftd (field->ftd f)]
+                                [sub-f* (cond
+                                          [(ftd-struct? ftd) (ftd-struct-field* ftd)]
+                                          [(ftd-union? ftd) (ftd-union-field* ftd)]
+                                          [(ftd-bits? ftd) (ftd-bits-field* ftd)]
+                                          [else #f])])
+                           (unless sub-f*
+                             (syntax-error defid "invalid anonymous field ftype in"))
+                           (let ([acc* (let gather ([sub-f* sub-f*] [acc* '()])
+                                         (if (null? sub-f*)
+                                             acc*
+                                             (let ([sub-name (caar sub-f*)])
+                                               (gather (cdr sub-f*)
+                                                       (cond
+                                                         [(symbol? sub-name)
+                                                          (check-unique sub-name)
+                                                          (cons sub-name acc*)]
+                                                         [(pair? sub-name)
+                                                          (for-each check-unique sub-name)
+                                                          (append sub-name acc*)]
+                                                         [else acc*])))))])
+                             (cons (cons acc* (cdr f))
+                                   (add (cdr f*) (cons acc* added*))))))))))))
        (check-size
          (let f/flags ([ftype ftype] [defid defid] [stype (syntax->datum ftype)] [packed? #f] [eness 'native] [funok? #t] [uid uid])
            (define (pad n k) (if packed? n (logand (+ n (- k 1)) (- k))))
@@ -547,7 +593,7 @@ ftype operators:
                                           #'(ftype ...) (datum (ftype ...)))]
                                [offset 0] [alignment 1] [field* '()])
                       (if (null? id*)
-                          (let ([field* (reverse field*)])
+                          (let ([field* (reverse (add-anon-accessors field* caddr))])
                             (make-ftd-struct (if (null? field*) rtd/fptr (sanitize-field-subtype (caddar field*)))
                               (or uid (and defid (symbol->string (syntax->datum defid))))
                               stype (pad offset alignment) alignment field*))
@@ -568,7 +614,7 @@ ftype operators:
                           stype
                           (pad (apply max 0 (map $ftd-size ftd*)) alignment)
                           alignment
-                          (map cons id* ftd*))))]
+                          (add-anon-accessors (map cons id* ftd*) cdr))))]
                    [(array-kwd ?n ftype)
                     (eq? (datum array-kwd) 'array)
                     (let ([n (datum ?n)])
@@ -1065,16 +1111,18 @@ ftype operators:
                 [(ftd-struct? ftd)
                  `(struct
                     ,@(map (lambda (field)
-                             (if (car field)
-                                 `(,(car field) ,(f fptr (caddr field) (+ offset (cadr field))))
-                                 '(_ _)))
+                             (let ([name (car field)])
+                               (if name
+                                   `(,(if (pair? name) '=> name) ,(f fptr (caddr field) (+ offset (cadr field))))
+                                   '(_ _))))
                         (ftd-struct-field* ftd)))]
                 [(ftd-union? ftd)
                  `(union
                     ,@(map (lambda (field)
-                             (if (car field)
-                                 `(,(car field) ,(f fptr (cdr field) offset))
-                                 '(_ _)))
+                             (let ([name (car field)])
+                               (if name
+                                   `(,(if (pair? name) '=> name) ,(f fptr (cdr field) offset))
+                                   '(_ _))))
                         (ftd-union-field* ftd)))]
                 [(ftd-array? ftd)
                  (let ([n (ftd-array-length ftd)]
@@ -1374,6 +1422,15 @@ ftype operators:
     (define-who ftype-access-code
       (lambda (whoid ftd a* fptr-expr offset)
         (let loop ([ftd ftd] [a* a*] [fptr-expr fptr-expr] [offset offset] [idx* '()])
+          (define (get-field s field*)
+            (if (null? field*)
+                (values #f #f)
+                (let* ([field (car field*)]
+                       [name (car field)])
+                  (cond
+                    [(eq? name s) (values field (cdr a*))]
+                    [(and (pair? name) (memq s name)) (values field a*)]
+                    [else (get-field s (cdr field*))]))))
           (if (null? a*)
               (values fptr-expr offset ftd idx* #f)
               (let ([a (car a*)])
@@ -1382,20 +1439,20 @@ ftype operators:
                    (syntax-error a "cannot access generic pointer content")]
                   [(ftd-struct? ftd)
                    (let ([s (syntax->datum a)])
-                     (cond
-                       [(and (symbol? s) (assq s (ftd-struct-field* ftd))) =>
-                        (lambda (field)
-                          (let ([offset #`(#3%fx+ #,offset #,(cadr field))] [ftd (caddr field)])
-                            (loop ftd (cdr a*) fptr-expr offset idx*)))]
-                       [else (syntax-error a "unexpected accessor")]))]
+                     (unless (symbol? s)
+                       (syntax-error a "unexpected accessor"))
+                     (let-values ([(field a*) (get-field s (ftd-struct-field* ftd))])
+                       (unless field (syntax-error a "unexpected accessor"))
+                       (let ([offset #`(#3%fx+ #,offset #,(cadr field))] [ftd (caddr field)])
+                         (loop ftd a* fptr-expr offset idx*))))]
                   [(ftd-union? ftd)
                    (let ([s (syntax->datum a)])
-                     (cond
-                       [(and (symbol? s) (assq s (ftd-union-field* ftd))) =>
-                        (lambda (field)
-                          (let ([ftd (cdr field)])
-                            (loop ftd (cdr a*) fptr-expr offset idx*)))]
-                       [else (syntax-error a "unexpected accessor")]))]
+                     (unless (symbol? s)
+                       (syntax-error a "unexpected accessor"))
+                     (let-values ([(field a*) (get-field s (ftd-union-field* ftd))])
+                       (unless field (syntax-error a "unexpected accessor"))
+                       (let ([ftd (cdr field)])
+                         (loop ftd a* fptr-expr offset idx*))))]
                   [(ftd-array? ftd)
                    (let ([elt-ftd (ftd-array-ftd ftd)] [len (ftd-array-length ftd)])
                      (if (memv (syntax->datum a) '(* 0))

--- a/s/inspect.ss
+++ b/s/inspect.ss
@@ -1978,9 +1978,20 @@
           ($oops 'ftype-pointer-object "invalid index ~s" f))
         (define (get-field f field*)
           (cond
-            [(assq f field*) => cdr]
+            [(let get ([field* field*])
+               (if (null? field*)
+                   #f
+                   (let* ([field (car field*)]
+                          [name (car field)])
+                     (if (or (eq? name f)
+                             (and (pair? name) (memq f name)))
+                         field
+                         (get (cdr field*))))))
+             => (lambda (field)
+                  (values (cdr field)
+                          (atom? (car field))))]
             [(and (fixnum? f) (#%$fxu< f (length field*)))
-             (cdr (list-ref field* f))]
+             (values (cdr (list-ref field* f)) #t)]
             [else (invalid-field-specifier f)]))
         (define (deref x)
           (let ([ux ($unwrap-ftype-pointer x)])
@@ -2003,8 +2014,13 @@
                 [ftype () (make-object (ftype-pointer-ftype x))]
                 [fields () (make-object (map (lambda (x) (or (car x) '_)) field*))]
                 [length () (length field*)]
-                [ref (f) (deref (get-field f field*))]
-                [set! (f v) (deset! 'ftype-struct-object (get-field f field*) v)]
+                [ref (f) (let-values ([(field gotten?) (get-field f field*)])
+                           (let ([object (deref field)])
+                             (if gotten? object (object 'ref f))))]
+                [set! (f v) (let-values ([(field gotten?) (get-field f field*)])
+                              (if gotten?
+                                  (deset! 'ftype-struct-object field v)
+                                  ((deref field) 'set! f v)))]
                 [size (g) (compute-size x g)]
                 [write (p) (write `(ftype struct ...) p)]
                 [print (p) (pretty-print (ftype-pointer->sexpr x) p)])
@@ -2015,8 +2031,13 @@
                 [ftype () (make-object (ftype-pointer-ftype x))]
                 [fields () (make-object (map (lambda (x) (or (car x) '_)) field*))]
                 [length () (length field*)]
-                [ref (f) (deref (get-field f field*))]
-                [set! (f v) (deset! 'ftype-union-object (get-field f field*) v)]
+                [ref (f) (let-values ([(field gotten?) (get-field f field*)])
+                           (let ([object (deref field)])
+                             (if gotten? object (object 'ref f))))]
+                [set! (f v) (let-values ([(field gotten?) (get-field f field*)])
+                              (if gotten?
+                                  (deset! 'ftype-union-object field v)
+                                  ((deref field) 'set! f v)))]
                 [size (g) (compute-size x g)]
                 [write (p) (write `(ftype union ...) p)]
                 [print (p) (pretty-print (ftype-pointer->sexpr x) p)])
@@ -2055,9 +2076,11 @@
                 [fields () (make-object (map (lambda (x) (or (car x) '_)) field*))]
                 [length () (length field*)]
                 [ref (f) (apply (lambda (getter setter) (make-object (getter)))
-                           (get-field f field*))]
+                           (let-values ([(field gotten?) (get-field f field*)])
+                             field))]
                 [set! (f v) (apply (lambda (getter setter) (make-object (setter v)))
-                              (get-field f field*))]
+                              (let-values ([(field gotten?) (get-field f field*)])
+                                field))]
                 [size (g) (compute-size x g)]
                 [write (p) (write `(ftype bits ...) p)]
                 [print (p) (pretty-print (ftype-pointer->sexpr x) p)])


### PR DESCRIPTION
Adds support for anonymous `struct`/`union`/`bits` fields to `struct`/`union` ftypes, mirroring anonymous structures/unions of C11 and later. Besides their direct benefits, they also obviate the need to introduce tags for intermediate levels when generating ftypes from C types that utilize them.

Implementation outline: Anonymous fields are given a `#t` name (as opposed to `#f` of unnamed ones), which is then replaced by the list of subfield names accessible from the containing ftype. They're marked by the `=>` keyword, as their functionality may be thought of as "field forwarding". The inspector has been adapted so that `ref`ing a field by name jumps to its level while registering a single `down` move (index-based access remains intact). Sample inspector session:

<details><summary>Transcript</summary>
<p>

```scheme
Chez Scheme Transcript [Tue Apr 28 19:26:06 2026]
> (define-ftype Frob
    (struct [=> (union [=> (bits [a unsigned 2] [b unsigned 6])]
                       [=> (bits [A unsigned 6] [B unsigned 2])])]
            [=> [union [c char] [s short]]]))
> (define the-frob
    (make-ftype-pointer Frob (foreign-alloc (ftype-sizeof Frob))))
> (inspect the-frob)(ftype struct ...)                                                : p

(struct
  [=> (union
        [=> (bits [a 0] [b 50])]
        [=> (bits [A 8] [B 3])])]
  [=> (union [c #\à] [s -2080])])

(ftype struct ...)                                                : ftype
(struct (=> (union (...) (...))) (=> (union (...) (...))))        : p

(struct
  [=> (union
        [=> (bits [a unsigned 2] [b unsigned 6])]
        [=> (bits [A unsigned 6] [B unsigned 2])])]
  [=> (union [c char] [s short])])

(struct (=> (union (...) (...))) (=> (union (...) (...))))        : u
(ftype struct ...)                                                : set! c #\Q
(ftype struct ...)                                                : p

(struct
  [=> (union
        [=> (bits [a 0] [b 50])]
        [=> (bits [A 8] [B 3])])]
  [=> (union [c #\Q] [s -2223])])

(ftype struct ...)                                                : set! b 0
(ftype struct ...)                                                : ref b
0                                                                 : u
(ftype struct ...)                                                : p

(struct
  [=> (union [=> (bits [a 0] [b 0])] [=> (bits [A 0] [B 0])])]
  [=> (union [c #\Q] [s -2223])])

(ftype struct ...)                                                : ref 0
(ftype union ...)                                                 : p

(union [=> (bits [a 0] [b 0])] [=> (bits [A 0] [B 0])])

(ftype union ...)                                                 : set! A 80
Exception in ftype-set!: invalid value 80 for bit field of size 6
(ftype union ...)                                                 : set! A 40
(ftype union ...)                                                 : ref 1
(ftype bits ...)                                                  : p

(bits [A 40] [B 0])

(ftype bits ...)                                                  : u 2
(ftype struct ...)                                                : p

(struct
  [=> (union
        [=> (bits [a 0] [b 10])]
        [=> (bits [A 40] [B 0])])]
  [=> (union [c #\Q] [s -2223])])

(ftype struct ...)                                                : q

> (transcript-off)
``` 

</p>
</details> 

Being new to the project, and given https://github.com/cisco/ChezScheme/issues/1028, I wish to clarify that I haven't used any LLMs when preparing these changes.
