### PR TITLE
ppc32 and logtest repairs

### DIFF
--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2995,17 +2995,15 @@ in fasl files does not generally make sense.
 
 \subsection{Repair allocation in \scheme{logtest} (10.4.1)}
 
-The \scheme{logtest} procedure could allocate incorrectly when given a
-mixture of fixnum and bignum arguments. The problem has been fixed by
-adding a missing \scheme{__alloc} annotation on the internal
-implementation.
+In Version 10.4.0, the \scheme{logtest} procedure could allocate incorrectly when given a
+mixture of fixnum and bignum arguments. The problem has been fixed by adding a missing
+\scheme{__alloc} annotation on the internal implementation.
 
 \subsection{Repair \scheme{__alloc} mode for ppc32 (10.4.1)}
 
-On ppc32, an \scheme{__atomic __alloc} foreign-procedure annotation
-was not handled correctly. The problem has been fixed by migrating the
-end-of-allocation pointer between a register and the thread context
-during an allocating foreign call.
+In Version 10.4.0 on ppc32, an \scheme{__atomic __alloc} foreign-procedure annotation was
+not handled correctly. The problem has been fixed by migrating the end-of-allocation
+pointer between a register and the thread context during an allocating foreign call.
 
 \subsection{Declare \scheme{Spopcount} in scheme.h (10.4.0)}
 

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -2993,6 +2993,19 @@ in fasl files does not generally make sense.
 %-----------------------------------------------------------------------------
 \section{Bug Fixes}\label{section:bugfixes}
 
+\subsection{Repair allocation in \scheme{logtest} (10.4.1)}
+
+The \scheme{logtest} procedure could allocate incorrectly when given a
+mixture of fixnum and bignum arguments. The problem has been fixed by
+adding a missing \scheme{__alloc} annotation on the internal
+implementation.
+
+\subsection{Repair \scheme{__alloc} mode for ppc32 (10.4.1)}
+
+On ppc32, an \scheme{__atomic __alloc} foreign-procedure annotation
+was not handled correctly. The problem has been fixed by migrating the
+end-of-allocation pointer between a register and the thread context
+during an allocating foreign call.
 
 \subsection{Declare \scheme{Spopcount} in scheme.h (10.4.0)}
 

--- a/s/cpnanopass.ss
+++ b/s/cpnanopass.ss
@@ -4719,6 +4719,9 @@
                                                                    [(real-register? '%ap) (eq? reg %ap)]
                                                                    [else #f])
                                                                   (meta-cond
+                                                                   [(real-register? '%eap) (eq? reg %eap)]
+                                                                   [else #f])
+                                                                  (meta-cond
                                                                    [(real-register? '%trap) (eq? reg %trap)]
                                                                    [else #f])))))
                                        (lambda (reg) #t))])

--- a/s/prims.ss
+++ b/s/prims.ss
@@ -2416,7 +2416,7 @@
     scheme-object))
 
 (define $logtest
-  (foreign-procedure __atomic "(cs)logtest"
+  (foreign-procedure __atomic __alloc "(cs)logtest"
     (scheme-object scheme-object)
     scheme-object))
 


### PR DESCRIPTION
Repairs two problems related to #1043.

One problem is specific to ppc32 and `__atomic __alloc`.

The other one affects `logtest` on all platforms when given a mixture of fixnum and bignum arguments. That kind of mixture is probably more likely on a 32-bit platform, so that may be why testing did not discover the problem before, but it's not clear why ppc32 was affected more than other 32-bit platforms.