### PR TITLE
add `arm7le` machine type, `configure` supoprt for Termux, `arm32` FFI repairs

### DIFF
--- a/c/build.zuo
+++ b/c/build.zuo
@@ -48,7 +48,8 @@
       [(string=? arch "i3")
        (cons "I386"
              (or-windows "i3le.c"))]
-      [(string=? arch "arm32")
+      [(or (string=? arch "arm32")
+           (string=? arch "arm7"))
        (cons "ARMV6"
              "clearcache.c")]
       [(string=? arch "arm64")

--- a/configure
+++ b/configure
@@ -90,6 +90,7 @@ disablex11=no
 disablecurses=no
 disableiconv=no
 addflags=yes
+hardlinks=yes
 addwarningflags=no
 default_warning_flags="-Wpointer-arith -Wall -Wextra -Wno-implicit-fallthrough"
 : ${CC:="gcc"}
@@ -113,6 +114,7 @@ enableFrompb=yes
 pbendian=l
 emscripten=no
 empetite=no
+android=no
 crossCompile=no
 moreBootFiles=
 preloadBootFiles=
@@ -137,6 +139,10 @@ case "${CONFIG_UNAME}" in
     unixsuffix=le
     installprefix=/usr
     installmansuffix=share/man
+    if [ "$(uname -o)" = "Android" ]; then
+        android=yes
+        hardlinks=no
+    fi
     ;;
   GNU)
     unixsuffix=gnu # the Hurd
@@ -147,6 +153,7 @@ case "${CONFIG_UNAME}" in
     unixsuffix=hk
     installprefix=/system
     installmansuffix=documentation/man
+    hardlinks=no
     ;;
   QNX)
     if uname -m | egrep 'x86' > /dev/null 2>&1 ; then
@@ -254,6 +261,10 @@ if [ "$unixsuffix" != "" ] ; then
         m64=arm64${unixsuffix}
         tm32=tarm32${unixsuffix}
         tm64=tarm64${unixsuffix}
+        if [ "$android" = "yes" ]; then
+            m32=arm7${unixsuffix}
+            tm32=tarm7${unixsuffix}
+        fi
     elif uname -m | grep 'riscv64' > /dev/null 2>&1 ; then
         m32=""
         m64=rv64${unixsuffix}
@@ -410,6 +421,9 @@ while [ $# != 0 ] ; do
       ;;
     --enable-warning-flags)
       addwarningflags=yes
+      ;;
+    --disable-hard-links)
+      hardlinks=no
       ;;
     --libkernel)
       Kernel=KernelLib
@@ -687,6 +701,7 @@ if [ "$help" = "yes" ]; then
   echo "  --enable-libffi                   enable libffi support for pb"
   echo "  --disable-auto-flags              no auto additions to CFLAGS/LDFLAGS/LIBS"
   echo "  --enable-warning-flags            add GCC warning flags to CFLAGS"
+  echo "  --disable-hard-links              install with soft instead of hard links"
   echo "  --libkernel                       build libkernel.a (the default)"
   echo "  --kernelobj                       build kernel.o instead of libkernel.a"
   echo "  --installprefix=<pathname>        final installation root ($installprefix)"
@@ -894,6 +909,9 @@ if [ "$addflags" = "yes" ] ; then
   case "${flagsm}" in
     *le|*gnu|*hk)
         LDFLAGS="${LDFLAGS} -rdynamic"
+        if [ "$android" = "yes" ]; then
+            LDFLAGS="${LDFLAGS} ${iconvLib}"
+        fi
         ;;
     *fb|*nb)
         LDFLAGS="${LDFLAGS} -rdynamic -L/usr/local/lib"
@@ -1238,4 +1256,5 @@ GzipManPages=$gzipmanpages
 InstallSchemeName=$installschemename
 InstallPetiteName=$installpetitename
 InstallScriptName=$installscriptname
+InstallHardlinks=$hardlinks
 END

--- a/makefiles/install.zuo
+++ b/makefiles/install.zuo
@@ -38,6 +38,8 @@
         (~a s ".exe")
         s))
 
+  (define hardlinks? (not (equal? (lookup 'InstallHardlinks) "no")))
+
   ;; The following variables determine where the executables, boot files,
   ;; example programs, and manual pages are installed.
 
@@ -179,12 +181,10 @@
     (shell/wait* "rm" "-f" f))
   (define (rm-rf d)
     (shell/wait* "rm" "-rf" d))
-  (define haiku? (glob-match? "*hk" m))
   (define (ln-f from to)
-    (if haiku?
-        ;; no hard links on BeFS
-        (shell/wait* "ln" "-s" from to)
-        (shell/wait* "ln" "-f" from to)))
+    (if hardlinks?
+        (shell/wait* "ln" "-f" from to)
+        (shell/wait* "ln" "-s" from to)))
   (define (ln-s from to)
     (shell/wait* "ln" "-s" from to))
 

--- a/makefiles/lib.zuo
+++ b/makefiles/lib.zuo
@@ -45,7 +45,7 @@
                  (and (>= (string-length uni) (string-length arch))
                       (string=? (substring uni 0 (string-length arch)) arch)
                       arch))
-               '("a6" "i3" "arm64" "arm32" "ppc32" "rv64" "la64" "pb"))
+               '("a6" "i3" "arm64" "arm32" "arm7" "ppc32" "rv64" "la64" "pb"))
         (error "could not extract architecture from machine name" m))))
 
 (define (hash-set* ht . keys+vals)

--- a/mats/bytevector.ms
+++ b/mats/bytevector.ms
@@ -36,7 +36,7 @@
                 i3osx ti3osx a6le ta6le a6nb ta6nb
                 a6osx ta6osx a6ios ta6ios a6fb ta6fb a6ob ta6ob a6s2 ta6s2 i3s2 ti3s2 i3qnx ti3qnx
                 arm32le tarm32le arm64le tarm64le arm64osx tarm64osx arm64ios tarm64ios rv64le trv64le
-                la64le tla64le a6hk ta6hk)
+                la64le tla64le arm7le tarm7le a6hk ta6hk)
           'little]
          [(ppc32le tppc32le ppc32osx tppc32osx) 'big]
          [(pb tpb) (native-endianness)]

--- a/mats/foreign.ms
+++ b/mats/foreign.ms
@@ -201,7 +201,9 @@
       (error? (load-shared-object 3))
     )
    ]
-  [(i3le ti3le a6le ta6le arm32le tarm32le arm64le tarm64le ppc32le tppc32le rv64le trv64le la64le tla64le)
+  [(i3le ti3le a6le ta6le arm32le tarm32le arm64le tarm64le
+         ppc32le tppc32le rv64le trv64le la64le tla64le
+         arm7le tarm7le)
    (mat load-shared-object
       (file-exists? foreign1.so)
       (begin (load-shared-object foreign1.so) #t)
@@ -3378,7 +3380,8 @@
       (machine-case
         [(i3ob ti3ob a6ob ta6ob a6s2 ta6s2 i3s2 ti3s2 i3qnx ti3qnx i3nb ti3nb a6nb ta6nb)
          '(load-shared-object "libc.so")]
-        [(i3le ti3le a6le ta6le arm32le tarm32le arm64le tarm64le ppc32le tppc32le rv64le trv64le la64le tla64le)
+        [(i3le ti3le a6le ta6le arm32le tarm32le arm64le tarm64le ppc32le tppc32le
+               rv64le trv64le la64le tla64le arm7le tarm7le)
          '(load-shared-object "libc.so.6")]
 	[(a6hk ta6hk)
 	 '(load-shared-object "libroot.so")]

--- a/mats/ftype.ms
+++ b/mats/ftype.ms
@@ -60,13 +60,13 @@
     (define max-integer-alignment
       (if (or (> (fixnum-width) 32)
               (memq (machine-type) '(i3nt ti3nt i3qnx ti3qnx arm32le tarm32le ppc32le tppc32le
-                                          pb32l tpb32l pb32b tpb32b)))
+                                          pb32l tpb32l pb32b tpb32b arm7le tarm7le)))
           8
           4))
     (define max-float-alignment
       (if (or (> (fixnum-width) 32)
               (memq (machine-type) '(i3nt ti3nt arm32le tarm32le ppc32le tppc32le
-                                          pb32l tpb32l pb32b tpb32b)))
+                                          pb32l tpb32l pb32b tpb32b arm7le tarm7le)))
           8
           4))
     (define-syntax fptr-free

--- a/mats/misc.ms
+++ b/mats/misc.ms
@@ -4711,7 +4711,7 @@
              (#2%display 1))))
 )
 
-(unless (memq (machine-type) '(arm32le tarm32le arm64le tarm64le arm64osx tarm64osx ; timestamp counter tends to be priviledged on Arm
+(unless (memq (machine-type) '(arm32le tarm32le arm64le tarm64le arm64osx tarm64osx arm7le tarm7le ; timestamp counter tends to be priviledged on Arm
                                        arm64ios tarm64ios arm64nt tarm64nt
                                        pb pb32l pb32b pb64l pb64b tpb tpb32l tpb32b tpb64l tpb64b)) ; doesn't increment for pb
   (mat $read-time-stamp-counter

--- a/release_notes/release_notes.stex
+++ b/release_notes/release_notes.stex
@@ -37,7 +37,8 @@ procedure) is given in parentheses.
      \item x86, nonthreaded (i3le) and threaded (ti3le)
      \item x86\_64, nonthreaded (a6le) and threaded (ta6le)
      \item AArch64 including Android, nonthreaded (arm64le) and threaded (tarm64le)
-     \item ARMv6 (32-bit) including Android, nonthreaded (arm32le) and threaded (tarm32le)
+     \item ARMv6 (32-bit armhf), nonthreaded (arm32le) and threaded (tarm32le)
+     \item ARMv7 (32-bit armel) including Android, nonthreaded (arm7le) and threaded (tarm7le)
      \item RV64G (64-bit RISC-V), nonthreaded (rv64le) and threaded (trv64le)
      \item LoongArch64 (64-bit LoongArch), nonthreaded (la64le) and threaded (tla64le)
      \item PowerPC (32-bit), nonthreaded (ppc32le) and threaded (tppc32le)
@@ -128,6 +129,12 @@ struct/union members as defined by C11 and later. Anonymous fields have arrow
 (\scheme{=>}) as their name and must themselves be of a struct, union, or bits
 ftype, whose fields are accessible directly from the containing ftype
 (recursively from the innermost named parent when nested).
+
+\subsection{New machine type for ARMv7 armel (10.5.0)}
+
+The arm7le and tarm7le machine types correspond to a 32-bit ARM
+compilation target using the armel ABI, which is consistent with (old)
+Android devices.
 
 \subsection{Named Cost Center (10.4.0)}
 
@@ -3008,6 +3015,21 @@ argument raises and error and the offset is out of bounds---has been fixed.
 
 When \scheme{log} is called with exact \scheme{1} as the second argument, the error is now
 reported in terms of \scheme{log} instead of a divide-by-zero error in \scheme{/}.
+
+\subsection{Repairs for 32-bit ARM foreign call and callables (10.5.0)}
+
+Several problems with floating-point values for foreign calls and
+callables on 32-bit ARM (arm32 and tarm32 machine types) have been
+fixed. Foreign calls in \scheme{__collect_safe} mode that have
+multiple floating-point arguments could deliver the wrong values. When
+a callable has both floating-point arguments and a struct result that
+does not fit into registers, then the argument was not received
+correctly. When a foreign-call argument or result is a multi-element
+\scheme{union} or a \scheme{struct} type that contains multi-element
+\scheme{union}s and has only \scheme{double} or \scheme{float}
+members, the argument or result could be passed incorrectly. A varargs
+foreign call's struct result was not received correctly when it was
+small and with only \scheme{double} or \scheme{float} members.
 
 \subsection{Repair allocation in \scheme{logtest} (10.4.1)}
 

--- a/s/arm32.def
+++ b/s/arm32.def
@@ -13,4 +13,6 @@
 (define-constant unaligned-floats #f)
 (define-constant unaligned-integers #t)
 
-(define-constant arm-isa-version 6)
+(define-constant-default arm-isa-version 6)
+
+(define-constant-default arm-softfp #f) ; affects ABI, not use of FP instructions

--- a/s/arm32.ss
+++ b/s/arm32.ss
@@ -2414,16 +2414,27 @@
                                     (fx= (cadr m) 8)))
     (define (float-member? m) (and (eq? (car m) 'float)
                                    (fx= (cadr m) 4)))
-    (define (indirect-result-that-fits-in-registers? result-type)
+    (define filter-union
+      (lambda (members)
+        ;; remove members of an `&`-wrapped ftd that have the
+        ;; same the same type and offset; this has the effect of
+        ;; counting elements correctly for homogenous aggregates
+        (let loop ([members members])
+          (cond
+            [(null? members) '()]
+            [(member (car members) (cdr members)) (loop (cdr members))]
+            [else (cons (car members) (loop (cdr members)))]))))
+    (define (indirect-result-that-fits-in-registers? result-type basestd?)
       (nanopass-case (Ltype Type) result-type
         [(fp-ftd& ,ftd ,fptd)
-         (let* ([members ($ftd->members ftd)]
+         (let* ([members (filter-union ($ftd->members ftd))]
                 [num-members (length members)])
            (or (fx<= ($ftd-size ftd) 4)
                (and (fx= num-members 1)
                     ;; a struct containing only int64 is not returned in a register
                     (or (not ($ftd-compound? ftd))))
-               (and (fx<= num-members 4)
+               (and (not basestd?)
+                    (fx<= num-members 4)
                     (or (andmap double-member? members)
                         (andmap float-member? members)))))]
         [else #f]))
@@ -2454,7 +2465,8 @@
                      (cond
                       [(null? fp-regs) e]
                       [else
-                       (let ([info (make-info-vpush (car fp-regs) (length fp-regs))])
+                       ;; assuming that fp registers will be contiguous starting from `%Cfparg1`
+                       (let ([info (make-info-vpush %Cfparg1 (length fp-regs))])
                          (%seq
                           (inline ,info ,%vpush-multiple)
                           ,e
@@ -2568,16 +2580,16 @@
                        (set! ,loreg ,(%mref ,x ,from-offset))
                        (set! ,hireg ,(%mref ,x ,(fx+ from-offset 4))))))]
                  [do-args
-                  (lambda (types varargs?)
+                  (lambda (types basestd?)
                     ; sgl* is always of even-length, i.e., has a sgl/dbl reg first
                     ; bsgl is set to "b" single (second half of double) if we have one to fill
-                    (let loop ([types types] [locs '()] [live* '()] [int* (int-regs)] [sgl* (if varargs? '() (sgl-regs))] [bsgl #f] [isp 0])
+                    (let loop ([types types] [locs '()] [live* '()] [int* (int-regs)] [sgl* (if basestd? '() (sgl-regs))] [bsgl #f] [isp 0])
                       (if (null? types)
                           (values isp locs live*)
                           (nanopass-case (Ltype Type) (car types)
                             [(fp-double-float)
                              (cond
-                              [(and varargs?
+                              [(and basestd?
                                     ;; For varargs, treat a double like a 64-bit integer
                                     (let ([int* (if (even? (length int*)) int* (cdr int*))])
                                       (and (pair? int*)
@@ -2594,7 +2606,7 @@
                               [else
                                (loop (cdr types)
                                      (cons (load-double-reg (car sgl*)) locs)
-                            (cons (car sgl*) live*) int* (cddr sgl*) bsgl isp)])]
+                                     (cons (car sgl*) live*) int* (cddr sgl*) bsgl isp)])]
                             [(fp-single-float)
                              (cond
                               [bsgl
@@ -2602,11 +2614,11 @@
                                      (cons (load-single-reg bsgl #f) locs)
                                      (cons bsgl live*) int* sgl* #f isp)]
                               [(and (not (null? sgl*))
-                                    (not varargs?))
+                                    (not basestd?))
                                (loop (cdr types)
                                      (cons (load-single-reg (car sgl*) #f) locs)
                                      (cons (car sgl*) live*) int* (cddr sgl*) (cadr sgl*) isp)]
-                              [(and varargs?
+                              [(and basestd?
                                     (not (null? int*)))
                                (loop (cdr types)
                                      (cons (load-single-int-reg (car int*)) locs)
@@ -2617,7 +2629,7 @@
                                      live* int* '() #f (fx+ isp 4))])]
                             [(fp-ftd& ,ftd ,fptd)
                              (let ([size ($ftd-size ftd)]
-                                   [members ($ftd->members ftd)]
+                                   [members (filter-union ($ftd->members ftd))]
                                    [combine-loc (lambda (loc f)
                                                   (if loc
                                                       (lambda (x) (%seq ,(loc x) ,(f x)))
@@ -2626,7 +2638,7 @@
                                  [(8)
                                   (let* ([int* (if (even? (length int*)) int* (cdr int*))]
                                          [num-members (length members)]
-                                         [doubles? (and (not varargs?)
+                                         [doubles? (and (not basestd?)
                                                         (fx<= num-members 4)
                                                         (andmap double-member? members))])
                                     ;; Sequence of up to 4 doubles that fits in registers?
@@ -2660,13 +2672,13 @@
                                                         (cons* (car int*) (cadr int*) live*) (cddr int*) isp))]))]))]
                                  [else
                                   (let* ([num-members (length members)]
-                                         [floats? (and (not varargs?)
+                                         [floats? (and (not basestd?)
                                                        (fx<= num-members 4)
                                                        (andmap float-member? members))])
                                     ;; Sequence of up to 4 floats that fits in registers?
                                     (cond
                                      [(and floats?
-                                           (not varargs?)
+                                           (not basestd?)
                                            (fx>= (fx+ (length sgl*) (if bsgl 1 0)) num-members))
                                       ;; Allocate each float to register
                                       (let flt-loop ([size size] [offset 0] [sgl* sgl*] [bsgl bsgl] [loc #f] [live* live*])
@@ -2717,18 +2729,19 @@
                                            (cons (load-int-reg (car int*)) locs)
                                            (cons (car int*) live*) (cdr int*) sgl* bsgl isp)))]))))]
                  [add-fill-result
-                  (lambda (fill-result-here? result-type args-frame-size e)
+                  (lambda (fill-result-here? result-type args-frame-size basestd? e)
                     (cond
                      [fill-result-here?
                       (nanopass-case (Ltype Type) result-type
                         [(fp-ftd& ,ftd ,fptd)
-                         (let* ([members ($ftd->members ftd)]
+                         (let* ([members (filter-union ($ftd->members ftd))]
                                 [num-members (length members)]
                                 ;; result pointer is stashed on the stack after all arguments:
                                 [dest-x %r2]
                                 [init-dest-e `(seq ,e (set! ,dest-x ,(%mref ,%sp ,args-frame-size)))])
                            (cond
-                            [(and (fx<= num-members 4)
+                            [(and (not basestd?)
+                                  (fx<= num-members 4)
                                   (or (andmap double-member? members)
                                       (andmap float-member? members)))
                              ;; double/float results are in floating-point registers
@@ -2762,14 +2775,14 @@
                                          (set! ,(%mref ,dest-x ,4) ,%r1))]))]))])]
                      [else e]))]
                  [get-result-regs
-                  (lambda (result-type varargs?)
+                  (lambda (result-type basestd?)
                     (nanopass-case (Ltype Type) result-type
                       [(fp-double-float)
-                       (if varargs?
+                       (if basestd?
                            (list %r1 %Cretval)
                            (list %Cfpretval))]
                       [(fp-single-float)
-                       (if varargs?
+                       (if basestd?
                            (list %Cretval)
                            (list %Cfpretval))]
                       [(fp-integer ,bits)
@@ -2781,10 +2794,11 @@
                          [(64) (list %r1 %Cretval)]
                          [else (list %Cretval)])]
                       [(fp-ftd& ,ftd ,fptd)
-                       (let* ([members ($ftd->members ftd)]
+                       (let* ([members (filter-union ($ftd->members ftd))]
                               [num-members (length members)])
                          (cond
-                          [(and (fx<= num-members 4)
+                          [(and (not basestd?)
+                                (fx<= num-members 4)
                                 (or (andmap double-member? members)
                                     (andmap float-member? members)))
                            ;; double/float results are in floating-point registers
@@ -2832,13 +2846,14 @@
             (safe-assert (reg-callee-save? %tc)) ; no need to save-restore
             (let* ([arg-type* (info-foreign-arg-type* info)]
                    [conv* (info-foreign-conv* info)]
-                   [varargs? (ormap (lambda (conv) (and (pair? conv) (eq? (car conv) 'varargs))) conv*)]
+                   [basestd? (or (constant arm-softfp)
+                                 (ormap (lambda (conv) (and (pair? conv) (eq? (car conv) 'varargs))) conv*))]
                    [result-type (info-foreign-result-type info)]
-                   [result-reg* (get-result-regs result-type varargs?)]
-                   [fill-result-here? (indirect-result-that-fits-in-registers? result-type)]
+                   [result-reg* (get-result-regs result-type basestd?)]
+                   [fill-result-here? (indirect-result-that-fits-in-registers? result-type basestd?)]
                    [adjust-active? (if-feature pthreads (memq 'adjust-active conv*) #f)])
               (with-values (do-args (if fill-result-here? (cdr arg-type*) arg-type*)
-                                    varargs?)
+                                    basestd?)
                 (lambda (args-frame-size locs live*)
                   (let* ([frame-size (align 8 (+ args-frame-size
                                                  (if fill-result-here?
@@ -2857,21 +2872,21 @@
                          ;; stash extra argument on the stack to be retrieved after call and filled with the result:
                          (cons (load-int-stack args-frame-size) locs)]
                         [else locs]))
-                     (lambda (t0 not-varargs? maybe-errno-lvalue)
-                       (add-fill-result fill-result-here? result-type args-frame-size
+                     (lambda (t0 atomic? maybe-errno-lvalue)
+                       (add-fill-result fill-result-here? result-type args-frame-size basestd?
                                         (add-deactivate/errno
                                          adjust-active? maybe-errno-lvalue t0 live* result-reg*
                                          (lambda (t0)
                                            `(inline ,(make-info-kill*-live* (add-caller-save-registers result-reg*) live*) ,%c-call ,t0)))))
                      (nanopass-case (Ltype Type) result-type
                        [(fp-double-float)
-                        (if varargs?
+                        (if basestd?
                             (lambda (lvalue) ; unboxed
                               `(set! ,lvalue ,(%inline fpcastfrom ,%r1 ,%Cretval)))
                             (lambda (lvalue) ; unboxed
                               `(set! ,lvalue ,%Cfpretval)))]
                        [(fp-single-float)
-                        (if varargs?
+                        (if basestd?
                             (lambda (lvalue) ; unboxed
                               (let ([t %Cfpretval]) ; should be ok as a temporary register
                                 `(seq
@@ -2979,21 +2994,21 @@
               (lambda (lvalue)
                 `(set! ,lvalue ,(%inline + ,%sp (immediate ,offset))))))
           (define count-reg-args
-            (lambda (types synthesize-first? varargs?)
+            (lambda (types synthesize-first? basestd?)
                     ; bsgl? is #t iff we have a "b" single (second half of double) float reg to fill
               (let f ([types types] [iint (if synthesize-first? -1 0)] [idbl 0] [bsgl? #f])
                 (if (null? types)
                     (values iint idbl)
                     (nanopass-case (Ltype Type) (car types)
                       [(fp-double-float)
-                       (if varargs?
+                       (if basestd?
                            (let ([iint (align 2 iint)])
                              (f (cdr types) (if (fx< iint num-int-regs) (fx+ iint 2) iint) idbl bsgl?))
                            (if (fx< idbl 8)
                                (f (cdr types) iint (fx+ idbl 1) bsgl?)
                                (f (cdr types) iint idbl #f)))]
                       [(fp-single-float)
-                       (if varargs?
+                       (if basestd?
                            (f (cdr types) (if (fx< iint num-int-regs) (fx+ iint 1) iint) idbl bsgl?)
                            (if bsgl?
                                (f (cdr types) iint idbl #f)
@@ -3002,11 +3017,11 @@
                                    (f (cdr types) iint idbl #f))))]
                       [(fp-ftd& ,ftd ,fptd)
                        (let* ([size ($ftd-size ftd)]
-                              [members ($ftd->members ftd)]
+                              [members (filter-union ($ftd->members ftd))]
                               [num-members (length members)])
                          (cond
                           [(and (fx<= num-members 4)
-                                (not varargs?)
+                                (not basestd?)
                                 (andmap double-member? members))
                            ;; doubles are either in registers or all on stack
                            (if (fx<= (fx+ idbl num-members) 8)
@@ -3014,7 +3029,7 @@
                                ;; no more floating-point registers should be used, but ok if we count more
                                (f (cdr types) iint idbl #f))]
                           [(and (fx<= num-members 4)
-                                (not varargs?)
+                                (not basestd?)
                                 (andmap float-member? members))
                            ;; floats are either in registers or all on stack
                            (let ([amt (fxsrl (align 2 (fx- num-members (if bsgl? 1 0))) 1)])
@@ -3045,10 +3060,10 @@
             ; continue on into the stack variables, which is convenient when a struct
             ; argument is split across registers and the stack
             (lambda (types saved-reg-bytes pre-pad-bytes return-bytes float-reg-bytes post-pad-bytes int-reg-bytes
-                           synthesize-first? varargs?)
+                           synthesize-first? basestd?)
               (let* ([return-space-offset (fx+ saved-reg-bytes pre-pad-bytes)]
-                     [float-reg-offset (fx+ return-space-offset return-bytes)]
-                     [int-reg-offset (fx+ float-reg-offset float-reg-bytes post-pad-bytes)]
+                     [float-reg-offset (fx+ return-space-offset)]
+                     [int-reg-offset (fx+ float-reg-offset float-reg-bytes return-bytes post-pad-bytes)]
                      [stack-arg-offset (fx+ int-reg-offset int-reg-bytes)])
                 (let loop ([types (if synthesize-first? (cdr types) types)]
                            [locs '()]
@@ -3067,7 +3082,7 @@
                       (nanopass-case (Ltype Type) (car types)
                         [(fp-double-float)
                          (cond
-                          [(and varargs?
+                          [(and basestd?
                                 ;; For varargs, treat a double like a 64-bit integer
                                 (let ([iint (align 2 iint)])
                                   (and (fx< iint num-int-regs)
@@ -3078,14 +3093,14 @@
                                   (loop (cdr types)
                                         (cons (load-double-stack int-reg-offset) locs)
                                         (fx+ iint 2) idbl bsgl-offset (fx+ int-reg-offset 8) float-reg-offset stack-arg-offset)))]
-                          [(and (not varargs?)
+                          [(and (not basestd?)
                                 (< idbl num-dbl-regs))
                            (loop (cdr types)
                                  (cons (load-double-stack float-reg-offset) locs)
                                  iint (fx+ idbl 1) bsgl-offset int-reg-offset (fx+ float-reg-offset 8) stack-arg-offset)]
                           [else
                            (let ([stack-arg-offset (align 8 stack-arg-offset)]
-                                 [iint (if varargs? (align 2 iint) iint)]) ; use up register if argument didn't fit
+                                 [iint (if basestd? (align 2 iint) iint)]) ; use up register if argument didn't fit
                              (loop (cdr types)
                                    (cons (load-double-stack stack-arg-offset) locs)
                                    iint num-dbl-regs #f int-reg-offset float-reg-offset (fx+ stack-arg-offset 8)))])]
@@ -3096,13 +3111,13 @@
                                  (cons (load-single-stack bsgl-offset) locs)
                                  iint idbl #f int-reg-offset float-reg-offset stack-arg-offset)]
                           [(and (< idbl num-dbl-regs)
-                                (not varargs?))
+                                (not basestd?))
                            (loop (cdr types)
                                  ; with big-endian ARM might need to adjust offset +/- 4 since pair of
                                  ; single floats in a pushed double float might be reversed
                                  (cons (load-single-stack float-reg-offset) locs)
                                  iint (fx+ idbl 1) (fx+ float-reg-offset 4) int-reg-offset (fx+ float-reg-offset 8) stack-arg-offset)]
-                          [(and varargs?
+                          [(and basestd?
                                 (fx< iint num-int-regs))
                            (loop (cdr types)
                                  (cons (load-single-stack int-reg-offset) locs)
@@ -3113,10 +3128,10 @@
                                  iint num-dbl-regs #f int-reg-offset float-reg-offset (fx+ stack-arg-offset 4))])]
                         [(fp-ftd& ,ftd ,fptd)
                          (let* ([size ($ftd-size ftd)]
-                                [members ($ftd->members ftd)]
+                                [members (filter-union ($ftd->members ftd))]
                                 [num-members (length members)])
                            (cond
-                            [(and (not varargs?)
+                            [(and (not basestd?)
                                   (fx<= num-members 4)
                                   (andmap double-member? members))
                              ;; doubles are either in registers or all on stack
@@ -3128,7 +3143,7 @@
                                    (loop (cdr types)
                                          (cons (load-stack-address stack-arg-offset) locs)
                                          iint num-dbl-regs #f int-reg-offset #f (fx+ stack-arg-offset size))))]
-                            [(and (not varargs?)
+                            [(and (not basestd?)
                                   (fx<= num-members 4)
                                   (andmap float-member? members))
                              ;; floats are either in registers or all on stack
@@ -3196,13 +3211,13 @@
                                        (cons (load-int-stack (car types) int-reg-offset) locs)
                                        (fx+ iint 1) idbl bsgl-offset (fx+ int-reg-offset 4) float-reg-offset stack-arg-offset)))]))))))
           (define do-result
-            (lambda (result-type synthesize-first? varargs? return-stack-offset)
+            (lambda (result-type synthesize-first? basestd? return-stack-offset)
               (nanopass-case (Ltype Type) result-type
                 [(fp-ftd& ,ftd ,fptd)
-                 (let* ([members ($ftd->members ftd)]
+                 (let* ([members (filter-union ($ftd->members ftd))]
                         [num-members (length members)])
                    (cond
-                    [(and (not varargs?)
+                    [(and (not basestd?)
                           (fx<= 1 num-members 4)
                           (or (andmap double-member? members)
                               (andmap float-member? members)))
@@ -3253,7 +3268,7 @@
                                 (list %Cretval)
                                 4)])]))]
                 [(fp-double-float)
-                 (values (if varargs?
+                 (values (if basestd?
                              (lambda (rhs)
                                (let-values ([(endreg otherreg) (constant-case native-endianness
                                                                               [(little) (values %Cretval %r1)]
@@ -3263,19 +3278,19 @@
                                    (set! ,otherreg ,(%mref ,rhs ,(fx+ 4 (constant flonum-data-disp)))))))
                              (lambda (rhs)
                                `(set! ,%Cfpretval ,(%mref ,rhs ,%zero ,(constant flonum-data-disp) fp))))
-                         (if varargs?
+                         (if basestd?
                              (list %Cretval %r1)
                              (list %Cfpretval))
                          0)]
                 [(fp-single-float)
-                 (values (if varargs?
+                 (values (if basestd?
                              (lambda (rhs)
                                `(seq
                                  (set! ,%Cfpretval ,(%inline double->single ,(%mref ,rhs ,%zero ,(constant flonum-data-disp) fp)))
                                  (set! ,%Cretval ,(%inline fpcastto/lo ,%Cfpretval))))
                              (lambda (rhs)
                                `(set! ,%Cfpretval ,(%inline double->single ,(%mref ,rhs ,%zero ,(constant flonum-data-disp) fp)))))
-                         (if varargs?
+                         (if basestd?
                              (list %Cretval)
                              (list %Cfpretval))
                          0)]
@@ -3313,11 +3328,12 @@
                                  (vector->list regvec)))
             (let* ([arg-type* (info-foreign-arg-type* info)]
                    [conv* (info-foreign-conv* info)]
-                   [varargs? (ormap (lambda (conv) (and (pair? conv) (eq? (car conv) 'varargs))) conv*)]
+                   [basestd? (or (constant arm-softfp)
+                                 (ormap (lambda (conv) (and (pair? conv) (eq? (car conv) 'varargs))) conv*))]
                    [result-type (info-foreign-result-type info)]
-                   [synthesize-first? (indirect-result-that-fits-in-registers? result-type)]
+                   [synthesize-first? (indirect-result-that-fits-in-registers? result-type basestd?)]
                    [adjust-active? (if-feature pthreads (memq 'adjust-active conv*) #f)])
-              (let-values ([(iint idbl) (count-reg-args arg-type* synthesize-first? varargs?)])
+              (let-values ([(iint idbl) (count-reg-args arg-type* synthesize-first? basestd?)])
                 (let ([saved-reg-bytes (fx+ (fx* isaved 4) (fx* fpsaved 8))]
                       [pre-pad-bytes (if (fxeven? isaved)
                                          (if adjust-active? 8 0)
@@ -3326,7 +3342,7 @@
                       [post-pad-bytes (if (fxeven? iint) 0 4)]
                       [float-reg-bytes (fx* idbl 8)])
                   (let-values ([(get-result result-regs return-bytes)
-                                (do-result result-type synthesize-first? varargs?
+                                (do-result result-type synthesize-first? basestd?
                                            (fx+ saved-reg-bytes pre-pad-bytes))])
                     (let ([return-bytes (align 8 return-bytes)])
                       (values
@@ -3359,7 +3375,7 @@
                        ; list of procedures that marshal arguments from their C stack locations
                        ; to the Scheme argument locations
                        (do-stack arg-type* saved-reg-bytes pre-pad-bytes return-bytes float-reg-bytes post-pad-bytes int-reg-bytes
-                                 synthesize-first? varargs?)
+                                 synthesize-first? basestd?)
                        get-result
                        (lambda ()
                          (in-context Tail

--- a/s/arm7.def
+++ b/s/arm7.def
@@ -1,0 +1,3 @@
+(define-constant arm-isa-version 7)
+(define-constant-default arm-softfp #t)
+(include "arm32.def")

--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -420,6 +420,7 @@
   rv64nb    trv64nb
   la64le    tla64le
   a6hk      ta6hk
+  arm7le    tarm7le
 )
 
 (include "machine.def")

--- a/s/machine.zuo
+++ b/s/machine.zuo
@@ -10,6 +10,7 @@
     [(string=? arch "i3") "x86"]
     [(string=? arch "rv64") "riscv64"]
     [(string=? arch "la64") "loongarch64"]
+    [(string=? arch "arm7") "arm32"]
     [else arch]))
 
 ;; Get or synthesize a "machine.def" file and supporting files,


### PR DESCRIPTION
The `arm7le` machine type corresponds to ARMv7 armel (like Android), while `arm32le` is still ARMv6 armhf (like Raspberry Pi).

I was not able to set up a 32-bit ARM Termux environment to make sure everything works. I tired out Arm64 Termux, and I built on armel Debian to test `tarm7le`.

Running "foreign.ms" tests on `arm32le`, meanwhile, exposed old problems via tests that were added relatively recently. Those problems involved unusual situations: `__collect-safe` mode, structs with unions that have only floating-point fields, and callables that have struct results and floating-point arguments.

Closes #1049, #1040, #1041