### PR TITLE
Fix typos in CSUG

### DIFF
--- a/csug/csug.stex
+++ b/csug/csug.stex
@@ -23,7 +23,7 @@
 \endschemeinit
 
 \generated
-;; We assume here that the verison used to build the documentation
+;; We assume here that the version used to build the documentation
 ;; is the same as the documented version. If it's a release version,
 ;; then the date is fixed to the release date. Otherwise, use
 ;; the date when the document is built.

--- a/csug/debug.stex
+++ b/csug/debug.stex
@@ -1460,7 +1460,7 @@ more efficient.
 The procedure \scheme{compute-size-increments} is similar to
 \scheme{compute-size} mapped over a list of elements, but it reports a
 size for each later element without including the size of objects
-reachable from ealier elements, and it treats weak and ephemeron pairs
+reachable from earlier elements, and it treats weak and ephemeron pairs
 differently. For a large number of reachable objects,
 \scheme{compute-size-increments} uses much less memory than
 \scheme{compute-size}.

--- a/csug/foreign.stex
+++ b/csug/foreign.stex
@@ -527,7 +527,7 @@ The argument is passed to C as an \scheme{int}.
 \foreigntype{\scheme{stdbool}}
 \index{\scheme{stdbool}}Any Scheme object may be passed as a boolean.
 \scheme{#f} is converted to 0; all other objects are converted to 1.
-The argument is passed to C as a \scheme{bool} defined by the the host
+The argument is passed to C as a \scheme{bool} defined by the host
 machine's \scheme{stdbool.h} include file.
 
 \foreigntype{\scheme{char}}
@@ -3415,7 +3415,7 @@ as relative to the current directory, so the executable path is not needed.
 In all of those cases, the boot file is opened but not loaded until the heap is built via
 \scheme{Sbuild_heap}. \scheme{Sregister_boot_file_fd} provides a specific boot file as a file descriptor,
 the given file name is used only for error reporting, and the file descriptor
-is not read until until the heap is built via \scheme{Sbuild_heap}.
+is not read until the heap is built via \scheme{Sbuild_heap}.
 For the first boot file registered only, the system also
 searches for the boot files upon which the named file
 depends, either directly or indirectly.

--- a/csug/objects.stex
+++ b/csug/objects.stex
@@ -3095,7 +3095,7 @@ and \scheme{eq-hashtable-contains?} are used on a
 particular hash table by any thread. To handle certain forms of
 contention, the result may be \scheme{#f}, in which case the operation
 might be retried. An even more significant constraint is that the hash
-table will not be resized interally as needed to provide constant-time
+table will not be resized internally as needed to provide constant-time
 behavior. Use \scheme{eq-hashtable-set!} or a similar operation from a
 single thread (e.g., during a collect-reqest handler) to allow the
 opportunity of resizing.
@@ -4693,7 +4693,7 @@ is the ``pretty'' name of the gensym (see~\ref{desc:gensym}).
 \var{rtd} must be a record-type descriptor.
 The field names are symbols.
 
-See also the Revised$^6$ Report version of this prodecure (exported from
+See also the Revised$^6$ Report version of this procedure (exported from
 the \scheme{(chezscheme)} library) which returns a vector.
 
 \schemedisplay
@@ -4811,7 +4811,7 @@ new record type has anonymous fields. The \scheme{car} of \var{fields}
 is a field count, and it is added to any fields present in
 \var{parent} to determine the record type's total number of fields.
 The \scheme{cdr} of \var{fields} must be an exact non-negative integer
-that is treated as a bit array; a \scheme{1} bit indicates the the
+that is treated as a bit array; a \scheme{1} bit indicates the
 corresponding field among new fields is mutable. The total number of
 fields in a record type must be a fixnum.
 

--- a/csug/smgmt.stex
+++ b/csug/smgmt.stex
@@ -1128,8 +1128,8 @@ in memory by the storage management system until it is reclaimed.
 
 \section{Phantom Bytevectors\label{SECTSMGMTPHANTOM}}
 
-\index{phamtom bytevectors}A \emph{phantom bytevector} represents
-memory that is allocated outside of the Scheme stroage management
+\index{phantom bytevectors}A \emph{phantom bytevector} represents
+memory that is allocated outside of the Scheme storage management
 system. A phantom bytevector itself uses a small amount of space, but
 it contains a length that reflects external allocation. Representing
 external allocation can be useful for reflecting memory consumption

--- a/csug/system.stex
+++ b/csug/system.stex
@@ -2421,7 +2421,7 @@ to select a distinct symbol to hold the value of the \scheme{a-var}
 defininion, since \scheme{a-var} itself should not be defined directly
 at the top level. Finally, the \scheme{current-generate-id} procedure
 is called on \scheme{a-var} to select a name for the macro-introduced
-definiton of \scheme{a-var} in the expansion of \scheme{(def)}---which
+definition of \scheme{a-var} in the expansion of \scheme{(def)}---which
 turns out to be completely inaccessible since no reference is
 introduced by the same expansion step.
 


### PR DESCRIPTION
Found some typos in the [User’s Guide](https://cisco.github.io/ChezScheme/csug/csug.html).